### PR TITLE
[CI](feat) Add docs-example test job to documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,6 @@ name: Documentation
 on:
   pull_request:
     paths:
-      - '*.md'
       - 'docs/**'
       - '.github/workflows/documentation.yml'
       - '.github/docs-ci/**'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,9 +4,7 @@ on:
   pull_request:
     paths:
       - '*.md'
-      - 'docs/**/*.md'
-      - 'docs/**/*.mdx'
-      - 'docs/**/_toc.yaml'
+      - 'docs/**'
       - '.github/workflows/documentation.yml'
       - '.github/docs-ci/**'
   # Manual full scans (checkAll) to surface errors in existing docs
@@ -132,3 +130,116 @@ jobs:
               cat output.md
             } >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  docs-examples-npu:
+    name: Docs examples test (${{ matrix.config.name }}, py${{ matrix.config.python_version }})
+    runs-on: ${{ matrix.config.runs_on }}
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/triton:${{ matrix.config.cann_version }}-${{ matrix.config.chip_type }}-${{ matrix.config.os }}-py${{ matrix.config.python_version }}-latest
+    timeout-minutes: 300
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {name: a3, runs_on: linux-aarch64-a3-4, cann_version: '8.5.0', chip_type: a3, os: ubuntu22.04, python_version: '3.10'}
+          - {name: a5, runs_on: linux-amd64-a5-4, cann_version: '9.1.0', chip_type: '950', os: ubuntu22.04, python_version: '3.12'}
+    env:
+      PYTHON: "python${{ matrix.config.python_version }}"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
+      PIP_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: "true"
+
+      - name: Add git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Cache build dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.triton/llvm
+            ~/.triton/json
+            ~/.triton/nvidia
+            ~/.ccache
+          key: ${{ runner.os }}-${{ runner.arch }}-cann${{ matrix.config.cann_version }}-${{ matrix.config.os }}-${{ matrix.config.chip_type }}-py${{ matrix.config.python_version }}-triton-${{ hashFiles('cmake/llvm-hash.txt', 'cmake/json-version.txt', 'cmake/nvidia-toolchain-version.json', 'third_party/ascend/patch/llvm_patch_*.patch') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-cann${{ matrix.config.cann_version }}-${{ matrix.config.os }}-${{ matrix.config.chip_type }}-py${{ matrix.config.python_version }}-triton-
+
+      - name: Download and install Bisheng compiler
+        shell: bash
+        run: |
+          if [ ! -f cmake/bisheng-version.txt ]; then
+            echo "cmake/bisheng-version.txt not found, skipping"
+            exit 0
+          fi
+          ARCH=$(uname -m)
+          OBS_BASE="https://triton-ascend-artifacts.obs.cn-southwest-2.myhuaweicloud.com"
+          BISHENG_FILENAME=$(sed -n "s/^${ARCH}: //p" cmake/bisheng-version.txt | xargs)
+          BISHENG_SHA256=$(sed -n "s/^${ARCH}_sha256: //p" cmake/bisheng-version.txt | xargs)
+          if [ -z "${BISHENG_FILENAME}" ]; then
+            echo "Error: cmake/bisheng-version.txt has no entry for arch ${ARCH}." >&2
+            exit 1
+          fi
+          echo "Downloading: ${BISHENG_FILENAME} (arch=${ARCH})"
+          curl -fL --connect-timeout 30 --retry 5 --retry-all-errors \
+            --retry-delay 10 -C - \
+            "${OBS_BASE}/cann/${BISHENG_FILENAME}" -o bisheng.run
+          if [ -n "${BISHENG_SHA256}" ]; then
+            echo "${BISHENG_SHA256}  bisheng.run" | sha256sum -c -
+          else
+            echo "Warning: No SHA256 checksum provided, skipping verification"
+          fi
+          chmod +x bisheng.run
+          ./bisheng.run --quiet --install --install-path=/usr/local/bisheng
+          echo "/usr/local/bisheng/tools/bishengir/bin" >> $GITHUB_PATH
+
+      - name: Build and install triton-ascend
+        shell: bash
+        env:
+          TRITON_BUILD_WITH_CCACHE: "true"
+          TRITON_BUILD_WITH_CLANG_LLD: "TRUE"
+          TRITON_DISABLE_LINE_INFO: 1
+          CCACHE_COMPRESS: "true"
+          TRITON_BUILD_WITH_O1: true
+          TRITON_BUILD_TD: ON
+          TRITON_BUILD_PROTON: OFF
+          TRITON_WHEEL_NAME: triton-ascend
+          TRITON_APPEND_CMAKE_ARGS: "-DTRITON_BUILD_UT=ON"
+        run: |
+          source /usr/local/Ascend/cann/set_env.sh
+          export PATH="/usr/local/bisheng/tools/bishengir/bin:$PATH"
+          npu-smi info
+          ccache --zero-stats
+          NUM_PROCS=$(( $(nproc) / 3 ))
+          if [ "$NUM_PROCS" -lt 1 ]; then NUM_PROCS=1; fi
+          if [ -f setup_ascend.py ]; then
+            SETUP_DIR="./"
+            SETUP_PY="setup_ascend.py"
+          elif [ -f setup.py ]; then
+            SETUP_DIR="./"
+            SETUP_PY="setup.py"
+          elif [ -f python/setup.py ]; then
+            SETUP_DIR="python"
+            SETUP_PY="setup.py"
+          else
+            echo "ERROR: setup.py or setup_ascend.py not found" >&2
+            exit 1
+          fi
+          cd "$SETUP_DIR"
+          MAX_JOBS="$NUM_PROCS" \
+          ${PYTHON} ${SETUP_PY} bdist_wheel
+          ${PYTHON} -m pip install dist/*.whl
+
+      - name: Run API doc example tests
+        shell: bash
+        run: |
+          source /usr/local/Ascend/cann/set_env.sh
+          export PATH="/usr/local/bisheng/tools/bishengir/bin:$PATH"
+          ${PYTHON} -m pytest -s -v -n 8 --dist=loadfile \
+            --import-mode=importlib \
+            --override-ini="python_files=triton.*.py" \
+            docs/zh/python-api/_examples/

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.abs.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.abs.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.acos.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.acos.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_acos():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_acos():
 
 
 if __name__ == "__main__":
-    test_acos()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_acos()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.acosh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.acosh.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_acosh():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_acosh():
 
 
 if __name__ == "__main__":
-    test_acosh()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_acosh()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.asin.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.asin.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_asin():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_asin():
 
 
 if __name__ == "__main__":
-    test_asin()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_asin()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.asinh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.asinh.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_asinh():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_asinh():
 
 
 if __name__ == "__main__":
-    test_asinh()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_asinh()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atan.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atan.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_atan():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_atan():
 
 
 if __name__ == "__main__":
-    test_atan()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_atan()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atan2.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atan2.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -18,6 +27,7 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_atan2():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -34,4 +44,7 @@ def test_atan2():
 
 
 if __name__ == "__main__":
-    test_atan2()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_atan2()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atanh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atanh.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_atanh():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_atanh():
 
 
 if __name__ == "__main__":
-    test_atanh()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_atanh()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.brev.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.brev.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.byte_perm.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.byte_perm.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cbrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cbrt.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ceil.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ceil.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.clz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.clz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.copysign.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.copysign.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -18,6 +27,7 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_copysign():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -34,4 +44,7 @@ def test_copysign():
 
 
 if __name__ == "__main__":
-    test_copysign()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_copysign()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cos.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cos.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cosh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cosh.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_cosh():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_cosh():
 
 
 if __name__ == "__main__":
-    test_cosh()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_cosh()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cospi.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cospi.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cyl_bessel_i0.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cyl_bessel_i0.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_cyl_bessel_i0():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_cyl_bessel_i0():
 
 
 if __name__ == "__main__":
-    test_cyl_bessel_i0()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_cyl_bessel_i0()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cyl_bessel_i1.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cyl_bessel_i1.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rz.py
@@ -1,8 +1,17 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -19,6 +28,7 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_div_rz():
     x0 = torch.tensor([10.0, -10.0, 7.5, -7.5], dtype=torch.float32, device='npu')
     x1 = torch.tensor([3.0, 3.0, 2.0, 2.0], dtype=torch.float32, device='npu')
@@ -34,4 +44,7 @@ def test_div_rz():
 
 
 if __name__ == "__main__":
-    test_div_rz()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_div_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erf.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfc.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfc.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcinv.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcinv.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcx.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcx.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfinv.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfinv.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_erfinv():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_erfinv():
 
 
 if __name__ == "__main__":
-    test_erfinv()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_erfinv()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp10.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp10.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp2.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp2.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.expm1.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.expm1.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_expm1():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_expm1():
 
 
 if __name__ == "__main__":
-    test_expm1()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_expm1()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_cosf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_cosf.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_dividef.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_dividef.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -18,6 +27,7 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_fast_dividef():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -34,4 +44,7 @@ def test_fast_dividef():
 
 
 if __name__ == "__main__":
-    test_fast_dividef()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fast_dividef()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_exp10f.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_exp10f.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_expf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_expf.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_fast_expf():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_fast_expf():
 
 
 if __name__ == "__main__":
-    test_fast_expf()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fast_expf()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_log10f.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_log10f.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_log2f.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_log2f.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_logf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_logf.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_powf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_powf.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_sinf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_sinf.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_tanf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_tanf.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_tanhf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_tanhf.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fdim.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fdim.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ffs.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ffs.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.finitef.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.finitef.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2half_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2half_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float_as_int.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float_as_int.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float_as_uint.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float_as_uint.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.floor.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.floor.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fmod.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fmod.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -18,6 +27,7 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_fmod():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -34,4 +44,7 @@ def test_fmod():
 
 
 if __name__ == "__main__":
-    test_fmod()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_fmod()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.gamma.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.gamma.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_gamma():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_gamma():
 
 
 if __name__ == "__main__":
-    test_gamma()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_gamma()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.hadd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.hadd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.half2float.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.half2float.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.hypot.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.hypot.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -18,6 +27,7 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_hypot():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -34,4 +44,7 @@ def test_hypot():
 
 
 if __name__ == "__main__":
-    test_hypot()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_hypot()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ilogb.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ilogb.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_ilogb():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_ilogb():
 
 
 if __name__ == "__main__":
-    test_ilogb()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_ilogb()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int_as_float.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int_as_float.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.isinf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.isinf.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_isinf():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -35,4 +45,7 @@ def test_isinf():
 
 
 if __name__ == "__main__":
-    test_isinf()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_isinf()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.isnan.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.isnan.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_isnan():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -35,4 +45,7 @@ def test_isnan():
 
 
 if __name__ == "__main__":
-    test_isnan()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_isnan()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.j0.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.j0.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.j1.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.j1.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.jn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.jn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ldexp.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ldexp.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import torch
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 def torch_ldexp_reference(x0, x1):
@@ -26,6 +35,7 @@ def triton_ldexp(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK: tl.constexpr, XBLOC
         tl.store(out_ptr0 + x_index, tmp2, xmask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_ldexp():
     shape = (2, 256)
     ncore, xblock, xblock_sub = 2, 1024, 512
@@ -44,4 +54,7 @@ def test_ldexp():
 
 
 if __name__ == "__main__":
-    test_ldexp()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_ldexp()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.lgamma.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.lgamma.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_lgamma():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_lgamma():
 
 
 if __name__ == "__main__":
-    test_lgamma()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_lgamma()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.llrint.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.llrint.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.llround.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.llround.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log10.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log10.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_log10():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_log10():
 
 
 if __name__ == "__main__":
-    test_log10()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_log10()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log1p.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log1p.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_log1p():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_log1p():
 
 
 if __name__ == "__main__":
-    test_log1p()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_log1p()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log2.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log2.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.logb.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.logb.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.max.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.max.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.min.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.min.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul24.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul24.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mulhi.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mulhi.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nan.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nan.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nearbyint.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nearbyint.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_nearbyint():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_nearbyint():
 
 
 if __name__ == "__main__":
-    test_nearbyint()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_nearbyint()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nextafter.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nextafter.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -18,6 +27,7 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_nextafter():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -34,4 +44,7 @@ def test_nextafter():
 
 
 if __name__ == "__main__":
-    test_nextafter()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_nextafter()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.norm3d.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.norm3d.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.norm4d.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.norm4d.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.normcdf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.normcdf.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.normcdfinv.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.normcdfinv.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.popc.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.popc.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.pow.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.pow.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -18,6 +27,7 @@ def triton_kernel(input, input2, output, n_elements, XBLOCK: tl.constexpr, XBLOC
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_pow():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -34,4 +44,7 @@ def test_pow():
 
 
 if __name__ == "__main__":
-    test_pow()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_pow()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcbrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcbrt.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.reciprocal.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.reciprocal.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_reciprocal():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_reciprocal():
 
 
 if __name__ == "__main__":
-    test_reciprocal()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_reciprocal()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.relu.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.relu.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_relu():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_relu():
 
 
 if __name__ == "__main__":
-    test_relu()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_relu()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.remainder.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.remainder.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhadd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhadd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhypot.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhypot.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rint.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rint.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_rint():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_rint():
 
 
 if __name__ == "__main__":
-    test_rint()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_rint()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rnorm3d.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rnorm3d.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rnorm4d.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rnorm4d.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.round.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.round.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_round():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_round():
 
 
 if __name__ == "__main__":
-    test_round()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_round()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rsqrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rsqrt.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rsqrt_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rsqrt_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sad.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sad.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest
@@ -22,7 +19,7 @@ def torch_sad_reference(x0, x1, x2):
     assert x2.device.type == "cpu"
     assert x0.dtype == torch.int32
     assert x1.dtype == torch.int32
-    assert x2.dtype == torch.uint32
+    assert x2.dtype == torch.int32
     assert x0.shape == x1.shape == x2.shape
 
     return (torch.abs(x0 - x1).to(torch.int64) + x2.to(torch.int64)).to(torch.int32)
@@ -47,7 +44,7 @@ def triton_kernel(input0, input1, input2, output, n_elements, XBLOCK: tl.constex
 def test_sad():
     x0 = (torch.randint(1, 16, (8, ))).to(torch.int32)
     x1 = (torch.randint(1, 16, (8, ))).to(torch.int32)
-    x2 = (torch.randint(1, 16, (8, ))).to(torch.uint32)
+    x2 = (torch.randint(1, 16, (8, ))).to(torch.int32)
     expected = (torch_sad_reference(x0, x1, x2)).npu()
     x0 = x0.npu()
     x1 = x1.npu()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.saturatef.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.saturatef.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.scalbn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.scalbn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.signbit.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.signbit.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_signbit():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_signbit():
 
 
 if __name__ == "__main__":
-    test_signbit()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_signbit()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sin.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sin.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sinh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sinh.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_sinh():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_sinh():
 
 
 if __name__ == "__main__":
-    test_sinh()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_sinh()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sinpi.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sinpi.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tan.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tan.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_tan():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_tan():
 
 
 if __name__ == "__main__":
-    test_tan()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_tan()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tanh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tanh.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_tanh():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_tanh():
 
 
 if __name__ == "__main__":
-    test_tanh()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_tanh()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tgamma.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tgamma.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.trunc.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.trunc.py
@@ -1,7 +1,16 @@
+import os
+
+os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
+
+import pytest
 import triton
 import triton.language as tl
 import triton.language.extra.cann.libdevice as libdevice
 import torch
+from triton.backends.ascend.utils import triton_enable_libdevice_simt
+
+_SIMT_SKIP_MSG = ("SIMT libdevice ops are not supported on A3; "
+                  "only runs on Ascend 950 with TRITON_ENABLE_LIBDEVICE_SIMT=1; skipping.")
 
 
 @triton.jit
@@ -17,6 +26,7 @@ def triton_kernel(input, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: t
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
 def test_trunc():
     param_list = [(2, 256, 4), 2, 2048, 1024]
     shape, ncore, xblock, xblock_sub = param_list
@@ -32,4 +42,7 @@ def test_trunc():
 
 
 if __name__ == "__main__":
-    test_trunc()
+    if not triton_enable_libdevice_simt():
+        print(_SIMT_SKIP_MSG)
+    else:
+        test_trunc()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint_as_float.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint_as_float.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rd.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_ru.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rz.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.y0.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.y0.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.y1.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.y1.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.yn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.yn.py
@@ -1,8 +1,5 @@
 import os
 
-# The libdevice SIMT ops below are A5-only (Ascend 910_95 / 950) and are
-# additionally gated by this env switch; set it so the examples run on A5
-# hardware without extra configuration.
 os.environ.setdefault("TRITON_ENABLE_LIBDEVICE_SIMT", "1")
 
 import pytest


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
## Summary

1、Add a job to the documentation workflow that builds triton-ascend and runs the API doc example tests under `docs/zh/python-api/_examples/` whenever a PR touches `docs/`. Runs on both a3 and a5 chips to ensure all of the examples passed.
2、Gate the `simt_only` libdevice examples under `docs/zh/python-api/_examples/` so they only run on Ascend 950: 37 examples used `compile_mode='simt_only'` without any target check and failed on A3 runners. 

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
