### PR TITLE
[Docs](fix) extend quick start with next-step development index

### DIFF
--- a/docs/en/quick_start.md
+++ b/docs/en/quick_start.md
@@ -57,3 +57,31 @@ tensor([0.8329, 1.0024, 1.3639,  ..., 1.0796, 1.0406, 1.5811], device='npu:0')
 tensor([0.8329, 1.0024, 1.3639,  ..., 1.0796, 1.0406, 1.5811], device='npu:0')
 The maximum difference between torch and triton is 0.0
 ```
+
+## Next Steps: From Examples to Full Development
+
+This page helps you finish installation and verify the first example. To continue through the full operator development workflow, follow the path below:
+
+1. **Operator development**: Read the Vector / Cube / fusion tutorials for your operator type, then modify an example kernel to complete the develop–compile–verify loop.
+2. **Autotune**: Use Autotune to select suitable tiling configs.
+3. **Debug and profiling**: Learn print-based debugging and performance collection.
+4. **Migration and advanced topics**: Migrate from GPU Triton to Ascend, or check environment variables and compiler options.
+
+### Development Guide
+
+| Document | Description |
+|----------|-------------|
+| [Triton-Ascend Operator Programming](./programming_guide/index.md) | General principles: multi-core split, on-chip memory, access patterns, and tiling |
+| [Triton-Ascend Operator Migration](./migration_guide/index.md) | Migrate GPU Triton operators to Ascend NPU |
+| [Triton-Ascend Operator Debugging and Profiling](./debug_guide/index.md) | Debugging, profiling, and accuracy troubleshooting |
+| [Environment Variables and Compiler Options](./environment_variable_and_compiler_options_reference.md) | Runtime and compilation configuration reference |
+
+### Tutorials & Examples
+
+| Document | Description |
+|----------|-------------|
+| [Vector Operator Development](./programming_guide/vector_operator.md) | Element-wise, reduction, gather/scatter, and other Vector Core operators |
+| [Cube Operator Development](./programming_guide/cube_operator.md) | Cube operators centered on `tl.dot` and matrix multiplication |
+| [CV Fusion Operator Development](./programming_guide/cv_fusion_operator.md) | Kernels that combine Cube compute with Vector post-processing |
+| [Triton-Ascend Autotune](./autotune_guide.md) | Recommended Autotune usage and automatic tiling scope |
+| [Example Operators](./examples/index.md) | End-to-end examples such as Softmax, LayerNorm, Attention, and Matmul |

--- a/docs/zh/quick_start.md
+++ b/docs/zh/quick_start.md
@@ -57,3 +57,31 @@ tensor([0.8329, 1.0024, 1.3639,  ..., 1.0796, 1.0406, 1.5811], device='npu:0')
 tensor([0.8329, 1.0024, 1.3639,  ..., 1.0796, 1.0406, 1.5811], device='npu:0')
 The maximum difference between torch and triton is 0.0
 ```
+
+## 下一步：从样例到完整开发
+
+本页帮助您完成安装与首个样例验证。若希望继续上手算子开发全流程，可按下面路径推进：
+
+1. **算子开发**：按算子类型阅读 Vector / Cube / 融合开发教程，再对照典型样例修改 Kernel，完成开发、编译、验证闭环。
+2. **自动调优**：使用 Autotune 选择合适的 Tiling 配置。
+3. **调试与调优**：掌握打印调试与性能采集方法。
+4. **迁移与进阶**：从 GPU Triton 迁移到 Ascend，或查阅环境变量与编译选项。
+
+### 开发指南
+
+| 文档 | 说明 |
+|------|------|
+| [Triton-Ascend 算子开发](./programming_guide/index.md) | 分核、片上内存、访存、Tiling 等通用开发原则 |
+| [Triton-Ascend 算子迁移](./migration_guide/index.md) | GPU Triton 算子迁移到昇腾 NPU |
+| [Triton-Ascend 算子调试与调优](./debug_guide/index.md) | 调试、性能分析与精度排查 |
+| [环境变量与编译选项](./environment_variable_and_compiler_options_reference.md) | 运行与编译相关配置说明 |
+
+### 教程与样例
+
+| 文档 | 说明 |
+|------|------|
+| [Vector 算子开发](./programming_guide/vector_operator.md) | 逐元素、归约、Gather/Scatter 等 Vector Core 算子 |
+| [Cube 算子开发](./programming_guide/cube_operator.md) | 以 `tl.dot`、矩阵乘为核心的 Cube 算子 |
+| [融合算子开发](./programming_guide/cv_fusion_operator.md) | 同一 Kernel 中 Cube + Vector 协同的 CV 融合场景 |
+| [Triton-Ascend autotune](./autotune_guide.md) | Autotune 推荐用法与自动 Tiling 适用边界 |
+| [典型算子样例](./examples/index.md) | Softmax、LayerNorm、Attention、Matmul 等端到端样例 |


### PR DESCRIPTION
## Summary
Add a “next steps” section to the Chinese and English quick start pages, linking newcomers from the first example to existing tutorials and development guides.

## What Is Included
- `docs/zh/quick_start.md`: add「下一步：从样例到完整开发」with a 4-step path, plus tables for 开发指南 and 教程与样例
- `docs/en/quick_start.md`: mirror the same structure (Development Guide, then Tutorials & Examples)

## User Impact
No code behavior change. Documentation only—helps newcomers move from first example to full operator development.

## Related Issue
[[Doc]: no quick_start guide for triton kernel development](https://github.com/triton-lang/triton-ascend/issues/971)

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [x] This PR does not need a test because it only updates documentation.
  - [ ] I have added tests.
- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices).
