### PR TITLE
[build](feat) add npuir build

### DIFF
--- a/build_npuir.py
+++ b/build_npuir.py
@@ -1,0 +1,201 @@
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_THIS_DIR = Path(__file__).resolve().parent
+_NPUIR_DIR = _THIS_DIR / "third_party" / "ascend" / "AscendNPU-IR"
+
+_MIN_FREE_DISK_GB = 30
+_GIT_RETRY_TIMES = 3
+_GIT_RETRY_INTERVAL = 5
+
+
+def _log(msg):
+    print(f"[build_npuir] {msg}", flush=True)
+
+
+def _is_git_repo(dir_path):
+    return (Path(dir_path) / ".git").is_dir()
+
+
+def _check_disk_space(min_free_gb=_MIN_FREE_DISK_GB):
+    """Check that the disk hosting the repo has at least ``min_free_gb`` free.
+
+    Building AscendNPU-IR recursively fetches LLVM / Torch-MLIR sources and
+    produces a large build tree, which requires substantial disk space.
+    """
+    usage = shutil.disk_usage(str(_THIS_DIR))
+    free_gb = usage.free / (1024**3)
+    total_gb = usage.total / (1024**3)
+    _log(f"Disk space on {_THIS_DIR.drive or _THIS_DIR.anchor}: "
+         f"free {free_gb:.1f} GiB / total {total_gb:.1f} GiB "
+         f"(required >= {min_free_gb} GiB)")
+    if free_gb < min_free_gb:
+        raise RuntimeError(f"Insufficient disk space: {free_gb:.1f} GiB free, but building "
+                           f"AscendNPU-IR requires at least {min_free_gb} GiB. "
+                           f"Please free up disk space and retry.")
+
+
+def _get_ascend_path() -> Path:
+    path = os.getenv("ASCEND_HOME_PATH", "")
+    if path == "":
+        raise EnvironmentError("ASCEND_HOME_PATH is not set, source <ascend-toolkit>/set_env.sh first")
+    return Path(path)
+
+
+def _run_with_retry(cmd, cwd=None, retries=_GIT_RETRY_TIMES, interval=_GIT_RETRY_INTERVAL):
+    """Run a network command (git clone/fetch/submodule) with retries."""
+    last_error = None
+    for attempt in range(1, retries + 1):
+        try:
+            subprocess.check_call(cmd, cwd=str(cwd) if cwd else None)
+            return
+        except subprocess.CalledProcessError as e:
+            last_error = e
+            if attempt < retries:
+                _log(f"Command '{' '.join(map(str, cmd))}' failed (attempt "
+                     f"{attempt}/{retries}), retrying in {interval}s...")
+                time.sleep(interval)
+            else:
+                _log(f"Command '{' '.join(map(str, cmd))}' failed after "
+                     f"{retries} attempts.")
+    raise last_error
+
+
+def _is_submodule_initialized(dir_path):
+    """A submodule is considered initialized when its source tree is present."""
+    dir_path = Path(dir_path)
+    return dir_path.is_dir() and (dir_path / "CMakeLists.txt").exists()
+
+
+def _init_npuir_repo():
+    """Initialize the AscendNPU-IR submodule and its nested submodules.
+
+    AscendNPU-IR depends on LLVM and Torch-MLIR, which are pulled in as
+    nested submodules, hence the recursive update.
+    """
+    _log("Initializing AscendNPU-IR repository ...")
+    if not _is_git_repo(_THIS_DIR):
+        raise RuntimeError(f"{_THIS_DIR} is not a git repository; cannot initialize the "
+                           f"Triton-Ascend submodule.")
+
+    # First initialize the AscendNPU-IR submodule itself from the root repo.
+    _run_with_retry([
+        "git",
+        "submodule",
+        "update",
+        "--init",
+        "--depth",
+        "1",
+        "--",
+        "third_party/ascend/AscendNPU-IR",
+    ], cwd=_THIS_DIR)
+
+    # Then recursively initialize its nested submodules (LLVM, Torch-MLIR).
+    if _is_submodule_initialized(_NPUIR_DIR):
+        _run_with_retry([
+            "git",
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+        ], cwd=_NPUIR_DIR)
+    else:
+        raise RuntimeError(f"AscendNPU-IR submodule initialization failed: {_NPUIR_DIR} is not git repository.")
+
+    if not _is_submodule_initialized(_NPUIR_DIR):
+        raise RuntimeError(f"AscendNPU-IR initialization failed: {_NPUIR_DIR} is still empty.")
+    _log("AscendNPU-IR repository initialized.")
+
+
+def _build_and_package_bisheng(repo_dir, bisheng_compiler_path, build_type="Release", rebuild=True):
+    """Configure, build and install AscendNPU-IR via its build.sh script."""
+    repo_dir = Path(repo_dir)
+    build_script = repo_dir / "build-tools" / "build.sh"
+    if not build_script.exists():
+        raise RuntimeError(f"Build script not found: {build_script}")
+    max_jobs = min(os.cpu_count() // 8, 32)
+    build_path = repo_dir / "build"
+    if build_path.exists():
+        shutil.rmtree(str(build_path))
+    build_path.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "bash",
+        str(build_script), f"--build-type={str(build_type)}", "-o",
+        str(build_path), "-t", "-j",
+        str(max_jobs), f"--bisheng-compiler={str(bisheng_compiler_path)}", "--add-cmake-options",
+        "-DLLVM_ENABLE_LLD=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+        "--build-triton", "--build-torch-mlir", "--build-shmem-template", "--bishengir-publish", "ON",
+        "--collect-binary"
+    ]
+    if rebuild:
+        cmd.append("-r")
+    _log(f"Building AscendNPU-IR (bisheng): {' '.join(cmd)}")
+    subprocess.check_call(cmd, cwd=str(repo_dir))
+    _log(f"AscendNPU-IR build finished. Artifacts under: {build_path}")
+    install_dir = build_path / "install"
+    if install_dir.is_dir():
+        _log(f"Installed artifacts under: {install_dir}")
+
+
+def _copy_artifacts():
+    """Collect built binaries/bitcode into third_party/ascend/bishengir."""
+    ascend_bishengir_path = _THIS_DIR / "third_party" / "ascend" / "backend" / "bishengir"
+    if ascend_bishengir_path.exists():
+        shutil.rmtree(ascend_bishengir_path)
+    bin_dir = ascend_bishengir_path / "bin"
+    lib_dir = ascend_bishengir_path / "lib"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    lib_dir.mkdir(parents=True, exist_ok=True)
+
+    file_copies = [
+        (_NPUIR_DIR / "bishengir-output" / "bin" / "bishengir-compile", bin_dir / "bishengir-compile"),
+        (_NPUIR_DIR / "bishengir-output" / "bin" / "bishengir-opt", bin_dir / "bishengir-opt"),
+        (_NPUIR_DIR / "bishengir-output" / "bin" / "hivmc", bin_dir / "hivmc"),
+        (_NPUIR_DIR / "bishengir-output" / "bin" / "hivmc-a5", bin_dir / "hivmc-a5"),
+    ]
+    for src, dst in file_copies:
+        if src.is_file():
+            shutil.copy(src, dst)
+            if not os.path.exists(dst):
+                raise RuntimeError(f"Copy {src} to {dst} failed.")
+            _log(f"Copied {src} -> {dst}")
+        else:
+            raise RuntimeError(f"Copy {src} to {dst} failed.")
+
+    bc_src_dir = _NPUIR_DIR / "bishengir-output" / "lib"
+    if bc_src_dir.is_dir():
+        for bc in bc_src_dir.glob("*.bc"):
+            shutil.copy(bc, lib_dir / bc.name)
+            if not os.path.exists(lib_dir / bc.name):
+                raise RuntimeError(f"Copy {bc} to {lib_dir} failed.")
+            _log(f"Copied {bc} -> {lib_dir / bc.name}")
+    else:
+        _log(f"warning: bitcode dir not found: {bc_src_dir}")
+
+
+def build_npuir():
+    _log("Step 1/5: checking disk space ...")
+    _check_disk_space()
+
+    _log("Step 2/5: locating bisheng compiler ...")
+    bisheng_compiler_path = (_get_ascend_path() / "tools" / "bisheng_compiler" / "bin")
+    _log(f"bisheng compiler: {bisheng_compiler_path}")
+
+    _log("Step 3/5: initializing code repositories ...")
+    _init_npuir_repo()
+
+    _log("Step 4/5: building and packaging ...")
+    _build_and_package_bisheng(
+        _NPUIR_DIR,
+        bisheng_compiler_path=bisheng_compiler_path,
+        build_type="Release",
+        rebuild=True,
+    )
+
+    _log("Step 5/5: copying artifacts ...")
+    _copy_artifacts()
+    _log("All done.")

--- a/setup_ascend.py
+++ b/setup_ascend.py
@@ -23,6 +23,7 @@ def _set_default_env_vars():
     os.environ.setdefault("TRITON_BUILD_WITH_CLANG_LLD", "true")
     os.environ.setdefault("TRITON_BUILD_PROTON", "OFF")
     os.environ.setdefault("TRITON_BUILD_TD", "OFF")
+    os.environ.setdefault("TRITON_BUILD_NPUIR", "OFF")
     os.environ.setdefault("TRITON_WHEEL_NAME", "triton_ascend")
     os.environ.setdefault("TRITON_APPEND_CMAKE_ARGS", "-DTRITON_BUILD_UT=OFF")
 
@@ -283,6 +284,13 @@ def _git_check_call_with_retry(cmd, cwd=None, retries=3, interval=5):
             else:
                 print(f"Command '{' '.join(cmd)}' failed after {retries} attempts.")
     raise last_error
+
+
+def _ensure_npuir_submodule():
+    if os.getenv("TRITON_BUILD_NPUIR", "OFF").upper() not in ["ON", "1", "YES", "TRUE", "Y"]:
+        return
+    import build_npuir
+    build_npuir.build_npuir()
 
 
 def _ensure_distributed_submodule():
@@ -585,6 +593,7 @@ def _build_setup_kwargs(mod, kwargs):
 
 def main():
     _set_default_env_vars()
+    _ensure_npuir_submodule()
     _ensure_distributed_submodule()
 
     # Import the community setup_triton module without executing its setup()


### PR DESCRIPTION
# NPUIR 构建特性设计文档

## 1. 背景与目标

Triton-Ascend 后端依赖 **AscendNPU-IR（毕昇编译器，bishengir）** 产物（`bishengir-compile`、`bishengir-opt`、`hivmc` 及 bitcode 库）。该组件源码体量大、依赖 LLVM/Torch-MLIR 等嵌套子模块，编译耗时长、磁盘占用高，此前缺乏自动化构建入口。

本特性新增独立构建脚本 `build_npuir.py`，一键完成 **环境检查 → 代码仓初始化 → 编译打包 → 产物收集**，并通过环境变量 `TRITON_BUILD_NPUIR` 接入标准安装流程，实现可选的源码内 NPUIR 构建。

## 2. 整体流程

入口 `build_npuir()`（`build_npuir.py`）按 5 步串行执行：

| 步骤 | 函数 | 职责 |
|---|---|---|
| 1/5 磁盘检查 | `_check_disk_space()` | 校验构建盘可用空间 ≥ 30 GiB，不足直接报错中止 |
| 2/5 定位编译器 | `_get_ascend_path()` | 读取 `ASCEND_HOME_PATH`，定位 CANN 自带的 bisheng 编译器 `tools/bisheng_compiler/bin` |
| 3/5 初始化代码仓 | `_init_npuir_repo()` | 初始化 AscendNPU-IR 子模块并递归初始化 LLVM、Torch-MLIR 嵌套子模块 |
| 4/5 编译打包 | `_build_and_package_bisheng()` | 调用 `build-tools/build.sh` 完成配置、编译与发布 |
| 5/5 收集产物 | `_copy_artifacts()` | 将发布目录整体拷贝到后端 bishengir 目录 |

## 3. 关键设计

### 3.1 磁盘容量前置校验

使用 `shutil.disk_usage` 检查仓库所在盘可用空间，阈值 `_MIN_FREE_DISK_GB = 30`。因 AscendNPU-IR 需递归拉取 LLVM/Torch-MLIR 源码并产生庞大 build 树，空间不足会在编译中后段才失败、代价高，故在最前端快速失败。

### 3.2 Git 网络操作重试

`_run_with_retry()` 封装 `subprocess.check_call`，对 `git submodule update` 等网络命令重试 `_GIT_RETRY_TIMES = 3` 次、间隔 `_GIT_RETRY_INTERVAL = 5s`，提升弱网环境构建成功率。

### 3.3 两段式子模块初始化

先在根仓库初始化 `third_party/ascend/AscendNPU-IR` 子模块本身，待其源码树（`CMakeLists.txt`）就位后，再在该目录内 `--recursive` 初始化嵌套子模块，避免在空目录上递归导致失败；初始化结果均经 `_is_submodule_initialized()` 校验。

### 3.4 构建脚本调用

调用 AscendNPU-IR 的 `build-tools/build.sh`，关键参数：

- `--bisheng-compiler=<CANN 自带编译器路径>`，复用 CANN 工具链；
- `--build-triton --build-torch-mlir --build-shmem-template` 构建所需组件；
- `--bishengir-publish ON --collect-binary` 生成汇总发布目录 `bishengir-output/`；
- `-DLLVM_ENABLE_LLD=ON` 及 ccache launcher 加速；并行度 `min(cpu_count//8, 32)` 控制内存占用；
- 构建前清理并重建 `build/` 目录，`-r` 触发 rebuild。

### 3.5 产物收集

不再硬编码文件清单，直接将发布目录 `bishengir-output/` 通过 `shutil.copytree` 整体拷贝到 `third_party/ascend/backend/bishengir/`（目标已存在则先删除）。源目录缺失即报错，保证产物完整且与发布目录结构一致，后续发布内容增减无需维护文件列表。

## 4. 与安装流程集成

在 `setup_ascend.py` 中以**默认关闭、按需开启**方式接入：

- 默认环境变量 `TRITON_BUILD_NPUIR=OFF`；
- `main()` 中调用 `_ensure_npuir_submodule()`，仅当变量取值为 `ON/1/YES/TRUE/Y` 时才 `import build_npuir` 并执行 `build_npuir()`。

延迟 import 使普通安装（不构建 NPUIR）零额外开销，也不影响未拉取该子模块的场景。

## 5. 使用方式

```bash
# 先加载 CANN 环境（提供 ASCEND_HOME_PATH 与 bisheng 编译器）
source /usr/local/Ascend/ascend-toolkit/set_env.sh

# 方式一：直接运行
python3 build_npuir.py

# 方式二：随源码安装触发
TRITON_BUILD_NPUIR=ON pip install -e .
```

## 6. 错误处理

- 磁盘不足、`ASCEND_HOME_PATH` 未设置、子模块初始化失败、构建脚本缺失、发布目录缺失等均抛出明确 `RuntimeError`/`EnvironmentError`；
- 入口 `__main__` 捕获异常，统一以 `[build_npuir] ERROR: ...` 输出到 stderr 并以非零码退出，便于 CI 识别失败。
