### PR TITLE
[ssbuffer](fix) Fix dominance violation for WhileOp outer-scope

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
@@ -1251,10 +1251,9 @@ static int addPollingControlFlow(DenseMap<int, TransferGroupInfo> &groups) {
     Value senderCond = prepareLoopPolling(senderWaitParent,
                                           g.senderChain.waitOp, senderBuilder);
     if (!senderCond) {
-      LDBG("FALLBACK: unexpected sender loop op " << senderWaitParent->getName()
-                                                  << ", rc="
-                                                  << CVPipeline::ERRCODE_IGNORED
-                                                  << ".");
+      LDBG("FALLBACK: unexpected sender loop op "
+           << senderWaitParent->getName()
+           << ", rc=" << CVPipeline::ERRCODE_IGNORED << ".");
       return CVPipeline::ERRCODE_IGNORED;
     }
 
@@ -1283,8 +1282,8 @@ static int addPollingControlFlow(DenseMap<int, TransferGroupInfo> &groups) {
             receiverWaitParent, g.receiverChain.waitOp, receiverBuilder);
         if (!receiverCond) {
           LDBG("FALLBACK: unexpected receiver loop op "
-               << receiverWaitParent->getName() << ", rc="
-               << CVPipeline::ERRCODE_IGNORED << ".");
+               << receiverWaitParent->getName()
+               << ", rc=" << CVPipeline::ERRCODE_IGNORED << ".");
           return CVPipeline::ERRCODE_IGNORED;
         }
         if (processTransferChain(g.receiverChain, receiverCond,

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
@@ -1219,7 +1219,8 @@ static Value prepareLoopPolling(Operation *loopOp, Operation *waitOp,
     // (counter % 2) == 0
     Block &after = whileOp.getAfter().front();
     Value counter = after.getArgument(after.getNumArguments() - 1);
-    builderOut.setInsertionPoint(after.getTerminator());
+    // Insert at body start to dominate the wrapping scf.ifs.
+    builderOut.setInsertionPointToStart(&after);
     OpBuilder condBuilder(builderOut);
     Value c2 =
         condBuilder.create<arith::ConstantIntOp>(whileOp.getLoc(), 2, 32);

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
@@ -1200,8 +1200,9 @@ static int processTransferChain(TransferOpChain &chain, Value cond,
 }
 
 /// Create polling condition and builder for a loop op (ForOp or WhileOp).
-/// Returns the condition Value; `builderOut` is set to the insertion point
-/// for subsequent wrapping ops (before the loop terminator).
+/// Returns the condition Value, or null on unexpected loop type;
+/// `builderOut` is set to the insertion point for subsequent wrapping ops
+/// (before the loop terminator).
 static Value prepareLoopPolling(Operation *loopOp, Operation *waitOp,
                                 OpBuilder &builderOut) {
   int bid = getBlockId(waitOp);
@@ -1232,10 +1233,12 @@ static Value prepareLoopPolling(Operation *loopOp, Operation *waitOp,
                                              arith::CmpIPredicate::eq, rem, c0);
   }
 
-  llvm_unreachable("unexpected loop op type");
+  // Unexpected loop type: caller falls back with ERRCODE_IGNORED.
+  return Value();
 }
 
-/// Add polling control flow for all transfer groups
+/// Add polling control flow for all transfer groups.
+/// Returns 0 on success, else a CVPipeline ERRCODE (1=FAILED, 2=IGNORED).
 static int addPollingControlFlow(DenseMap<int, TransferGroupInfo> &groups) {
   for (auto &p : groups) {
     TransferGroupInfo &g = p.second;
@@ -1247,12 +1250,19 @@ static int addPollingControlFlow(DenseMap<int, TransferGroupInfo> &groups) {
     OpBuilder senderBuilder(senderWaitParent->getContext());
     Value senderCond = prepareLoopPolling(senderWaitParent,
                                           g.senderChain.waitOp, senderBuilder);
+    if (!senderCond) {
+      LDBG("FALLBACK: unexpected sender loop op " << senderWaitParent->getName()
+                                                  << ", rc="
+                                                  << CVPipeline::ERRCODE_IGNORED
+                                                  << ".");
+      return CVPipeline::ERRCODE_IGNORED;
+    }
 
     // Process sender chain (isProducer=true)
     if (processTransferChain(g.senderChain, senderCond, g.senderInputBuffer,
                              g.senderOutputBuffer, g.outputFlag, true,
                              senderBuilder) != 0) {
-      return -1;
+      return CVPipeline::ERRCODE_FAILED;
     }
 
     // Process receiver chain (may use different loop op) (isProducer=false)
@@ -1264,17 +1274,23 @@ static int addPollingControlFlow(DenseMap<int, TransferGroupInfo> &groups) {
         if (processTransferChain(g.receiverChain, senderCond,
                                  g.receiverInputBuffer, g.receiverOutputBuffer,
                                  g.outputFlag, false, senderBuilder) != 0) {
-          return -1;
+          return CVPipeline::ERRCODE_FAILED;
         }
       } else {
         // Receiver uses a different loop op, prepare new cond and builder
         OpBuilder receiverBuilder(receiverWaitParent->getContext());
         Value receiverCond = prepareLoopPolling(
             receiverWaitParent, g.receiverChain.waitOp, receiverBuilder);
+        if (!receiverCond) {
+          LDBG("FALLBACK: unexpected receiver loop op "
+               << receiverWaitParent->getName() << ", rc="
+               << CVPipeline::ERRCODE_IGNORED << ".");
+          return CVPipeline::ERRCODE_IGNORED;
+        }
         if (processTransferChain(g.receiverChain, receiverCond,
                                  g.receiverInputBuffer, g.receiverOutputBuffer,
                                  g.outputFlag, false, receiverBuilder) != 0) {
-          return -1;
+          return CVPipeline::ERRCODE_FAILED;
         }
       }
     }
@@ -1419,10 +1435,11 @@ void AddMultiBufferOuterScopePass::runOnOperation() {
     LDBG("[Step 2/3] Done.");
 
     LDBG("[Step 3/3] Start: polling control flow.");
-    if (addPollingControlFlow(groups)) {
+    int pollingRc = addPollingControlFlow(groups);
+    if (pollingRc != 0) {
       LDBG("FALLBACK: Step 3/3 failed, polling control flow failed, rc="
-           << CVPipeline::ERRCODE_FAILED << ".");
-      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+           << pollingRc << ".");
+      CVPipeline::setFallbackAttr(module, pollingRc);
       return;
     }
     LDBG("[Step 3/3] Done.");

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
@@ -775,6 +775,8 @@ static Value ensureWhileOpHasCounter(scf::WhileOp whileOp) {
   newResultTypes.push_back(i32Type);
 
   Value counterIterArg;
+  Operation *counterOne = nullptr;
+  Operation *counterAdd = nullptr;
 
   // Rebuild via the Builder callback API (matching InnerScope's
   // setupWhileIterArgCounter)
@@ -812,6 +814,8 @@ static Value ensureWhileOpHasCounter(scf::WhileOp whileOp) {
         auto oldYield = cast<scf::YieldOp>(oldAfter->getTerminator());
         Value one = ab.create<arith::ConstantIntOp>(al, 1, 32);
         Value nextCounter = ab.create<arith::AddIOp>(al, counterIterArg, one);
+        counterOne = one.getDefiningOp();
+        counterAdd = nextCounter.getDefiningOp();
         SmallVector<Value> yOps;
         for (Value v : oldYield.getOperands())
           yOps.push_back(map.lookupOrDefault(v));
@@ -823,6 +827,22 @@ static Value ensureWhileOpHasCounter(scf::WhileOp whileOp) {
   for (auto attr : oldWhile->getAttrs())
     newWhile->setAttr(attr.getName(), attr.getValue());
   newWhile->setAttr(CVPipeline::kIterCounter, builder.getUnitAttr());
+
+  // Tag counter-update ops with the last block_id of the after body so
+  // CloneOps' block-id contiguity check holds (mirrors InnerScope's
+  // insertWhileCounterOps).
+  Block &afterBody = newWhile.getAfter().front();
+  std::optional<int> lastBlockId;
+  for (Operation &op : afterBody) {
+    if (auto id = CVPipeline::getOpBlockId(&op))
+      lastBlockId = *id;
+  }
+  if (lastBlockId && counterOne && counterAdd) {
+    IntegerAttr blockIdAttr = builder.getI32IntegerAttr(*lastBlockId);
+    counterOne->setAttr(CVPipeline::kBlockId, blockIdAttr);
+    counterAdd->setAttr(CVPipeline::kBlockId, blockIdAttr);
+    counterAdd->setAttr(CVPipeline::kIterCounter, builder.getUnitAttr());
+  }
 
   // Replace results (exclude counter result)
   for (unsigned i = 0, e = oldWhile.getNumResults(); i < e; ++i)
@@ -1222,15 +1242,31 @@ static Value prepareLoopPolling(Operation *loopOp, Operation *waitOp,
     Value counter = after.getArgument(after.getNumArguments() - 1);
     // Insert at body start to dominate the wrapping scf.ifs.
     builderOut.setInsertionPointToStart(&after);
+    // Tag the condition ops with the first body block_id so the
+    // block-id contiguity check in CloneOps holds.
+    std::optional<int> pollBlockId;
+    for (Operation &op : after) {
+      if (auto id = CVPipeline::getOpBlockId(&op)) {
+        pollBlockId = *id;
+        break;
+      }
+    }
+    if (!pollBlockId)
+      pollBlockId = bid;
     OpBuilder condBuilder(builderOut);
     Value c2 =
         condBuilder.create<arith::ConstantIntOp>(whileOp.getLoc(), 2, 32);
+    setSsbufferTags(c2.getDefiningOp(), condBuilder, *pollBlockId, tid);
     Value rem =
         condBuilder.create<arith::RemSIOp>(whileOp.getLoc(), counter, c2);
+    setSsbufferTags(rem.getDefiningOp(), condBuilder, *pollBlockId, tid);
     Value c0 =
         condBuilder.create<arith::ConstantIntOp>(whileOp.getLoc(), 0, 32);
-    return condBuilder.create<arith::CmpIOp>(whileOp.getLoc(),
-                                             arith::CmpIPredicate::eq, rem, c0);
+    setSsbufferTags(c0.getDefiningOp(), condBuilder, *pollBlockId, tid);
+    Value cond = condBuilder.create<arith::CmpIOp>(
+        whileOp.getLoc(), arith::CmpIPredicate::eq, rem, c0);
+    setSsbufferTags(cond.getDefiningOp(), condBuilder, *pollBlockId, tid);
+    return cond;
   }
 
   // Unexpected loop type: caller falls back with ERRCODE_IGNORED.

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Outer-scope-whileop.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Outer-scope-whileop.mlir
@@ -1,19 +1,47 @@
 // RUN: triton-opt --add_multi_buffer_outer_scope %s | FileCheck %s
 
-// Test: C→V transfer with scf.while (main_loop) in single-buffer mode.
-// Pass must not crash; IR structure (whileOp, main_loop, TCB marks) preserved.
-//   We pin the inter-core buffer count to 1 via the module-level
-//   `ssbuffer.inter_core_buf_count` attribute so the default of 2 doesn't
-//   trigger the double-buffer polling branch (scf.if dispatch), which is
-//   not supported for scf.while main loops here.
+// Test: C→V transfer with scf.while (main_loop) in double-buffer mode.
+// - pin inter_core_buf_count=2: polling branch (scf.if dispatch) now
+//   supported for scf.while, as the polling condition is inserted at
+//   while-body start (dominance fix); supersedes the pin-to-1 workaround
+// - wrong insertion order still rejected by verifier
+//   (operand-defined-after-use)
+// - CHECK locks double-buffer output: two mutually-exclusive transfer
+//   groups (even/odd flags) + double-buffer selection
 
 // CHECK-LABEL: func.func @tc_while_ctov_sender
-// CHECK: scf.while
-// CHECK: ssbuffer.main_loop
 // CHECK: tightly_coupled_buffer
+// while gets injected counter iter_arg
+// CHECK: scf.while {{.*}} : (i32, i32) -> (i32, i32)
+// polling condition computed at body start
+// CHECK: arith.remsi
+// CHECK: arith.cmpi eq
+// two mutually-exclusive transfer groups: even flag=3 / odd flag=8
+// CHECK: scf.if
+// CHECK: sync_block_wait {{.*}} flag = 3
+// CHECK: } else {
+// CHECK: sync_block_wait {{.*}} flag = 8
+// CHECK: ssbuffer.cross_buffer
+// double-buffer selection
+// CHECK: memref.memory_space_cast
+// CHECK: } else {
+// CHECK: memref.memory_space_cast
+// CHECK: sync_block_set {{.*}} flag = 3
+// CHECK: } else {
+// CHECK: sync_block_set {{.*}} flag = 8
+// CHECK: ssbuffer.iterCounter
+// CHECK: ssbuffer.main_loop
+// cross-core initial signals for both flags + CUBE-side waits
+// CHECK: sync_block_set {{.*}} flag = 3
+// CHECK: sync_block_set {{.*}} flag = 8
+// CHECK: sync_block_wait {{.*}} flag = 3
+// CHECK: sync_block_wait {{.*}} flag = 8
+// CUBE side: fixpipe double-buffer selection
+// CHECK: hivm.hir.fixpipe
+// CHECK: } else {
+// CHECK: hivm.hir.fixpipe
 
-module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">,
-                   ssbuffer.inter_core_buf_count = 1 : i32} {
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">, ssbuffer.inter_core_buf_count = 2 : i32} {
 func.func @tc_while_ctov_sender() {
   %c0_i32 = arith.constant 0 : i32
   %c100_i32 = arith.constant 100 : i32
@@ -56,9 +84,36 @@ func.func @tc_while_ctov_sender() {
 
 
 // Test: Both sender and receiver use scf.while with main_loop
+// - both whiles get counter injection + two mutually-exclusive groups
+
 // CHECK-LABEL: func.func @tc_while_both_sides
-// CHECK: scf.while
-// CHECK: ssbuffer.main_loop
+// CHECK: tightly_coupled_buffer
+// VECTOR while: counter injection + two mutually-exclusive groups (flag 6/7)
+// CHECK: scf.while {{.*}} : (i32, i32) -> (i32, i32)
+// CHECK: arith.remsi
+// CHECK: arith.cmpi eq
+// CHECK: scf.if
+// CHECK: sync_block_wait {{.*}} flag = 6
+// CHECK: } else {
+// CHECK: sync_block_wait {{.*}} flag = 7
+// CHECK: ssbuffer.cross_buffer
+// CHECK: memref.memory_space_cast
+// CHECK: } else {
+// CHECK: memref.memory_space_cast
+// CHECK: sync_block_set {{.*}} flag = 6
+// CHECK: } else {
+// CHECK: sync_block_set {{.*}} flag = 7
+// CHECK: ssbuffer.iterCounter
+// CHECK: sync_block_set {{.*}} flag = 6
+// CHECK: sync_block_set {{.*}} flag = 7
+// CHECK: sync_block_wait {{.*}} flag = 6
+// CHECK: sync_block_wait {{.*}} flag = 7
+// CUBE while: same counter injection + fixpipe double-buffer selection
+// CHECK: scf.while {{.*}} : (i32, i32) -> (i32, i32)
+// CHECK: hivm.hir.fixpipe
+// CHECK: } else {
+// CHECK: hivm.hir.fixpipe
+// CHECK: ssbuffer.iterCounter
 
 func.func @tc_while_both_sides() {
   %c0_i32 = arith.constant 0 : i32


### PR DESCRIPTION
…ng condition

The polling condition (iterCounter % 2 == 0) computed in prepareLoopPolling() for scf.WhileOp was inserted before the loop body terminator, while the wrapping scf.ifs referencing it are created at the original sync/transfer op positions in the middle of the loop body. This yields an SSA dominance violation: operand defined after its use.

Insert the condition computation at the start of the while body instead, so it dominates all its uses, matching the ForOp branch which inserts the condition before the sender wait op.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
