### PR TITLE
[graph](fix) lift semantically safe Row assertions

### DIFF
--- a/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/RowCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/RowCoalescing.cpp
@@ -94,6 +94,24 @@ static bool isScalarIntegerLike(Value value) {
   return intTy && intTy.getWidth() > 1;
 }
 
+static bool isRankedI1Tensor(Value value) {
+  auto type = dyn_cast<RankedTensorType>(value.getType());
+  if (!type)
+    return false;
+  auto elementType = dyn_cast<IntegerType>(type.getElementType());
+  return elementType && elementType.getWidth() == 1;
+}
+
+static bool isAutomaticOverflowAssert(triton::AssertOp assertOp) {
+  if (!assertOp || !assertOp->hasAttr("tt.auto_overflow_assert"))
+    return false;
+  // The frontend gives only sanitize_overflow assertions this marker.  The
+  // text by itself is not provenance: a user device_assert can use it too.
+  auto message = dyn_cast<StringAttr>(assertOp.getMessageAttr());
+  return message &&
+         message.getValue().contains("overflow detected for operation");
+}
+
 // Match the canonical rowwise guard:
 //
 //   %pid = tt.get_program_id x
@@ -151,6 +169,9 @@ static std::optional<RowSeed> matchRowSeed(ModuleOp moduleOp) {
 static bool isRowLiftable(Operation *op) {
   if (isa<triton::ReturnOp, cf::BranchOp, cf::CondBranchOp>(op))
     return false;
+  if (auto assertOp = dyn_cast<triton::AssertOp>(op))
+    return isAutomaticOverflowAssert(assertOp) &&
+           isRankedI1Tensor(assertOp.getCondition());
   if (auto *dialect = op->getDialect()) {
     StringRef ns = dialect->getNamespace();
     if (ns == arith::ArithDialect::getDialectNamespace() ||
@@ -467,6 +488,33 @@ static bool rewriteMatchedRow(ModuleOp moduleOp, const RowSeed &seed,
       }
       rw.create<triton::StoreOp>(opLoc, ptr, val, mask, st.getBoundaryCheck(),
                                  st.getCache(), st.getEvict());
+      return true;
+    }
+
+    if (auto assertOp = dyn_cast<triton::AssertOp>(op)) {
+      if (!isAutomaticOverflowAssert(assertOp) ||
+          !isRankedI1Tensor(assertOp.getCondition()))
+        return false;
+      Value condition = liftOperand(assertOp.getCondition(), localMap);
+      auto conditionType = dyn_cast<RankedTensorType>(condition.getType());
+      if (!conditionType)
+        return false;
+      Value activeMask = maskForType(opLoc, condition.getType());
+      if (!activeMask || activeMask.getType() != condition.getType())
+        return false;
+
+      // ceil-div Row launches create inactive tail rows that did not execute
+      // in the original kernel.  Make those lanes vacuously satisfy the
+      // frontend-generated check while preserving it on every active row.
+      auto oneAttr = rw.getIntegerAttr(conditionType.getElementType(), 1);
+      Value allTrue = rw.create<arith::ConstantOp>(
+          opLoc, DenseElementsAttr::get(conditionType, oneAttr));
+      Value inactiveMask = rw.create<arith::XOrIOp>(opLoc, activeMask, allTrue);
+      Value guardedCondition =
+          rw.create<arith::OrIOp>(opLoc, inactiveMask, condition);
+      auto rewrittenAssert = rw.create<triton::AssertOp>(
+          assertOp.getLoc(), guardedCondition, assertOp.getMessage());
+      copyAttrs(assertOp, rewrittenAssert);
       return true;
     }
 

--- a/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/RowCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/RowCoalescing.cpp
@@ -32,6 +32,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -65,6 +66,7 @@ struct RowSeed {
   Value validCount;
   arith::CmpIOp entryGuard;
   Block *workBlock = nullptr;
+  SmallVector<Operation *> externalPidDefinitions;
 };
 
 static int64_t inferRowsPerProgram(int64_t maxBaseElements) {
@@ -102,15 +104,14 @@ static bool isRankedI1Tensor(Value value) {
   return elementType && elementType.getWidth() == 1;
 }
 
-static bool isAutomaticOverflowAssert(triton::AssertOp assertOp) {
-  if (!assertOp || !assertOp->hasAttr("tt.auto_overflow_assert"))
-    return false;
-  // The frontend gives only sanitize_overflow assertions this marker.  The
-  // text by itself is not provenance: a user device_assert can use it too.
-  auto message = dyn_cast<StringAttr>(assertOp.getMessageAttr());
-  return message &&
-         message.getValue().contains("overflow detected for operation");
+static bool isI1AssertCondition(Value value) {
+  if (auto type = dyn_cast<IntegerType>(value.getType()))
+    return type.getWidth() == 1;
+  return isRankedI1Tensor(value);
 }
+
+static bool isRowLiftable(Operation *op);
+static bool collectExternalPidDefinitions(RowSeed &seed);
 
 // Match the canonical rowwise guard:
 //
@@ -160,7 +161,10 @@ static std::optional<RowSeed> matchRowSeed(ModuleOp moduleOp) {
     if (!isScalarIntegerLike(cmp.getRhs()))
       continue;
 
-    return RowSeed{pid, axis, cmp.getRhs(), cmp, falseBlock};
+    RowSeed seed{pid, axis, cmp.getRhs(), cmp, falseBlock};
+    if (!collectExternalPidDefinitions(seed))
+      continue;
+    return seed;
   }
 
   return std::nullopt;
@@ -170,8 +174,7 @@ static bool isRowLiftable(Operation *op) {
   if (isa<triton::ReturnOp, cf::BranchOp, cf::CondBranchOp>(op))
     return false;
   if (auto assertOp = dyn_cast<triton::AssertOp>(op))
-    return isAutomaticOverflowAssert(assertOp) &&
-           isRankedI1Tensor(assertOp.getCondition());
+    return isI1AssertCondition(assertOp.getCondition());
   if (auto *dialect = op->getDialect()) {
     StringRef ns = dialect->getNamespace();
     if (ns == arith::ArithDialect::getDialectNamespace() ||
@@ -182,6 +185,87 @@ static bool isRowLiftable(Operation *op) {
              triton::ExpandDimsOp, triton::LoadOp, triton::StoreOp,
              triton::MakeRangeOp, triton::ScanOp, triton::ReduceOp,
              triton::ClampFOp, triton::FpToFpOp, scf::ForOp>(op);
+}
+
+static bool isInWorkRegion(Operation *operation, Block *workBlock) {
+  for (Operation *current = operation; current;
+       current = current->getParentOp()) {
+    if (current->getBlock() == workBlock)
+      return true;
+  }
+  return false;
+}
+
+// Rebuild only side-effect-free, regionless PID-derived definitions that live
+// in the canonical entry block.  Loads, stores and assertions need their own
+// Row masking semantics, so keep them in the work block or reject the match.
+static bool isExternalPidDefinitionLiftable(Operation *operation) {
+  if (!operation || operation->getNumRegions() != 0 ||
+      isa<triton::LoadOp, triton::StoreOp, triton::AssertOp,
+          triton::ReduceOp, triton::ScanOp, scf::ForOp>(operation))
+    return false;
+  return isRowLiftable(operation) && isMemoryEffectFree(operation);
+}
+
+// A PID-derived value may be defined before the branch and then consumed by
+// the work block.  It must be rebuilt from the lifted PID rather than treated
+// as a uniform scalar.  Keep the canonical guard's direct PID use intact and
+// reject every other external dependency that cannot be safely cloned.
+static bool collectExternalPidDefinitions(RowSeed &seed) {
+  Block *entryBlock = seed.pid->getBlock();
+  if (!entryBlock || !seed.workBlock)
+    return false;
+
+  DenseSet<Value> visited;
+  DenseSet<Operation *> definitions;
+  SmallVector<Value> worklist{seed.pid.getResult()};
+  while (!worklist.empty()) {
+    Value value = worklist.pop_back_val();
+    if (!visited.insert(value).second)
+      continue;
+    for (Operation *user : value.getUsers()) {
+      if (user == seed.entryGuard.getOperation()) {
+        // The matched guard is exactly "%pid >= count".  A value derived
+        // from PID must not also feed that guard, because it is not rebuilt.
+        if (value != seed.pid.getResult())
+          return false;
+        continue;
+      }
+      if (isInWorkRegion(user, seed.workBlock)) {
+        for (Value result : user->getResults())
+          worklist.push_back(result);
+        continue;
+      }
+      if (user->getBlock() != entryBlock ||
+          !isExternalPidDefinitionLiftable(user))
+        return false;
+      definitions.insert(user);
+      for (Value result : user->getResults())
+        worklist.push_back(result);
+    }
+  }
+
+  seed.externalPidDefinitions.clear();
+  for (Operation &operation : *entryBlock)
+    if (definitions.contains(&operation))
+      seed.externalPidDefinitions.push_back(&operation);
+  return true;
+}
+
+// Assertions in the work block and in nested scf.for bodies are rebuilt
+// explicitly.  Reduce/scan combine regions are cloned as-is, so assertions in
+// those regions cannot receive the Row tail guard and must fail closed.
+static bool isAssertInRowRebuildableRegion(Operation *operation,
+                                           Block *workBlock) {
+  for (Operation *current = operation; current;
+       current = current->getParentOp()) {
+    if (current->getBlock() == workBlock)
+      return true;
+    Operation *parent = current->getParentOp();
+    if (!parent || !isa<scf::ForOp>(parent))
+      return false;
+  }
+  return false;
 }
 
 static bool collectRowRegion(const RowSeed &seed,
@@ -200,8 +284,13 @@ static bool collectRowRegion(const RowSeed &seed,
         return;
       if (!isRowLiftable(nested))
         safe = false;
+      if (isa<triton::AssertOp>(nested) &&
+          !isAssertInRowRebuildableRegion(nested, seed.workBlock))
+        safe = false;
     });
-    if (!safe || !isRowLiftable(&op))
+    if (!safe || !isRowLiftable(&op) ||
+        (isa<triton::AssertOp>(&op) &&
+         !isAssertInRowRebuildableRegion(&op, seed.workBlock)))
       return false;
     if (isa<triton::StoreOp>(op))
       hasStore = true;
@@ -492,20 +581,19 @@ static bool rewriteMatchedRow(ModuleOp moduleOp, const RowSeed &seed,
     }
 
     if (auto assertOp = dyn_cast<triton::AssertOp>(op)) {
-      if (!isAutomaticOverflowAssert(assertOp) ||
-          !isRankedI1Tensor(assertOp.getCondition()))
+      if (!isI1AssertCondition(assertOp.getCondition()))
         return false;
       Value condition = liftOperand(assertOp.getCondition(), localMap);
-      auto conditionType = dyn_cast<RankedTensorType>(condition.getType());
-      if (!conditionType)
+      if (!condition || !isRankedI1Tensor(condition))
         return false;
+      auto conditionType = cast<RankedTensorType>(condition.getType());
       Value activeMask = maskForType(opLoc, condition.getType());
       if (!activeMask || activeMask.getType() != condition.getType())
         return false;
 
       // ceil-div Row launches create inactive tail rows that did not execute
-      // in the original kernel.  Make those lanes vacuously satisfy the
-      // frontend-generated check while preserving it on every active row.
+      // in the original kernel.  Make those lanes vacuously satisfy every
+      // lifted assertion while preserving it on each active row.
       auto oneAttr = rw.getIntegerAttr(conditionType.getElementType(), 1);
       Value allTrue = rw.create<arith::ConstantOp>(
           opLoc, DenseElementsAttr::get(conditionType, oneAttr));
@@ -617,6 +705,10 @@ static bool rewriteMatchedRow(ModuleOp moduleOp, const RowSeed &seed,
   };
 
   DenseMap<Value, Value> topMap;
+  for (Operation *op : seed.externalPidDefinitions) {
+    if (!rebuildOp(op, &topMap, false))
+      return false;
+  }
   for (Operation *op : ordered) {
     if (!rebuildOp(op, &topMap, true))
       return false;
@@ -652,6 +744,11 @@ static bool rewriteMatchedRow(ModuleOp moduleOp, const RowSeed &seed,
   }
   if (seed.entryGuard->use_empty())
     rw.eraseOp(seed.entryGuard);
+  for (auto it = seed.externalPidDefinitions.rbegin();
+       it != seed.externalPidDefinitions.rend(); ++it) {
+    if ((*it)->use_empty())
+      rw.eraseOp(*it);
+  }
 
   (void)moduleOp;
   return true;

--- a/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/RowCoalescing.cpp
+++ b/third_party/ascend/lib/TritonToGraph/LegacyMemoryAccess/RowCoalescing.cpp
@@ -201,8 +201,8 @@ static bool isInWorkRegion(Operation *operation, Block *workBlock) {
 // Row masking semantics, so keep them in the work block or reject the match.
 static bool isExternalPidDefinitionLiftable(Operation *operation) {
   if (!operation || operation->getNumRegions() != 0 ||
-      isa<triton::LoadOp, triton::StoreOp, triton::AssertOp,
-          triton::ReduceOp, triton::ScanOp, scf::ForOp>(operation))
+      isa<triton::LoadOp, triton::StoreOp, triton::AssertOp, triton::ReduceOp,
+          triton::ScanOp, scf::ForOp>(operation))
     return false;
   return isRowLiftable(operation) && isMemoryEffectFree(operation);
 }

--- a/third_party/ascend/lib/TritonToGraph/Rules/RowCoalescingRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/RowCoalescingRule.cpp
@@ -31,6 +31,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Interfaces/CallInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
@@ -132,22 +133,17 @@ bool isRankedI1Tensor(Value value) {
   return elementType && elementType.getWidth() == 1;
 }
 
-bool isAutomaticOverflowAssert(triton::AssertOp assertOp) {
-  if (!assertOp || !assertOp->hasAttr("tt.auto_overflow_assert"))
-    return false;
-  // The frontend gives only sanitize_overflow assertions this marker.  The
-  // text by itself is not provenance: a user device_assert can use it too.
-  auto message = dyn_cast<StringAttr>(assertOp.getMessageAttr());
-  return message &&
-         message.getValue().contains("overflow detected for operation");
+bool isI1AssertCondition(Value value) {
+  if (auto type = dyn_cast<IntegerType>(value.getType()))
+    return type.getWidth() == 1;
+  return isRankedI1Tensor(value);
 }
 
 bool isRowLiftable(Operation *operation) {
   if (isa<triton::ReturnOp, cf::BranchOp, cf::CondBranchOp>(operation))
     return false;
   if (auto assertOp = dyn_cast<triton::AssertOp>(operation))
-    return isAutomaticOverflowAssert(assertOp) &&
-           isRankedI1Tensor(assertOp.getCondition());
+    return isI1AssertCondition(assertOp.getCondition());
   if (Dialect *dialect = operation->getDialect()) {
     StringRef dialectNamespace = dialect->getNamespace();
     if (dialectNamespace == arith::ArithDialect::getDialectNamespace() ||
@@ -158,6 +154,29 @@ bool isRowLiftable(Operation *operation) {
              triton::ExpandDimsOp, triton::LoadOp, triton::StoreOp,
              triton::MakeRangeOp, triton::ScanOp, triton::ReduceOp,
              triton::ClampFOp, triton::FpToFpOp, scf::ForOp>(operation);
+}
+
+// Reduce/scan combine regions are cloned without recursively rebuilding their
+// bodies.  Only assertions in the work block or nested scf.for bodies can be
+// given the Row tail guard.
+bool isAssertInRowRebuildableRegion(Operation *operation, Block *workBlock) {
+  for (Operation *current = operation; current;
+       current = current->getParentOp()) {
+    if (current->getBlock() == workBlock)
+      return true;
+    Operation *parent = current->getParentOp();
+    if (!parent || !isa<scf::ForOp>(parent))
+      return false;
+  }
+  return false;
+}
+
+bool isExternalPidDefinitionLiftable(Operation *operation) {
+  if (!operation || operation->getNumRegions() != 0 ||
+      isa<triton::LoadOp, triton::StoreOp, triton::AssertOp,
+          triton::ReduceOp, triton::ScanOp, scf::ForOp>(operation))
+    return false;
+  return isRowLiftable(operation) && isMemoryEffectFree(operation);
 }
 
 bool collectRowRegion(const RowSeed &seed,
@@ -177,8 +196,13 @@ bool collectRowRegion(const RowSeed &seed,
         return;
       if (!isRowLiftable(nested))
         safe = false;
+      if (isa<triton::AssertOp>(nested) &&
+          !isAssertInRowRebuildableRegion(nested, seed.workBlock))
+        safe = false;
     });
-    if (!safe || !isRowLiftable(&operation))
+    if (!safe || !isRowLiftable(&operation) ||
+        (isa<triton::AssertOp>(&operation) &&
+         !isAssertInRowRebuildableRegion(&operation, seed.workBlock)))
       return false;
     hasStore |= isa<triton::StoreOp>(operation);
     ordered.push_back(&operation);
@@ -217,7 +241,11 @@ int64_t inferRowsPerProgram(int64_t maxBaseElements) {
   return kDefaultRowsPerProgram;
 }
 
-bool hasPidDerivedValueOutsideWork(RowSeed &seed) {
+bool hasUnsupportedPidDependencyOutsideWork(RowSeed &seed) {
+  Block *entryBlock = seed.pid->getBlock();
+  if (!entryBlock || !seed.workBlock)
+    return true;
+
   DenseSet<Value> visited;
   SmallVector<Value> worklist{seed.pid.getResult()};
   while (!worklist.empty()) {
@@ -225,12 +253,20 @@ bool hasPidDerivedValueOutsideWork(RowSeed &seed) {
     if (!visited.insert(value).second)
       continue;
     for (Operation *user : value.getUsers()) {
-      // The canonical guard intentionally consumes the scalar PID before the
-      // work block.  Every other PID-derived calculation must be rebuilt in
-      // the lifted region; otherwise legacy Row would splat it as uniform.
-      if (user == seed.entryGuard.getOperation())
+      if (user == seed.entryGuard.getOperation()) {
+        // The canonical guard consumes the original scalar PID directly.
+        // A derived value feeding it cannot be rebuilt independently.
+        if (value != seed.pid.getResult())
+          return true;
         continue;
-      if (!isInWorkRegion(user, seed.workBlock))
+      }
+      if (isInWorkRegion(user, seed.workBlock)) {
+        for (Value result : user->getResults())
+          worklist.push_back(result);
+        continue;
+      }
+      if (user->getBlock() != entryBlock ||
+          !isExternalPidDefinitionLiftable(user))
         return true;
       for (Value result : user->getResults())
         worklist.push_back(result);
@@ -292,7 +328,7 @@ std::optional<RowSeed> matchRowSeed(triton::FuncOp function) {
       continue;
 
     RowSeed seed{pid, axis, guard.getRhs(), guard, workBlock};
-    if (hasPidDerivedValueOutsideWork(seed))
+    if (hasUnsupportedPidDependencyOutsideWork(seed))
       continue;
     return seed;
   }

--- a/third_party/ascend/lib/TritonToGraph/Rules/RowCoalescingRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/RowCoalescingRule.cpp
@@ -173,8 +173,8 @@ bool isAssertInRowRebuildableRegion(Operation *operation, Block *workBlock) {
 
 bool isExternalPidDefinitionLiftable(Operation *operation) {
   if (!operation || operation->getNumRegions() != 0 ||
-      isa<triton::LoadOp, triton::StoreOp, triton::AssertOp,
-          triton::ReduceOp, triton::ScanOp, scf::ForOp>(operation))
+      isa<triton::LoadOp, triton::StoreOp, triton::AssertOp, triton::ReduceOp,
+          triton::ScanOp, scf::ForOp>(operation))
     return false;
   return isRowLiftable(operation) && isMemoryEffectFree(operation);
 }

--- a/third_party/ascend/lib/TritonToGraph/Rules/RowCoalescingRule.cpp
+++ b/third_party/ascend/lib/TritonToGraph/Rules/RowCoalescingRule.cpp
@@ -124,9 +124,30 @@ bool isInWorkRegion(Operation *operation, Block *workBlock) {
   return false;
 }
 
+bool isRankedI1Tensor(Value value) {
+  auto type = dyn_cast<RankedTensorType>(value.getType());
+  if (!type)
+    return false;
+  auto elementType = dyn_cast<IntegerType>(type.getElementType());
+  return elementType && elementType.getWidth() == 1;
+}
+
+bool isAutomaticOverflowAssert(triton::AssertOp assertOp) {
+  if (!assertOp || !assertOp->hasAttr("tt.auto_overflow_assert"))
+    return false;
+  // The frontend gives only sanitize_overflow assertions this marker.  The
+  // text by itself is not provenance: a user device_assert can use it too.
+  auto message = dyn_cast<StringAttr>(assertOp.getMessageAttr());
+  return message &&
+         message.getValue().contains("overflow detected for operation");
+}
+
 bool isRowLiftable(Operation *operation) {
   if (isa<triton::ReturnOp, cf::BranchOp, cf::CondBranchOp>(operation))
     return false;
+  if (auto assertOp = dyn_cast<triton::AssertOp>(operation))
+    return isAutomaticOverflowAssert(assertOp) &&
+           isRankedI1Tensor(assertOp.getCondition());
   if (Dialect *dialect = operation->getDialect()) {
     StringRef dialectNamespace = dialect->getNamespace();
     if (dialectNamespace == arith::ArithDialect::getDialectNamespace() ||

--- a/third_party/ascend/unittest/pytest_ut/test_row_coalescing_compat.py
+++ b/third_party/ascend/unittest/pytest_ut/test_row_coalescing_compat.py
@@ -112,21 +112,15 @@ def _row_module(
         store_value = "%out"
     elif body in ("auto_overflow_assert", "user_tensor_assert"):
         marker = " {tt.auto_overflow_assert}" if body == "auto_overflow_assert" else ""
-        message = (
-            "int32 overflow detected for operation add"
-            if body == "auto_overflow_assert"
-            else "user tensor assertion"
-        )
+        message = ("int32 overflow detected for operation add"
+                   if body == "auto_overflow_assert" else "user tensor assertion")
         pre_load = f"""    %overflow_ok = arith.cmpi sle, %offsets, %offsets : tensor<{width}xi32>
     tt.assert %overflow_ok, "{message}"{marker} : tensor<{width}xi1>
 """
     elif body in ("auto_scalar_assert", "user_scalar_assert"):
         marker = " {tt.auto_overflow_assert}" if body == "auto_scalar_assert" else ""
-        message = (
-            "int32 overflow detected for operation add"
-            if body == "auto_scalar_assert"
-            else "user scalar assertion"
-        )
+        message = ("int32 overflow detected for operation add"
+                   if body == "auto_scalar_assert" else "user scalar assertion")
         pre_load = f"""    %scalar_ok = arith.cmpi slt, {pid_in_work}, %count : i32
     tt.assert %scalar_ok, "{message}"{marker} : i1
 """
@@ -268,9 +262,7 @@ def test_row_coalescing_lifts_user_tensor_assert_with_tail_guard(tmp_path):
         ("user_scalar_assert", "user scalar assertion", False),
     ),
 )
-def test_row_coalescing_lifts_scalar_assert_with_tail_guard(
-    body, message, has_auto_marker, tmp_path
-):
+def test_row_coalescing_lifts_scalar_assert_with_tail_guard(body, message, has_auto_marker, tmp_path):
     text = _run_row(_row_module(f"row_{body}", 16, body=body), tmp_path)
 
     _assert_row_hit(text)

--- a/third_party/ascend/unittest/pytest_ut/test_row_coalescing_compat.py
+++ b/third_party/ascend/unittest/pytest_ut/test_row_coalescing_compat.py
@@ -97,6 +97,11 @@ def _row_module(
     }}
 """
         store_value = "%out"
+    elif body in ("auto_overflow_assert", "unmarked_overflow_assert"):
+        marker = " {tt.auto_overflow_assert}" if body == "auto_overflow_assert" else ""
+        pre_load = f"""    %overflow_ok = arith.cmpi sle, %offsets, %offsets : tensor<{width}xi32>
+    tt.assert %overflow_ok, "int32 overflow detected for operation add"{marker} : tensor<{width}xi1>
+"""
     elif body == "non_whitelisted_y_num_programs":
         post_load = "    %not_whitelisted = tt.get_num_programs y : i32\n"
     elif body != "copy":
@@ -193,6 +198,35 @@ def test_row_coalescing_adds_tail_mask_to_masked_load_and_store(tmp_path):
     lifted_stores = [line for line in text.splitlines() if "tt.store" in line and "tensor<8x16x!tt.ptr<f32>>" in line]
     assert len(lifted_loads) == 1 and lifted_loads[0].count(",") >= 2
     assert len(lifted_stores) == 1 and lifted_stores[0].count(",") >= 2
+
+
+def test_row_coalescing_lifts_automatic_overflow_assert_with_tail_guard(tmp_path):
+    text = _run_row(
+        _row_module("row_auto_overflow_assert", 16, body="auto_overflow_assert"),
+        tmp_path,
+    )
+
+    _assert_row_hit(text)
+    assert text.count("tt.assert") == 1
+    assert "tt.auto_overflow_assert" in text
+    assert "arith.xori" in text
+    assert "arith.ori" in text
+    assert "tensor<8x16xi1>" in text
+
+
+def test_row_coalescing_rejects_unmarked_overflow_assert(tmp_path):
+    text = _run_row(
+        _row_module(
+            "row_unmarked_overflow_assert",
+            16,
+            body="unmarked_overflow_assert",
+        ),
+        tmp_path,
+    )
+
+    _assert_row_bailout(text)
+    assert "tt.assert" in text
+    assert "tt.auto_overflow_assert" not in text
 
 
 def test_row_coalescing_lifts_reduce_along_original_row_axis(tmp_path):

--- a/third_party/ascend/unittest/pytest_ut/test_row_coalescing_compat.py
+++ b/third_party/ascend/unittest/pytest_ut/test_row_coalescing_compat.py
@@ -97,10 +97,25 @@ def _row_module(
     }}
 """
         store_value = "%out"
-    elif body in ("auto_overflow_assert", "unmarked_overflow_assert"):
+    elif body in ("auto_overflow_assert", "user_tensor_assert"):
         marker = " {tt.auto_overflow_assert}" if body == "auto_overflow_assert" else ""
+        message = (
+            "int32 overflow detected for operation add"
+            if body == "auto_overflow_assert"
+            else "user tensor assertion"
+        )
         pre_load = f"""    %overflow_ok = arith.cmpi sle, %offsets, %offsets : tensor<{width}xi32>
-    tt.assert %overflow_ok, "int32 overflow detected for operation add"{marker} : tensor<{width}xi1>
+    tt.assert %overflow_ok, "{message}"{marker} : tensor<{width}xi1>
+"""
+    elif body in ("auto_scalar_assert", "user_scalar_assert"):
+        marker = " {tt.auto_overflow_assert}" if body == "auto_scalar_assert" else ""
+        message = (
+            "int32 overflow detected for operation add"
+            if body == "auto_scalar_assert"
+            else "user scalar assertion"
+        )
+        pre_load = f"""    %scalar_ok = arith.cmpi slt, {pid_in_work}, %count : i32
+    tt.assert %scalar_ok, "{message}"{marker} : i1
 """
     elif body == "non_whitelisted_y_num_programs":
         post_load = "    %not_whitelisted = tt.get_num_programs y : i32\n"
@@ -214,19 +229,44 @@ def test_row_coalescing_lifts_automatic_overflow_assert_with_tail_guard(tmp_path
     assert "tensor<8x16xi1>" in text
 
 
-def test_row_coalescing_rejects_unmarked_overflow_assert(tmp_path):
+def test_row_coalescing_lifts_user_tensor_assert_with_tail_guard(tmp_path):
     text = _run_row(
         _row_module(
-            "row_unmarked_overflow_assert",
+            "row_user_tensor_assert",
             16,
-            body="unmarked_overflow_assert",
+            body="user_tensor_assert",
         ),
         tmp_path,
     )
 
-    _assert_row_bailout(text)
+    _assert_row_hit(text)
     assert "tt.assert" in text
+    assert "user tensor assertion" in text
     assert "tt.auto_overflow_assert" not in text
+    assert "arith.xori" in text
+    assert "arith.ori" in text
+    assert "tensor<8x16xi1>" in text
+
+
+@pytest.mark.parametrize(
+    ("body", "message", "has_auto_marker"),
+    (
+        ("auto_scalar_assert", "int32 overflow detected for operation add", True),
+        ("user_scalar_assert", "user scalar assertion", False),
+    ),
+)
+def test_row_coalescing_lifts_scalar_assert_with_tail_guard(
+    body, message, has_auto_marker, tmp_path
+):
+    text = _run_row(_row_module(f"row_{body}", 16, body=body), tmp_path)
+
+    _assert_row_hit(text)
+    assert text.count("tt.assert") == 1
+    assert message in text
+    assert ("tt.auto_overflow_assert" in text) == has_auto_marker
+    assert "arith.xori" in text
+    assert "arith.ori" in text
+    assert "tensor<8xi1>" in text
 
 
 def test_row_coalescing_lifts_reduce_along_original_row_axis(tmp_path):
@@ -289,16 +329,21 @@ def test_row_coalescing_requires_force_simt_only_and_rule_bit(tmp_path):
     _assert_row_bailout(mask_disabled)
 
 
-def test_row_coalescing_rejects_pid_value_defined_before_work_block(tmp_path):
+def test_row_coalescing_lifts_pure_pid_value_defined_before_work_block(tmp_path):
     text = _run_row(
-        _row_module("row_pid_derived_before_work", 16, pid_derived_outside_work=True),
+        _row_module(
+            "row_pid_derived_before_work",
+            16,
+            pid_derived_outside_work=True,
+            body="user_scalar_assert",
+        ),
         tmp_path,
     )
 
-    _assert_row_bailout(text)
-    # The Python MLIR printer may renumber SSA values, so check the preserved
-    # scalar add structurally rather than relying on its textual value name.
-    assert text.count("arith.addi") >= 2
+    _assert_row_hit(text)
+    assert "user scalar assertion" in text
+    assert "tensor<8xi1>" in text
+    assert "cf.cond_br" not in text
 
 
 def test_row_coalescing_rejects_direct_call_even_outside_work_region(tmp_path):

--- a/third_party/ascend/unittest/pytest_ut/test_row_coalescing_compat.py
+++ b/third_party/ascend/unittest/pytest_ut/test_row_coalescing_compat.py
@@ -97,6 +97,19 @@ def _row_module(
     }}
 """
         store_value = "%out"
+    elif body == "for_with_scalar_assert":
+        post_load = f"""    %for_lb = arith.constant 0 : index
+    %for_step = arith.constant 1 : index
+    %for_ub = arith.constant 2 : index
+    %out = scf.for %i = %for_lb to %for_ub step %for_step iter_args(%acc = %value) -> (tensor<{width}xf32>) {{
+      %scalar_ok = arith.cmpi slt, {pid_in_work}, %count : i32
+      tt.assert %scalar_ok, "loop scalar assertion" : i1
+      %one = arith.constant dense<1.000000e+00> : tensor<{width}xf32>
+      %next = arith.addf %acc, %one : tensor<{width}xf32>
+      scf.yield %next : tensor<{width}xf32>
+    }}
+"""
+        store_value = "%out"
     elif body in ("auto_overflow_assert", "user_tensor_assert"):
         marker = " {tt.auto_overflow_assert}" if body == "auto_overflow_assert" else ""
         message = (
@@ -296,6 +309,19 @@ def test_row_coalescing_clones_scf_for_with_lifted_iter_args(tmp_path):
     assert "iter_args" in text
     assert "-> (tensor<8x16xf32>)" in text
     assert "scf.yield" in text
+
+
+def test_row_coalescing_lifts_scalar_assert_in_scf_for_body(tmp_path):
+    text = _run_row(
+        _row_module("row_for_scalar_assert", 16, body="for_with_scalar_assert"),
+        tmp_path,
+    )
+
+    _assert_row_hit(text)
+    assert "loop scalar assertion" in text
+    assert "tensor<8xi1>" in text
+    assert "arith.xori" in text
+    assert "arith.ori" in text
 
 
 def test_row_coalescing_rejects_non_whitelisted_y_num_programs(tmp_path):


### PR DESCRIPTION
## Summary

Replace the marker-only Row workaround with a semantic `tt.assert` lift:

- accept Row-rebuildable scalar `i1` and ranked `i1` tensor conditions without classifying their source by message or `tt.auto_overflow_assert`;
- rebuild pure PID-derived definitions from the lifted Row PID when they are defined before the work block;
- preserve assertion location, message, attributes, and lexical ordering;
- guard every lifted assertion with `!activeRowMask || liftedCondition`, so ceil-div tail rows cannot create a new device-side failure;
- conservatively reject calls, effects, unsupported regions, and non-rebuildable external PID dependencies.

The detached sandbox + MLIR verification path remains unchanged.  Coverage now includes automatic/user assertions, scalar/tensor conditions, `scf.for` bodies, and a pure entry-block PID dependency.

## 问题表述

在 `TRITON_ALWAYS_COMPILE=1 TRITON_DEBUG=1` 运行 Row E2E 用例时，前端的 `sanitize_overflow` 会物化 `tt.assert`。旧 RowCoalescing 把 assertion 视为不可提升操作，因此 Row 规则不生效，预期的 `row_coalescing_applied=True`、`coalesce_factor=8`、`coalesce_axis=0` 和 `coalesce_grid_ceil_div=True` 均不会生成，最终触发 pytest 断言失败。

问题本质是 Debug 编译路径与 RowCoalescing 的语义兼容性缺失，不是 kernel 发生真实整数溢出，也不是 metadata / launcher 自身错误。通用修复不再依赖自动断言 marker：对所有可按 Row 语义重建的用户或自动 `tt.assert` 统一转换；不能证明等价时保持 Row 保守退出。

## Validation

- isolated wheel build: `triton_ascend-3.6.0.dev0+git3b4f0498-cp311-cp311-linux_x86_64.whl` (`build.status=0`)
- `python -m pytest -q third_party/ascend/unittest/pytest_ut/test_row_coalescing_compat.py` — 19 passed
- all 7 current `graph-optimize-load-store.mlir` `RUN:` lines with the self-built `triton-opt` + `FileCheck`
- `TRITON_ALWAYS_COMPILE=1 TRITON_DEBUG=1 pytest -sv test_layout_memory_91095_native_e2e.py::test_row_91095_native_metadata_launcher_and_ir` — passed on Ascend 950
- corresponding no-debug native Row E2E — passed
