### PR TITLE
[ssbuffer](fix) updateBlockId consider multi-region

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h
@@ -49,6 +49,7 @@ public:
 
   llvm::LogicalResult markOpBlockId(Operation *op);
   llvm::LogicalResult markOpsWithNewId(llvm::ArrayRef<Operation *> ops);
+  void updateBlockIdWithInner(Operation *parentOp, int targetId);
   void updateBlockId(Operation *op, int blockId);
 
   bool shouldInheritFromParent(Block *block, CoreType requiredCoreType) const;

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MoveLoadIntoUserPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MoveLoadIntoUserPass.cpp
@@ -302,7 +302,7 @@ void MoveLoadIntoUserPass::runOnOperation() {
 
     // Update block_id for all ops
     for (auto *op : opsToMove) {
-      bm.updateBlockId(op, targetBlockId);
+      bm.updateBlockIdWithInner(op, targetBlockId);
     }
 
     LOG_DEBUG("Successfully moved ops to block " << targetBlockId);

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
@@ -550,42 +550,6 @@ DenseMap<int, int> UBUsageOptPass::collectRecordChange(
   return recordChange;
 }
 
-static void processOpsInblock(Operation *parentOp, int targetId,
-                              CVPipeline::ComputeBlockIdManager &bm) {
-  // If the parentOp's blockId is the same as every op's id in each of its
-  // blocks, we need to change the ops inside its blocks to targetId as well.
-  int parentBlockId = bm.getBlockIdByOp(parentOp);
-  if (parentBlockId == -1) {
-    return;
-  }
-  // LinalgDialect should have targetId only in prarent, the inner op shouldn't
-  // have blockId.
-  if (isa<linalg::LinalgDialect>(parentOp->getDialect())) {
-    return;
-  }
-
-  bool allSame = true;
-  parentOp->walk([&](Operation *op) {
-    auto innerBlockId = bm.getBlockIdByOp(op);
-    if (innerBlockId != -1 && innerBlockId != parentBlockId) {
-      allSame = false;
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
-
-  if (allSame) {
-    parentOp->walk([&](Operation *op) {
-      // Never fold a sync into a compute block: it must keep its own unique
-      // block id so the fence between before/after ops survives.
-      if (CVPipeline::isSyncOp(op)) {
-        return;
-      }
-      bm.updateBlockId(op, targetId);
-    });
-  }
-}
-
 bool applyRecordChange(DenseMap<int, int> &recordChange,
                        DenseMap<int, Operation *> &nodeId2op,
                        const CVPipeline::MemoryDependenceGraph &memGraph,
@@ -616,8 +580,7 @@ bool applyRecordChange(DenseMap<int, int> &recordChange,
     }
 
     for (auto op : willaddOps) {
-      processOpsInblock(op, targetBlockId, bm);
-      bm.updateBlockId(op, targetBlockId);
+      bm.updateBlockIdWithInner(op, targetBlockId);
     }
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
@@ -32,6 +32,7 @@
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Support/WalkResult.h"
 
 namespace mlir {
 namespace CVPipeline {
@@ -75,6 +76,43 @@ bool ComputeBlockIdManager::isSameBlock(Operation *a, Operation *b) {
 }
 
 int ComputeBlockIdManager::getNextId() { return cntComputeBlockId++; }
+
+void ComputeBlockIdManager::updateBlockIdWithInner(Operation *parentOp,
+                                                   int targetId) {
+  // If the parentOp's blockId is the same as every op's id in each of its
+  // blocks, we need to change the ops inside its blocks to targetId as well.
+  int parentBlockId = getBlockIdByOp(parentOp);
+  if (parentBlockId == -1) {
+    updateBlockId(parentOp, targetId);
+    return;
+  }
+  // LinalgDialect should have targetId only in prarent, the inner op shouldn't
+  // have blockId.
+  if (isa<linalg::LinalgDialect>(parentOp->getDialect())) {
+    updateBlockId(parentOp, targetId);
+    return;
+  }
+
+  auto ret = parentOp->walk([&](Operation *op) {
+    auto innerBlockId = getBlockIdByOp(op);
+    if (innerBlockId != -1 && innerBlockId != parentBlockId) {
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+
+  if (ret != WalkResult::interrupt()) {
+    parentOp->walk([&](Operation *op) {
+      // Never fold a sync into a compute block: it must keep its own unique
+      // block id so the fence between before/after ops survives.
+      if (CVPipeline::isSyncOp(op)) {
+        return;
+      }
+      updateBlockId(op, targetId);
+    });
+  }
+  updateBlockId(parentOp, targetId);
+}
 
 void ComputeBlockIdManager::updateBlockId(Operation *op, int blockId) {
   if (!op) {

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -59,7 +59,7 @@ using namespace mlir;
 static constexpr const char *DEBUG_TYPE = "ReorderOpsByBlockIdPass";
 
 #define DBGS(...) LLVM_DEBUG(llvm::dbgs() << __VA_ARGS__)
-#define LOG_DEBUG(...) DBGS("\n[" << DEBUG_TYPE << "] " << __VA_ARGS__)
+#define LOG_DEBUG(...) DBGS("[" << DEBUG_TYPE << "] " << __VA_ARGS__)
 
 using namespace triton;
 using namespace CVPipeline;


### PR DESCRIPTION

updateBlockId consider multi-region
```
if() {
fill (xxx) {block_id = 1}
} {block_id= 2}

```
this pr avoid the case


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
