### PR TITLE
[ssbuffer](feat) add merge cube block pass

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/BlockDependencyGraph.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/BlockDependencyGraph.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_BLOCK_DEPENDENCY_GRAPH_H
+#define TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_BLOCK_DEPENDENCY_GRAPH_H
+
+#include "mlir/IR/Block.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+namespace CVPipeline {
+
+// Forward declarations
+class MemoryDependenceGraph;
+class ComputeBlockIdManager;
+
+struct BlockNode {
+  int blockId;
+  llvm::SmallVector<Operation *> ops;
+  bool isCube;
+  int depth;
+};
+
+class BlockDependencyGraph {
+public:
+  BlockDependencyGraph(Block *block, const MemoryDependenceGraph &memGraph,
+                       ComputeBlockIdManager &bm);
+
+  // Build block-level dependency graph (only includes dependencies within
+  // current MLIR Block)
+  llvm::LogicalResult buildGraph();
+
+  BlockNode *getBlockNode(int blockId);
+  llvm::SmallVector<int> getPredecessors(int blockId);
+  llvm::SmallVector<int> getSuccessors(int blockId);
+
+  // computeDepth
+  void computeDepths();
+  int getDepth(int blockId);
+
+  // detect cycle
+  bool wouldCreateCycle(int blockId1, int blockId2);
+
+  // rebuildgraph
+  void rebuildAfterMerge(int targetBlockId, int sourceBlockId);
+
+  llvm::DenseMap<int, BlockNode> blockNodes;
+
+private:
+  Block *block;
+  const MemoryDependenceGraph &memGraph;
+  ComputeBlockIdManager &bm;
+
+  llvm::DenseMap<int, llvm::SmallVector<int>> predecessors;
+  llvm::DenseMap<int, llvm::SmallVector<int>> successors;
+
+  void addEdge(int from, int to);
+
+  bool isInCurrentBlock(Operation *op);
+};
+
+} // namespace CVPipeline
+} // namespace mlir
+
+#endif // TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_BLOCK_DEPENDENCY_GRAPH_H

--- a/third_party/ascend/include/DynamicCVPipeline/Common/BlockDependencyGraph.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/BlockDependencyGraph.h
@@ -29,6 +29,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include <memory>
 
 namespace mlir {
 namespace CVPipeline {
@@ -42,6 +43,14 @@ struct BlockNode {
   llvm::SmallVector<Operation *> ops;
   bool isCube;
   int depth;
+
+  // Neighbour sets are stored directly on the node so that traversal and
+  // edge rewiring can avoid the extra hash lookup a separate map would
+  // require. Because each BlockNode is heap-allocated behind a unique_ptr,
+  // pointers stored here stay stable across insertions/erases in
+  // `BlockDependencyGraph::blockNodes`.
+  llvm::DenseSet<BlockNode *> predecessors;
+  llvm::DenseSet<BlockNode *> successors;
 };
 
 class BlockDependencyGraph {
@@ -54,32 +63,35 @@ public:
   llvm::LogicalResult buildGraph();
 
   BlockNode *getBlockNode(int blockId);
-  llvm::SmallVector<int> getPredecessors(int blockId);
-  llvm::SmallVector<int> getSuccessors(int blockId);
+  llvm::SmallVector<BlockNode *> getPredecessors(BlockNode *node);
+  llvm::SmallVector<BlockNode *> getSuccessors(BlockNode *node);
 
   // computeDepth
   void computeDepths();
   int getDepth(int blockId);
 
-  // detect cycle
-  bool wouldCreateCycle(int blockId1, int blockId2);
-
   // rebuildgraph
-  void rebuildAfterMerge(int targetBlockId, int sourceBlockId);
+  llvm::LogicalResult rebuildAfterMerge(BlockNode *target, BlockNode *source);
 
-  llvm::DenseMap<int, BlockNode> blockNodes;
+  // BlockNode objects are owned by unique_ptr so that the address of a
+  // BlockNode is stable across insertions/erases in the DenseMap. The
+  // pointers stored in each BlockNode's predecessor/successor sets
+  // therefore remain valid for the lifetime of the graph.
+  llvm::DenseMap<int, std::unique_ptr<BlockNode>> blockNodes;
 
 private:
   Block *block;
   const MemoryDependenceGraph &memGraph;
   ComputeBlockIdManager &bm;
 
-  llvm::DenseMap<int, llvm::SmallVector<int>> predecessors;
-  llvm::DenseMap<int, llvm::SmallVector<int>> successors;
-
-  void addEdge(int from, int to);
+  void addEdge(BlockNode *from, BlockNode *to);
 
   bool isInCurrentBlock(Operation *op);
+
+  // Recompute depths starting from `start` and propagating forward through
+  // its successor chain. Assumes predecessors of `start` already hold
+  // correct depths.
+  void recomputeDepthsFrom(BlockNode *start);
 };
 
 } // namespace CVPipeline

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_MERGE_CUBE_BLOCK_PASS_H
+#define TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_MERGE_CUBE_BLOCK_PASS_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+namespace CVPipeline {
+
+class BlockDependencyGraph;
+class MemoryDependenceGraph;
+class ComputeBlockIdManager;
+
+class MergeCubeBlockPass
+    : public PassWrapper<MergeCubeBlockPass, OperationPass<ModuleOp>> {
+public:
+  MergeCubeBlockPass() = default;
+
+  StringRef getArgument() const override { return "merge-cube-block"; }
+  StringRef getDescription() const override {
+    return "Merge cube blocks with same loaded data";
+  }
+
+  void runOnOperation() override;
+
+private:
+  void findInnermostLoopBlocksWithMatmul(
+      ModuleOp moduleOp, llvm::SmallVectorImpl<Block *> &innermostBlocks);
+
+  llvm::LogicalResult processBlock(Block *block,
+                                   const MemoryDependenceGraph &memGraph,
+                                   ComputeBlockIdManager &bm);
+
+  // Collect loaded data for each block
+  llvm::LogicalResult collectLoadedValues(
+      BlockDependencyGraph &graph, ComputeBlockIdManager &bm,
+      llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
+
+  // Find merge candidates (only for cube blocks)
+  llvm::LogicalResult findMergeCandidates(
+      BlockDependencyGraph &graph,
+      llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues,
+      llvm::SmallVectorImpl<std::pair<int, int>> &candidates);
+
+  bool
+  canMergeBlocks(int blockId1, int blockId2, BlockDependencyGraph &graph,
+                 const MemoryDependenceGraph &memGraph,
+                 ComputeBlockIdManager &bm,
+                 llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
+
+  // Execute merge
+  llvm::LogicalResult mergeBlocks(int targetBlockId, int sourceBlockId,
+                                  ComputeBlockIdManager &bm);
+
+  // Update loadedValues
+  llvm::LogicalResult updateLoadedValues(
+      int targetBlockId, int sourceBlockId,
+      llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
+
+  // Perform iterative merging
+  llvm::LogicalResult
+  performMerging(BlockDependencyGraph &graph,
+                 const MemoryDependenceGraph &memGraph,
+                 ComputeBlockIdManager &bm,
+                 llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues,
+                 llvm::SmallVectorImpl<std::pair<int, int>> &candidates);
+
+  // Print graph structure
+  void
+  printGraph(BlockDependencyGraph &graph,
+             llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
+
+  bool hasCommonInputOrOutput(int blockId1, int blockId2,
+                              BlockDependencyGraph &graph);
+  bool checkSameSourceAndSink(int blockId1, int blockId2,
+                              BlockDependencyGraph &graph);
+  bool checkNoCycle(int blockId1, int blockId2, BlockDependencyGraph &graph,
+                    const MemoryDependenceGraph &memGraph,
+                    ComputeBlockIdManager &bm);
+  bool checkSameLoadedData(
+      int blockId1, int blockId2,
+      llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
+
+  llvm::SmallVector<int> filterBlocksByType(int blockId,
+                                            llvm::SmallVector<int> blocks,
+                                            BlockDependencyGraph &graph);
+};
+
+} // namespace CVPipeline
+} // namespace mlir
+
+namespace mlir {
+namespace triton {
+std::unique_ptr<OperationPass<ModuleOp>> createMergeCubeBlockPass();
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_MERGE_CUBE_BLOCK_PASS_H

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h
@@ -99,6 +99,7 @@ private:
                               BlockDependencyGraph &graph);
   bool checkSameSourceAndSink(int blockId1, int blockId2,
                               BlockDependencyGraph &graph);
+  bool hasSameDepth(int blockId1, int blockId2, BlockDependencyGraph &graph);
   bool checkNoCycle(int blockId1, int blockId2, BlockDependencyGraph &graph,
                     const MemoryDependenceGraph &memGraph,
                     ComputeBlockIdManager &bm);

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h
@@ -23,6 +23,9 @@
 #ifndef TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_MERGE_CUBE_BLOCK_PASS_H
 #define TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_MERGE_CUBE_BLOCK_PASS_H
 
+#include "DynamicCVPipeline/Common/BlockDependencyGraph.h"
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/DenseMap.h"
@@ -31,10 +34,6 @@
 
 namespace mlir {
 namespace CVPipeline {
-
-class BlockDependencyGraph;
-class MemoryDependenceGraph;
-class ComputeBlockIdManager;
 
 class MergeCubeBlockPass
     : public PassWrapper<MergeCubeBlockPass, OperationPass<ModuleOp>> {
@@ -49,67 +48,42 @@ public:
   void runOnOperation() override;
 
 private:
-  void findInnermostLoopBlocksWithMatmul(
-      ModuleOp moduleOp, llvm::SmallVectorImpl<Block *> &innermostBlocks);
-
   llvm::LogicalResult processBlock(Block *block,
                                    const MemoryDependenceGraph &memGraph,
                                    ComputeBlockIdManager &bm);
 
-  // Collect loaded data for each block
-  llvm::LogicalResult collectLoadedValues(
-      BlockDependencyGraph &graph, ComputeBlockIdManager &bm,
-      llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
-
-  // Find merge candidates (only for cube blocks)
-  llvm::LogicalResult findMergeCandidates(
-      BlockDependencyGraph &graph,
-      llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues,
-      llvm::SmallVectorImpl<std::pair<int, int>> &candidates);
-
-  bool
-  canMergeBlocks(int blockId1, int blockId2, BlockDependencyGraph &graph,
-                 const MemoryDependenceGraph &memGraph,
-                 ComputeBlockIdManager &bm,
-                 llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
+  bool canMergeBlocks(BlockNode *target, BlockNode *source,
+                      BlockDependencyGraph &graph,
+                      const MemoryDependenceGraph &memGraph,
+                      ComputeBlockIdManager &bm);
 
   // Execute merge
-  llvm::LogicalResult mergeBlocks(int targetBlockId, int sourceBlockId,
+  llvm::LogicalResult mergeBlocks(BlockNode *target, BlockNode *source,
                                   ComputeBlockIdManager &bm);
 
-  // Update loadedValues
-  llvm::LogicalResult updateLoadedValues(
-      int targetBlockId, int sourceBlockId,
-      llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
-
-  // Perform iterative merging
-  llvm::LogicalResult
-  performMerging(BlockDependencyGraph &graph,
-                 const MemoryDependenceGraph &memGraph,
-                 ComputeBlockIdManager &bm,
-                 llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues,
-                 llvm::SmallVectorImpl<std::pair<int, int>> &candidates);
+  // Perform iterative merging by repeatedly scanning the live cube blocks.
+  llvm::LogicalResult performMerging(BlockDependencyGraph &graph,
+                                     const MemoryDependenceGraph &memGraph,
+                                     ComputeBlockIdManager &bm);
 
   // Print graph structure
-  void
-  printGraph(BlockDependencyGraph &graph,
-             llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
+  void printGraph(BlockDependencyGraph &graph);
 
-  bool hasCommonInputOrOutput(int blockId1, int blockId2,
+  bool hasCommonInputOrOutput(BlockNode *node1, BlockNode *node2,
                               BlockDependencyGraph &graph);
-  bool checkSameSourceAndSink(int blockId1, int blockId2,
-                              BlockDependencyGraph &graph);
-  bool hasSameDepth(int blockId1, int blockId2, BlockDependencyGraph &graph);
-  bool checkNoCycle(int blockId1, int blockId2, BlockDependencyGraph &graph,
+  bool hasSameDepth(BlockNode *node1, BlockNode *node2,
+                    BlockDependencyGraph &graph);
+  bool checkNoCycle(BlockNode *node1, BlockNode *node2,
+                    BlockDependencyGraph &graph,
                     const MemoryDependenceGraph &memGraph,
                     ComputeBlockIdManager &bm);
-  bool checkSameLoadedData(
-      int blockId1, int blockId2,
-      llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues);
 
-  llvm::SmallVector<int> filterBlocksByType(int blockId,
-                                            llvm::SmallVector<int> blocks,
-                                            BlockDependencyGraph &graph);
+  // Return the subset of `blocks` whose type (cube/vector) differs from
+  // `currentNode`'s. Returned as a DenseSet so callers can do O(N) set
+  // intersection directly.
+  llvm::DenseSet<BlockNode *>
+  getBlocksOfDifferentType(BlockNode *currentNode,
+                           llvm::ArrayRef<BlockNode *> blocks);
 };
 
 } // namespace CVPipeline

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -162,6 +162,8 @@ private:
                                                   int iniConsumerId);
   mlir::Operation *getConsumerWaitPoint(int transferIndex);
   mlir::Operation *getCopyPointBeforeStore(DependencyInfo &dep, Value value);
+  mlir::Operation *getFixpipePointAfterProducer(Value depValue,
+                                                int iniProducerBlockId);
   mlir::Operation *
   insertVectorToCubeTransfer(mlir::OpBuilder &builder,
                              mlir::Value normalizedValue, DependencyInfo &dep,

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/BlockDependencyGraph.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/BlockDependencyGraph.cpp
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/BlockDependencyGraph.h"
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "llvm/Support/Debug.h"
+#include <queue>
+
+using namespace mlir;
+using namespace CVPipeline;
+
+static constexpr const char *DEBUG_TYPE = "block-dependency-graph";
+#define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+#define LDBG(...) LLVM_DEBUG(DBGS() << __VA_ARGS__ << "\n")
+
+static bool isCubeOp(Operation *op) {
+  if (!op)
+    return false;
+  auto coreTypeAttr = op->getAttrOfType<StringAttr>(CVPipeline::kCoreType);
+  if (!coreTypeAttr)
+    return false;
+
+  return coreTypeAttr.getValue() == "CUBE";
+}
+
+BlockDependencyGraph::BlockDependencyGraph(
+    Block *block, const MemoryDependenceGraph &memGraph,
+    ComputeBlockIdManager &bm)
+    : block(block), memGraph(memGraph), bm(bm) {}
+
+llvm::LogicalResult BlockDependencyGraph::buildGraph() {
+  // Step 1: Collect all compute blocks (including cube and vector) in current
+  // MLIR Block
+  block->walk([&](Operation *op) {
+    int blockId = bm.getBlockIdByOp(op);
+    if (blockId == -1)
+      return;
+
+    // Only process operations in current MLIR Block
+    if (op->getBlock() != block)
+      return;
+
+    if (!blockNodes.count(blockId)) {
+      BlockNode node;
+      node.blockId = blockId;
+      node.isCube = isCubeOp(op);
+      node.depth = 0;
+      blockNodes[blockId] = node;
+    }
+
+    blockNodes[blockId].ops.push_back(op);
+  });
+
+  LDBG("Collected " << blockNodes.size() << " blocks");
+
+  // Step 2: Build dependency relationships between blocks (only in current MLIR
+  // Block)
+  for (auto &entry : blockNodes) {
+    int blockId = entry.first;
+    auto &node = entry.second;
+
+    for (Operation *op : node.ops) {
+      // Process SSA data flow dependencies
+      for (Value operand : op->getOperands()) {
+        if (Operation *def = operand.getDefiningOp()) {
+          // Key: Check if def is in current MLIR Block
+          if (!isInCurrentBlock(def))
+            continue;
+
+          int defBlockId = bm.getBlockIdByOp(def);
+          if (defBlockId != -1 && defBlockId != blockId) {
+            addEdge(defBlockId, blockId);
+          }
+        }
+      }
+
+      // Process memory dependencies
+      for (Operation *memDef : memGraph.getMemDefs(op)) {
+        // Key: Check if memDef is in current MLIR Block
+        if (!isInCurrentBlock(memDef))
+          continue;
+
+        int defBlockId = bm.getBlockIdByOp(memDef);
+        if (defBlockId != -1 && defBlockId != blockId) {
+          addEdge(defBlockId, blockId);
+        }
+      }
+    }
+  }
+
+  // Step 3: Compute depths (for all blocks)
+  computeDepths();
+
+  return llvm::success();
+}
+
+bool BlockDependencyGraph::isInCurrentBlock(Operation *op) {
+  if (!op)
+    return false;
+
+  // Get the MLIR Block where op is located
+  Block *opBlock = op->getBlock();
+
+  // Check if it's in current MLIR Block
+  return opBlock == block;
+}
+
+void BlockDependencyGraph::addEdge(int from, int to) {
+  // Avoid duplicate additions
+  if (!llvm::is_contained(predecessors[to], from)) {
+    predecessors[to].push_back(from);
+  }
+  if (!llvm::is_contained(successors[from], to)) {
+    successors[from].push_back(to);
+  }
+}
+
+void BlockDependencyGraph::computeDepths() {
+  // Use topological sort to compute depth for each node
+  // Depth definition: maximum steps from nodes with zero in-degree
+  // Special rule: depth only increases when cube and vector type conversion
+  // occurs
+
+  llvm::DenseMap<int, int> indegree;
+  std::queue<int> queue;
+
+  // Initialize in-degree
+  for (auto &entry : blockNodes) {
+    indegree[entry.first] = predecessors[entry.first].size();
+    if (indegree[entry.first] == 0) {
+      queue.push(entry.first);
+      blockNodes[entry.first].depth = 0;
+    }
+  }
+
+  // BFS to compute depths
+  while (!queue.empty()) {
+    int current = queue.front();
+    queue.pop();
+
+    for (int succ : successors[current]) {
+      // Compute depth from current to succ
+      // If types are different (cube->vector or vector->cube), depth+1
+      // If types are the same, depth remains unchanged
+      int newDepth = blockNodes[current].depth;
+      if (blockNodes[current].isCube != blockNodes[succ].isCube) {
+        newDepth++;
+      }
+
+      // Update successor's depth (take maximum)
+      blockNodes[succ].depth = std::max(blockNodes[succ].depth, newDepth);
+
+      indegree[succ]--;
+      if (indegree[succ] == 0) {
+        queue.push(succ);
+      }
+    }
+  }
+
+  LDBG("Computed depths for all blocks");
+}
+
+int BlockDependencyGraph::getDepth(int blockId) {
+  auto it = blockNodes.find(blockId);
+  if (it != blockNodes.end()) {
+    return it->second.depth;
+  }
+  return -1;
+}
+
+BlockNode *BlockDependencyGraph::getBlockNode(int blockId) {
+  auto it = blockNodes.find(blockId);
+  if (it != blockNodes.end()) {
+    return &it->second;
+  }
+  return nullptr;
+}
+
+llvm::SmallVector<int> BlockDependencyGraph::getPredecessors(int blockId) {
+  auto it = predecessors.find(blockId);
+  if (it != predecessors.end()) {
+    return it->second;
+  }
+  return {};
+}
+
+llvm::SmallVector<int> BlockDependencyGraph::getSuccessors(int blockId) {
+  auto it = successors.find(blockId);
+  if (it != successors.end()) {
+    return it->second;
+  }
+  return {};
+}
+
+bool BlockDependencyGraph::wouldCreateCycle(int blockId1, int blockId2) {
+  // Use DFS to check reachability
+  llvm::DenseSet<int> visited;
+
+  std::function<bool(int, int)> hasPath = [&](int from, int to) -> bool {
+    if (from == to)
+      return true;
+    if (visited.count(from))
+      return false;
+    visited.insert(from);
+
+    for (int succ : successors[from]) {
+      if (hasPath(succ, to))
+        return true;
+    }
+    return false;
+  };
+
+  // If there are bidirectional paths, merging would create a cycle
+  bool path1to2 = hasPath(blockId1, blockId2);
+  visited.clear();
+  bool path2to1 = hasPath(blockId2, blockId1);
+
+  return path1to2 && path2to1;
+}
+
+void BlockDependencyGraph::rebuildAfterMerge(int targetBlockId,
+                                             int sourceBlockId) {
+  // Merge node information of two blocks
+  auto sourceIt = blockNodes.find(sourceBlockId);
+  if (sourceIt != blockNodes.end()) {
+    auto &targetNode = blockNodes[targetBlockId];
+    auto &sourceNode = sourceIt->second;
+
+    // Merge ops
+    targetNode.ops.append(sourceNode.ops.begin(), sourceNode.ops.end());
+
+    // Delete source node
+    blockNodes.erase(sourceIt);
+  }
+
+  // Merge predecessors and successors
+  auto sourcePredIt = predecessors.find(sourceBlockId);
+  if (sourcePredIt != predecessors.end()) {
+    for (int pred : sourcePredIt->second) {
+      if (!llvm::is_contained(predecessors[targetBlockId], pred)) {
+        predecessors[targetBlockId].push_back(pred);
+      }
+      // Update successors
+      auto &predSuccs = successors[pred];
+      predSuccs.erase(llvm::find(predSuccs, sourceBlockId));
+      if (!llvm::is_contained(predSuccs, targetBlockId)) {
+        predSuccs.push_back(targetBlockId);
+      }
+    }
+    predecessors.erase(sourcePredIt);
+  }
+
+  auto sourceSuccIt = successors.find(sourceBlockId);
+  if (sourceSuccIt != successors.end()) {
+    for (int succ : sourceSuccIt->second) {
+      if (!llvm::is_contained(successors[targetBlockId], succ)) {
+        successors[targetBlockId].push_back(succ);
+      }
+      // Update predecessors
+      auto &succPreds = predecessors[succ];
+      succPreds.erase(llvm::find(succPreds, sourceBlockId));
+      if (!llvm::is_contained(succPreds, targetBlockId)) {
+        succPreds.push_back(targetBlockId);
+      }
+    }
+    successors.erase(sourceSuccIt);
+  }
+
+  // Recompute depths
+  computeDepths();
+
+  LDBG("Rebuilt graph after merging block " << sourceBlockId << " into "
+                                            << targetBlockId);
+}

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/BlockDependencyGraph.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/BlockDependencyGraph.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "DynamicCVPipeline/Common/BlockDependencyGraph.h"
+#include "DynamicCVPipeline/Common/DependencyHelper.h"
 #include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 #include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
@@ -34,14 +35,8 @@ static constexpr const char *DEBUG_TYPE = "block-dependency-graph";
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 #define LDBG(...) LLVM_DEBUG(DBGS() << __VA_ARGS__ << "\n")
 
-static bool isCubeOp(Operation *op) {
-  if (!op)
-    return false;
-  auto coreTypeAttr = op->getAttrOfType<StringAttr>(CVPipeline::kCoreType);
-  if (!coreTypeAttr)
-    return false;
-
-  return coreTypeAttr.getValue() == "CUBE";
+static bool isCubeSimpleOpOrCf(Operation *op) {
+  return !isSyncOp(op) && getCoreTypeOfSimpleOpOrCf(op) == CoreType::CUBE_ONLY;
 }
 
 BlockDependencyGraph::BlockDependencyGraph(
@@ -52,60 +47,46 @@ BlockDependencyGraph::BlockDependencyGraph(
 llvm::LogicalResult BlockDependencyGraph::buildGraph() {
   // Step 1: Collect all compute blocks (including cube and vector) in current
   // MLIR Block
-  block->walk([&](Operation *op) {
-    int blockId = bm.getBlockIdByOp(op);
+  for (Operation &op : *block) {
+    int blockId = bm.getBlockIdByOp(&op);
     if (blockId == -1)
-      return;
+      continue;
 
-    // Only process operations in current MLIR Block
-    if (op->getBlock() != block)
-      return;
-
-    if (!blockNodes.count(blockId)) {
-      BlockNode node;
-      node.blockId = blockId;
-      node.isCube = isCubeOp(op);
-      node.depth = 0;
-      blockNodes[blockId] = node;
+    if (!blockNodes.contains(blockId)) {
+      auto node = std::make_unique<BlockNode>();
+      node->blockId = blockId;
+      node->isCube = isCubeSimpleOpOrCf(&op);
+      node->depth = 0;
+      blockNodes[blockId] = std::move(node);
     }
 
-    blockNodes[blockId].ops.push_back(op);
-  });
+    blockNodes[blockId]->ops.push_back(&op);
+  }
 
   LDBG("Collected " << blockNodes.size() << " blocks");
 
   // Step 2: Build dependency relationships between blocks (only in current MLIR
   // Block)
+  DependencyHelper depHelper(memGraph);
   for (auto &entry : blockNodes) {
-    int blockId = entry.first;
-    auto &node = entry.second;
+    BlockNode *consumerNode = entry.second.get();
 
-    for (Operation *op : node.ops) {
-      // Process SSA data flow dependencies
-      for (Value operand : op->getOperands()) {
-        if (Operation *def = operand.getDefiningOp()) {
-          // Key: Check if def is in current MLIR Block
-          if (!isInCurrentBlock(def))
-            continue;
+    for (Operation *op : consumerNode->ops) {
+      // Use DependencyHelper to iterate all source ops (SSA defs + memory
+      // exec-before) in one pass.
+      depHelper.forEachSource<DependencyHelper::SourceMode::Default>(
+          op, [&](Operation *source) {
+            if (!isInCurrentBlock(source))
+              return;
 
-          int defBlockId = bm.getBlockIdByOp(def);
-          if (defBlockId != -1 && defBlockId != blockId) {
-            addEdge(defBlockId, blockId);
-          }
-        }
-      }
+            int sourceBlockId = bm.getBlockIdByOp(source);
+            if (sourceBlockId == -1 || sourceBlockId == consumerNode->blockId)
+              return;
 
-      // Process memory dependencies
-      for (Operation *memDef : memGraph.getMemDefs(op)) {
-        // Key: Check if memDef is in current MLIR Block
-        if (!isInCurrentBlock(memDef))
-          continue;
-
-        int defBlockId = bm.getBlockIdByOp(memDef);
-        if (defBlockId != -1 && defBlockId != blockId) {
-          addEdge(defBlockId, blockId);
-        }
-      }
+            BlockNode *producerNode = getBlockNode(sourceBlockId);
+            if (producerNode)
+              addEdge(producerNode, consumerNode);
+          });
     }
   }
 
@@ -126,14 +107,9 @@ bool BlockDependencyGraph::isInCurrentBlock(Operation *op) {
   return opBlock == block;
 }
 
-void BlockDependencyGraph::addEdge(int from, int to) {
-  // Avoid duplicate additions
-  if (!llvm::is_contained(predecessors[to], from)) {
-    predecessors[to].push_back(from);
-  }
-  if (!llvm::is_contained(successors[from], to)) {
-    successors[from].push_back(to);
-  }
+void BlockDependencyGraph::addEdge(BlockNode *from, BlockNode *to) {
+  to->predecessors.insert(from);
+  from->successors.insert(to);
 }
 
 void BlockDependencyGraph::computeDepths() {
@@ -142,34 +118,35 @@ void BlockDependencyGraph::computeDepths() {
   // Special rule: depth only increases when cube and vector type conversion
   // occurs
 
-  llvm::DenseMap<int, int> indegree;
-  std::queue<int> queue;
+  llvm::DenseMap<BlockNode *, int> indegree;
+  std::queue<BlockNode *> queue;
 
-  // Initialize in-degree
+  // Initialize in-degree directly from each node's predecessor set.
   for (auto &entry : blockNodes) {
-    indegree[entry.first] = predecessors[entry.first].size();
-    if (indegree[entry.first] == 0) {
-      queue.push(entry.first);
-      blockNodes[entry.first].depth = 0;
+    BlockNode *node = entry.second.get();
+    indegree[node] = node->predecessors.size();
+    if (indegree[node] == 0) {
+      queue.push(node);
+      node->depth = 0;
     }
   }
 
   // BFS to compute depths
   while (!queue.empty()) {
-    int current = queue.front();
+    BlockNode *current = queue.front();
     queue.pop();
 
-    for (int succ : successors[current]) {
+    for (BlockNode *succ : current->successors) {
       // Compute depth from current to succ
       // If types are different (cube->vector or vector->cube), depth+1
       // If types are the same, depth remains unchanged
-      int newDepth = blockNodes[current].depth;
-      if (blockNodes[current].isCube != blockNodes[succ].isCube) {
+      int newDepth = current->depth;
+      if (current->isCube != succ->isCube) {
         newDepth++;
       }
 
       // Update successor's depth (take maximum)
-      blockNodes[succ].depth = std::max(blockNodes[succ].depth, newDepth);
+      succ->depth = std::max(succ->depth, newDepth);
 
       indegree[succ]--;
       if (indegree[succ] == 0) {
@@ -184,7 +161,7 @@ void BlockDependencyGraph::computeDepths() {
 int BlockDependencyGraph::getDepth(int blockId) {
   auto it = blockNodes.find(blockId);
   if (it != blockNodes.end()) {
-    return it->second.depth;
+    return it->second->depth;
   }
   return -1;
 }
@@ -192,104 +169,102 @@ int BlockDependencyGraph::getDepth(int blockId) {
 BlockNode *BlockDependencyGraph::getBlockNode(int blockId) {
   auto it = blockNodes.find(blockId);
   if (it != blockNodes.end()) {
-    return &it->second;
+    return it->second.get();
   }
   return nullptr;
 }
 
-llvm::SmallVector<int> BlockDependencyGraph::getPredecessors(int blockId) {
-  auto it = predecessors.find(blockId);
-  if (it != predecessors.end()) {
-    return it->second;
-  }
-  return {};
+llvm::SmallVector<BlockNode *>
+BlockDependencyGraph::getPredecessors(BlockNode *node) {
+  if (!node)
+    return {};
+  return llvm::SmallVector<BlockNode *>(node->predecessors.begin(),
+                                        node->predecessors.end());
 }
 
-llvm::SmallVector<int> BlockDependencyGraph::getSuccessors(int blockId) {
-  auto it = successors.find(blockId);
-  if (it != successors.end()) {
-    return it->second;
-  }
-  return {};
+llvm::SmallVector<BlockNode *>
+BlockDependencyGraph::getSuccessors(BlockNode *node) {
+  if (!node)
+    return {};
+  return llvm::SmallVector<BlockNode *>(node->successors.begin(),
+                                        node->successors.end());
 }
 
-bool BlockDependencyGraph::wouldCreateCycle(int blockId1, int blockId2) {
-  // Use DFS to check reachability
-  llvm::DenseSet<int> visited;
+void BlockDependencyGraph::recomputeDepthsFrom(BlockNode *start) {
+  // Walk forward through the successor chain starting at `start`. For each
+  // visited node, the new depth is propagated to its successors; a successor
+  // is enqueued again only when its depth actually grows. Since depth is
+  // monotonically non-decreasing, this terminates.
+  std::queue<BlockNode *> queue;
+  queue.push(start);
+  while (!queue.empty()) {
+    BlockNode *current = queue.front();
+    queue.pop();
 
-  std::function<bool(int, int)> hasPath = [&](int from, int to) -> bool {
-    if (from == to)
-      return true;
-    if (visited.count(from))
-      return false;
-    visited.insert(from);
-
-    for (int succ : successors[from]) {
-      if (hasPath(succ, to))
-        return true;
+    for (BlockNode *succ : current->successors) {
+      int newDepth = current->depth;
+      if (current->isCube != succ->isCube)
+        newDepth++;
+      if (succ->depth < newDepth) {
+        succ->depth = newDepth;
+        queue.push(succ);
+      }
     }
-    return false;
-  };
+  }
 
-  // If there are bidirectional paths, merging would create a cycle
-  bool path1to2 = hasPath(blockId1, blockId2);
-  visited.clear();
-  bool path2to1 = hasPath(blockId2, blockId1);
-
-  return path1to2 && path2to1;
+  LDBG("Recomputed depths from block " << start->blockId);
 }
 
-void BlockDependencyGraph::rebuildAfterMerge(int targetBlockId,
-                                             int sourceBlockId) {
-  // Merge node information of two blocks
-  auto sourceIt = blockNodes.find(sourceBlockId);
-  if (sourceIt != blockNodes.end()) {
-    auto &targetNode = blockNodes[targetBlockId];
-    auto &sourceNode = sourceIt->second;
+llvm::LogicalResult BlockDependencyGraph::rebuildAfterMerge(BlockNode *target,
+                                                            BlockNode *source) {
+  // Merge node information: append source ops into target.
+  target->ops.append(source->ops.begin(), source->ops.end());
 
-    // Merge ops
-    targetNode.ops.append(sourceNode.ops.begin(), sourceNode.ops.end());
-
-    // Delete source node
-    blockNodes.erase(sourceIt);
+  // Sanity check: source must be connected to the graph (either has at
+  // least one predecessor or one successor). Merging an isolated node is
+  // meaningless and indicates an unsupported scenario.
+  if (source->predecessors.empty() && source->successors.empty()) {
+    LDBG("Cannot merge block " << source->blockId
+                               << ": no predecessors or successors\n");
+    return llvm::failure();
   }
 
-  // Merge predecessors and successors
-  auto sourcePredIt = predecessors.find(sourceBlockId);
-  if (sourcePredIt != predecessors.end()) {
-    for (int pred : sourcePredIt->second) {
-      if (!llvm::is_contained(predecessors[targetBlockId], pred)) {
-        predecessors[targetBlockId].push_back(pred);
-      }
-      // Update successors
-      auto &predSuccs = successors[pred];
-      predSuccs.erase(llvm::find(predSuccs, sourceBlockId));
-      if (!llvm::is_contained(predSuccs, targetBlockId)) {
-        predSuccs.push_back(targetBlockId);
-      }
-    }
-    predecessors.erase(sourcePredIt);
+  // Re-direct every edge touching source so that it points to target.
+  // DenseSet::insert de-duplicates, so any edge target already owns from
+  // before the merge is preserved naturally.
+  //
+  // Note: the iteration loops read `source->predecessors` / `source->
+  // successors` while we mutate them in place. To avoid invalidating the
+  // current iterator we drain them into temporary vectors first. Using
+  // range insert on the destination keeps this O(N) overall.
+  llvm::SmallVector<BlockNode *> sourcePreds(source->predecessors.begin(),
+                                             source->predecessors.end());
+  llvm::SmallVector<BlockNode *> sourceSuccs(source->successors.begin(),
+                                             source->successors.end());
+
+  for (BlockNode *pred : sourcePreds) {
+    pred->successors.erase(source);
+    pred->successors.insert(target);
   }
+  target->predecessors.insert(sourcePreds.begin(), sourcePreds.end());
 
-  auto sourceSuccIt = successors.find(sourceBlockId);
-  if (sourceSuccIt != successors.end()) {
-    for (int succ : sourceSuccIt->second) {
-      if (!llvm::is_contained(successors[targetBlockId], succ)) {
-        successors[targetBlockId].push_back(succ);
-      }
-      // Update predecessors
-      auto &succPreds = predecessors[succ];
-      succPreds.erase(llvm::find(succPreds, sourceBlockId));
-      if (!llvm::is_contained(succPreds, targetBlockId)) {
-        succPreds.push_back(targetBlockId);
-      }
-    }
-    successors.erase(sourceSuccIt);
+  for (BlockNode *succ : sourceSuccs) {
+    succ->predecessors.erase(source);
+    succ->predecessors.insert(target);
   }
+  target->successors.insert(sourceSuccs.begin(), sourceSuccs.end());
 
-  // Recompute depths
-  computeDepths();
+  // Drop the source node from blockNodes. The BlockNode object itself is
+  // destroyed here (unique_ptr is reset); only `source`'s local pointer
+  // value is invalidated, which we are done using.
+  int sourceId = source->blockId;
+  blockNodes.erase(source->blockId);
 
-  LDBG("Rebuilt graph after merging block " << sourceBlockId << " into "
-                                            << targetBlockId);
+  // Only the successor chain reachable from target is affected by the
+  // merge; recompute depth locally rather than walking the entire graph.
+  recomputeDepthsFrom(target);
+
+  LDBG("Rebuilt graph after merging block " << sourceId << " into "
+                                            << target->blockId);
+  return llvm::success();
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
@@ -305,21 +305,28 @@ bool MergeCubeBlockPass::canMergeBlocks(
   }
 
   // Step 2: Check if they have same source and sink with no other nodes
-  if (!checkSameSourceAndSink(blockId1, blockId2, graph)) {
+  if (checkSameSourceAndSink(blockId1, blockId2, graph)) {
     LDBG("Blocks " << blockId1 << " and " << blockId2
-                   << " cannot merge: different source or sink\n");
-    return false;
-  }
-
-  // Step 3: Check if merging would create a cycle
-  if (checkNoCycle(blockId1, blockId2, graph, memGraph, bm)) {
-    LDBG("Blocks " << blockId1 << " and " << blockId2
-                   << " can merge: no cycle detected\n");
+                   << " can merge: same source or sink\n");
     return true;
   }
 
+  // Step 3: Check if merging would create a cycle
+  if (!checkNoCycle(blockId1, blockId2, graph, memGraph, bm)) {
+    LDBG("Blocks " << blockId1 << " and " << blockId2
+                   << "cannot merge: would create cycle\n");
+    return false;
+  }
+
+  // Step 4: cube block in the same depth
+  if (hasSameDepth(blockId1, blockId2, graph)) {
+    LDBG("Blocks " << blockId1 << " and " << blockId2
+                    << " can merge: cube blocks have same depth\n");
+    return true;
+    }
+
   LDBG("Blocks " << blockId1 << " and " << blockId2
-                 << " cannot merge: would create cycle\n");
+                 << " cannot merge: unsupport scenario\n");
   return false;
 }
 
@@ -368,6 +375,44 @@ bool MergeCubeBlockPass::checkSameSourceAndSink(int blockId1, int blockId2,
   }
 
   return true;
+}
+
+bool MergeCubeBlockPass::hasSameDepth(int blockId1, int blockId2,
+                                      BlockDependencyGraph &graph) {
+
+  // Get block nodes
+  BlockNode *node1 = graph.getBlockNode(blockId1);
+  BlockNode *node2 = graph.getBlockNode(blockId2);
+
+  if (!node1 || !node2) {
+    return false;
+  }
+
+  if (node1->depth != node2->depth) {
+    return false;
+  }
+
+  // Check that the max depth among successors of both blocks is the same
+  auto getMaxSuccDepth = [&](int blockId) {
+    int maxDepth = -1;
+    for (int succId : graph.getSuccessors(blockId)) {
+      BlockNode *succNode = graph.getBlockNode(succId);
+      if (succNode && succNode->depth > maxDepth) {
+        maxDepth = succNode->depth;
+      }
+    }
+    return maxDepth;
+  };
+
+  int maxSuccDepth1 = getMaxSuccDepth(blockId1);
+  int maxSuccDepth2 = getMaxSuccDepth(blockId2);
+
+  // If either block has no successors, still mergeable
+  if (maxSuccDepth1 == -1 || maxSuccDepth2 == -1) {
+    return true;
+  }
+
+  return maxSuccDepth1 == maxSuccDepth2;
 }
 
 llvm::SmallVector<int> MergeCubeBlockPass::filterBlocksByType(

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
@@ -20,6 +20,7 @@
  * THE SOFTWARE.
  */
 
+#include "ComputeBlockOpt/SplitIfByBlockId/Common.h"
 #include "DynamicCVPipeline/Common/BlockDependencyGraph.h"
 #include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
 #include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
@@ -44,91 +45,13 @@ static constexpr const char *DEBUG_TYPE = "merge-cube-block";
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 #define LDBG(...) LLVM_DEBUG(DBGS() << __VA_ARGS__ << "\n")
 
-static const llvm::DenseSet<llvm::StringRef> kDisnbleMergeCubeKernel = {
+static const llvm::DenseSet<llvm::StringRef> kDisableMergeCubeKernel = {
     "flex_attention_backward_dq_kernel",
     "parallel_deltaformer_bwd_kernel_qk",
     "_parallel_hstu_attn_bwd",
     "chunk_kda_bwd_kernel_intra",
     "chunk_gated_delta_rule_fwd_kernel_h_blockdim64",
 };
-
-void MergeCubeBlockPass::findInnermostLoopBlocksWithMatmul(
-    ModuleOp moduleOp, llvm::SmallVectorImpl<Block *> &innermostBlocks) {
-
-  // Find all matmul operations
-  llvm::SmallVector<linalg::MatmulOp> matmulOps;
-  moduleOp.walk([&](linalg::MatmulOp matmulOp) {
-    matmulOps.push_back(matmulOp);
-    return WalkResult::advance();
-  });
-
-  if (matmulOps.empty()) {
-    LDBG("No matmul operations found");
-    return;
-  }
-
-  // For each matmul, find its innermost loop and calculate depth
-  llvm::DenseMap<Block *, int> blockDepthMap;
-
-  for (auto matmulOp : matmulOps) {
-    // Walk up the parent chain to find all loops
-    llvm::SmallVector<Operation *> loops;
-    Operation *currentOp = matmulOp;
-
-    while (currentOp) {
-      if (auto forOp = dyn_cast<scf::ForOp>(currentOp)) {
-        loops.push_back(forOp);
-      } else if (auto whileOp = dyn_cast<scf::WhileOp>(currentOp)) {
-        loops.push_back(whileOp);
-      }
-      currentOp = currentOp->getParentOp();
-    }
-
-    // If this matmul is inside loops, record the innermost loop's block
-    if (!loops.empty()) {
-      Operation *innermostLoop =
-          loops.front(); // The first one is the innermost
-      int depth = loops.size();
-
-      // Get the block from the innermost loop
-      Block *block = nullptr;
-      if (auto forOp = dyn_cast<scf::ForOp>(innermostLoop)) {
-        block = forOp.getBody();
-      } else if (auto whileOp = dyn_cast<scf::WhileOp>(innermostLoop)) {
-        // WhileOp has a region, get the first block
-        block = whileOp.getAfterBody();
-      }
-
-      if (block) {
-        // Update depth map (keep the maximum depth for each block)
-        if (blockDepthMap.find(block) == blockDepthMap.end() ||
-            depth > blockDepthMap[block]) {
-          blockDepthMap[block] = depth;
-        }
-
-        LDBG("Matmul at " << matmulOp << " is in loop at depth " << depth);
-      }
-    }
-  }
-
-  // Find the maximum depth
-  int maxDepth = 0;
-  for (auto &entry : blockDepthMap) {
-    if (entry.second > maxDepth) {
-      maxDepth = entry.second;
-    }
-  }
-
-  LDBG("Maximum loop depth: " << maxDepth);
-
-  // Collect all blocks with maximum depth
-  for (auto &entry : blockDepthMap) {
-    if (entry.second == maxDepth) {
-      LDBG("Found innermost loop block with matmul");
-      innermostBlocks.push_back(entry.first);
-    }
-  }
-}
 
 void MergeCubeBlockPass::runOnOperation() {
   auto moduleOp = getOperation();
@@ -138,7 +61,7 @@ void MergeCubeBlockPass::runOnOperation() {
   }
 
   for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
-    if (kDisnbleMergeCubeKernel.contains(funcOp.getSymName())) {
+    if (kDisableMergeCubeKernel.contains(funcOp.getSymName())) {
       LDBG("Found unsupport kernel: " << funcOp.getSymName());
       return;
     }
@@ -150,15 +73,21 @@ void MergeCubeBlockPass::runOnOperation() {
 
   LDBG("Starting MergeCubeBlockPass\n" << moduleOp);
 
-  // Find innermost loop blocks with matmul operations
-  llvm::SmallVector<Block *> innermostBlocks;
-  findInnermostLoopBlocksWithMatmul(moduleOp, innermostBlocks);
+  // Collect main loop body blocks via the shared walkMainLoop helper.
+  llvm::SmallVector<Block *> mainLoopBlocks;
+  if (failed(CVPipeline::SplitIf::walkMainLoop(
+          moduleOp, [&](Operation *loop) -> llvm::LogicalResult {
+            mainLoopBlocks.push_back(&loop->getRegion(0).front());
+            return llvm::success();
+          }))) {
+    CVPipeline::setFallbackAttr(moduleOp, CVPipeline::ERRCODE_FAILED);
+    return;
+  }
 
-  LDBG("Found " << innermostBlocks.size()
-                << " innermost loop blocks with matmul\n");
+  LDBG("Found " << mainLoopBlocks.size() << " main loop blocks\n");
 
-  // Process each innermost loop block
-  for (Block *block : innermostBlocks) {
+  // Process each main loop block
+  for (Block *block : mainLoopBlocks) {
     if (failed(processBlock(block, memGraph, bm))) {
       CVPipeline::setFallbackAttr(moduleOp, CVPipeline::ERRCODE_FAILED);
       return;
@@ -172,8 +101,6 @@ llvm::LogicalResult
 MergeCubeBlockPass::processBlock(Block *block,
                                  const MemoryDependenceGraph &memGraph,
                                  ComputeBlockIdManager &bm) {
-
-  // Print block information before processing
   LDBG("Processing Block: " << *block);
   if (Operation *parentOp = block->getParentOp()) {
     LDBG("  Parent operation: " << parentOp->getName().getStringRef());
@@ -189,25 +116,22 @@ MergeCubeBlockPass::processBlock(Block *block,
   LDBG("Built dependency graph with " << graph.blockNodes.size()
                                       << " blocks\n");
 
-  llvm::DenseMap<int, llvm::DenseSet<Value>> blockLoadedValues;
+  // If there are at least two cube blocks, print the graph for debugging.
+  LLVM_DEBUG({
+    unsigned cubeCount = 0;
+    for (auto &entry : graph.blockNodes)
+      if (entry.second->isCube)
+        ++cubeCount;
+    if (cubeCount >= 2) {
+      LDBG("=== Printing dependency graph for current region ===");
+      printGraph(graph);
+    }
+  });
 
-  // Step 2: Find merge candidates
-  llvm::SmallVector<std::pair<int, int>> candidates;
-  if (failed(findMergeCandidates(graph, blockLoadedValues, candidates))) {
-    LDBG("Failed to find merge candidates");
-    return llvm::failure();
-  }
-  LDBG("Found " << candidates.size() << " merge candidates\n");
-
-  // If merge candidates are found, print graph structure
-  if (!candidates.empty()) {
-    LDBG("=== Printing dependency graph for current region ===");
-    printGraph(graph, blockLoadedValues);
-  }
-
-  // Step 3: Perform iterative merging
-  if (failed(
-          performMerging(graph, memGraph, bm, blockLoadedValues, candidates))) {
+  // Step 2: Perform iterative merging. The nested loop inside performs the
+  // candidate selection itself by re-scanning the live cube blocks every
+  // round, so there is no separate findMergeCandidates phase.
+  if (failed(performMerging(graph, memGraph, bm))) {
     LDBG("Failed to perform merging");
     return llvm::failure();
   }
@@ -215,39 +139,72 @@ MergeCubeBlockPass::processBlock(Block *block,
   return llvm::success();
 }
 
-llvm::LogicalResult MergeCubeBlockPass::performMerging(
-    BlockDependencyGraph &graph, const MemoryDependenceGraph &memGraph,
-    ComputeBlockIdManager &bm,
-    llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues,
-    llvm::SmallVectorImpl<std::pair<int, int>> &candidates) {
+llvm::LogicalResult
+MergeCubeBlockPass::performMerging(BlockDependencyGraph &graph,
+                                   const MemoryDependenceGraph &memGraph,
+                                   ComputeBlockIdManager &bm) {
+
+  // Collect the live cube blocks once. After every merge we simply drop
+  // the merged-out source from this list, so we never need to re-scan
+  // graph.blockNodes during the merging rounds.
+  llvm::SmallVector<BlockNode *> cubeBlocks;
+  for (auto &entry : graph.blockNodes) {
+    if (entry.second->isCube)
+      cubeBlocks.push_back(entry.second.get());
+  }
 
   bool merged = true;
   int mergeCount = 0;
 
   while (merged) {
     merged = false;
-    for (auto &pair : candidates) {
-      if (canMergeBlocks(pair.first, pair.second, graph, memGraph, bm,
-                         blockLoadedValues)) {
-        LDBG("Merging block " << pair.second << " into " << pair.first);
+
+    // Nested scan: outer index plays the role of target, inner index the
+    // role of source. As soon as one (target, source) pair is mergeable we
+    // commit, drop `source` from the list, and restart from the top of the
+    // round.
+    for (size_t i = 0; i < cubeBlocks.size() && !merged; ++i) {
+      for (size_t j = 0; j < cubeBlocks.size(); ++j) {
+        if (i == j)
+          continue;
+        BlockNode *target = cubeBlocks[i];
+        BlockNode *source = cubeBlocks[j];
+        if (!canMergeBlocks(target, source, graph, memGraph, bm))
+          continue;
+
+        LDBG("Merging block " << source->blockId << " into "
+                              << target->blockId);
 
         // Execute merge
-        if (failed(mergeBlocks(pair.first, pair.second, bm))) {
+        if (failed(mergeBlocks(target, source, bm))) {
           LDBG("Failed to merge blocks");
           return llvm::failure();
         }
         merged = true;
         mergeCount++;
 
-        // Update graph structure
-        graph.rebuildAfterMerge(pair.first, pair.second);
-
-        // Re-find candidates
-        candidates.clear();
-        if (failed(findMergeCandidates(graph, blockLoadedValues, candidates))) {
-          LDBG("Failed to re-find merge candidates");
+        // Update graph structure. After this call, the BlockNode pointed to
+        // by `source` has been destroyed; the pointer value itself remains
+        // usable for equality checks, but any dereference is unsafe. The
+        // pointers for `target` and unrelated nodes stay valid because
+        // blockNodes.erase() does not rehash or relocate other entries.
+        //
+        // Note: mergeBlocks above has already re-tagged source's ops to
+        // target via the ComputeBlockIdManager, which is not transactional.
+        // A rebuildAfterMerge failure therefore leaves the graph and the
+        // blockIdManager in an inconsistent state, so we abort the whole
+        // merging pass and surface the error to processBlock.
+        if (failed(graph.rebuildAfterMerge(target, source))) {
+          LDBG("Failed to rebuild graph after merging "
+               << source->blockId << " into " << target->blockId);
           return llvm::failure();
         }
+
+        // Drop the merged-out source from the candidate list in place; we
+        // already know it lives at index j. The pointer itself is dangling
+        // after the rebuild but we only use its value for erase, which
+        // shifts elements down to fill the gap.
+        cubeBlocks.erase(cubeBlocks.begin() + j);
         break;
       }
     }
@@ -258,131 +215,44 @@ llvm::LogicalResult MergeCubeBlockPass::performMerging(
   return llvm::success();
 }
 
-llvm::LogicalResult MergeCubeBlockPass::findMergeCandidates(
-    BlockDependencyGraph &graph,
-    llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues,
-    llvm::SmallVectorImpl<std::pair<int, int>> &candidates) {
-
-  // Only get cube blocks (filtered from complete dependency graph)
-  llvm::SmallVector<int> cubeBlocks;
-  for (auto &entry : graph.blockNodes) {
-    if (entry.second.isCube) {
-      cubeBlocks.push_back(entry.first);
-    }
-  }
-
-  // Check all pairs of cube blocks for merge possibility
-  for (size_t i = 0; i < cubeBlocks.size(); ++i) {
-    for (size_t j = i + 1; j < cubeBlocks.size(); ++j) {
-      int blockId1 = cubeBlocks[i];
-      int blockId2 = cubeBlocks[j];
-
-      candidates.push_back({blockId1, blockId2});
-    }
-  }
-
-  return llvm::success();
-}
-
-bool MergeCubeBlockPass::canMergeBlocks(
-    int blockId1, int blockId2, BlockDependencyGraph &graph,
-    const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm,
-    llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues) {
+bool MergeCubeBlockPass::canMergeBlocks(BlockNode *target, BlockNode *source,
+                                        BlockDependencyGraph &graph,
+                                        const MemoryDependenceGraph &memGraph,
+                                        ComputeBlockIdManager &bm) {
 
   // Precondition: both blocks must be cube
-  BlockNode *node1 = graph.getBlockNode(blockId1);
-  BlockNode *node2 = graph.getBlockNode(blockId2);
-
-  if (!node1 || !node2 || !node1->isCube || !node2->isCube) {
+  if (!target || !source || !target->isCube || !source->isCube) {
     return false;
   }
 
   // Step 1: Check if they have common input or output nodes
-  if (!hasCommonInputOrOutput(blockId1, blockId2, graph)) {
-    LDBG("Blocks " << blockId1 << " and " << blockId2
+  if (!hasCommonInputOrOutput(target, source, graph)) {
+    LDBG("Blocks " << target->blockId << " and " << source->blockId
                    << " cannot merge: no common input or output nodes\n");
     return false;
   }
 
-  // Step 2: Check if they have same source and sink with no other nodes
-  if (checkSameSourceAndSink(blockId1, blockId2, graph)) {
-    LDBG("Blocks " << blockId1 << " and " << blockId2
-                   << " can merge: same source or sink\n");
-    return true;
-  }
-
-  // Step 3: Check if merging would create a cycle
-  if (!checkNoCycle(blockId1, blockId2, graph, memGraph, bm)) {
-    LDBG("Blocks " << blockId1 << " and " << blockId2
-                   << "cannot merge: would create cycle\n");
+  // Step 2: Check if merging would create a cycle
+  if (!checkNoCycle(target, source, graph, memGraph, bm)) {
+    LDBG("Blocks " << target->blockId << " and " << source->blockId
+                   << " cannot merge: would create cycle\n");
     return false;
   }
 
-  // Step 4: cube block in the same depth
-  if (hasSameDepth(blockId1, blockId2, graph)) {
-    LDBG("Blocks " << blockId1 << " and " << blockId2
-                    << " can merge: cube blocks have same depth\n");
+  // Step 3: cube blocks at the same depth (with matching successor depths).
+  if (hasSameDepth(target, source, graph)) {
+    LDBG("Blocks " << target->blockId << " and " << source->blockId
+                   << " can merge: cube blocks have same depth\n");
     return true;
-    }
+  }
 
-  LDBG("Blocks " << blockId1 << " and " << blockId2
+  LDBG("Blocks " << target->blockId << " and " << source->blockId
                  << " cannot merge: unsupport scenario\n");
   return false;
 }
 
-bool MergeCubeBlockPass::checkSameSourceAndSink(int blockId1, int blockId2,
-                                                BlockDependencyGraph &graph) {
-
-  // Get block nodes
-  BlockNode *node1 = graph.getBlockNode(blockId1);
-  BlockNode *node2 = graph.getBlockNode(blockId2);
-
-  if (!node1 || !node2) {
-    return false;
-  }
-
-  // Get predecessors and successors
-  auto preds1 = graph.getPredecessors(blockId1);
-  auto preds2 = graph.getPredecessors(blockId2);
-
-  auto succs1 = graph.getSuccessors(blockId1);
-  auto succs2 = graph.getSuccessors(blockId2);
-
-  // Filter blocks: only keep blocks with different type from current block
-  llvm::SmallVector<int> filteredPreds1 =
-      filterBlocksByType(blockId1, preds1, graph);
-  llvm::SmallVector<int> filteredPreds2 =
-      filterBlocksByType(blockId2, preds2, graph);
-  llvm::SmallVector<int> filteredSuccs1 =
-      filterBlocksByType(blockId1, succs1, graph);
-  llvm::SmallVector<int> filteredSuccs2 =
-      filterBlocksByType(blockId2, succs2, graph);
-
-  // Check if filtered predecessors are exactly the same
-  llvm::DenseSet<int> predSet1(filteredPreds1.begin(), filteredPreds1.end());
-  llvm::DenseSet<int> predSet2(filteredPreds2.begin(), filteredPreds2.end());
-
-  if (predSet1 != predSet2) {
-    return false;
-  }
-
-  // Check if filtered successors are exactly the same
-  llvm::DenseSet<int> succSet1(filteredSuccs1.begin(), filteredSuccs1.end());
-  llvm::DenseSet<int> succSet2(filteredSuccs2.begin(), filteredSuccs2.end());
-
-  if (succSet1 != succSet2) {
-    return false;
-  }
-
-  return true;
-}
-
-bool MergeCubeBlockPass::hasSameDepth(int blockId1, int blockId2,
+bool MergeCubeBlockPass::hasSameDepth(BlockNode *node1, BlockNode *node2,
                                       BlockDependencyGraph &graph) {
-
-  // Get block nodes
-  BlockNode *node1 = graph.getBlockNode(blockId1);
-  BlockNode *node2 = graph.getBlockNode(blockId2);
 
   if (!node1 || !node2) {
     return false;
@@ -393,19 +263,19 @@ bool MergeCubeBlockPass::hasSameDepth(int blockId1, int blockId2,
   }
 
   // Check that the max depth among successors of both blocks is the same
-  auto getMaxSuccDepth = [&](int blockId) {
+  auto getMaxSuccDepth = [&](BlockNode *node) {
     int maxDepth = -1;
-    for (int succId : graph.getSuccessors(blockId)) {
-      BlockNode *succNode = graph.getBlockNode(succId);
-      if (succNode && succNode->depth > maxDepth) {
+    for (BlockNode *succNode : graph.getSuccessors(node)) {
+      if (succNode && succNode->isCube != node->isCube &&
+          succNode->depth > maxDepth) {
         maxDepth = succNode->depth;
       }
     }
     return maxDepth;
   };
 
-  int maxSuccDepth1 = getMaxSuccDepth(blockId1);
-  int maxSuccDepth2 = getMaxSuccDepth(blockId2);
+  int maxSuccDepth1 = getMaxSuccDepth(node1);
+  int maxSuccDepth2 = getMaxSuccDepth(node2);
 
   // If either block has no successors, still mergeable
   if (maxSuccDepth1 == -1 || maxSuccDepth2 == -1) {
@@ -415,108 +285,93 @@ bool MergeCubeBlockPass::hasSameDepth(int blockId1, int blockId2,
   return maxSuccDepth1 == maxSuccDepth2;
 }
 
-llvm::SmallVector<int> MergeCubeBlockPass::filterBlocksByType(
-    int blockId, llvm::SmallVector<int> blocks, BlockDependencyGraph &graph) {
+llvm::DenseSet<BlockNode *> MergeCubeBlockPass::getBlocksOfDifferentType(
+    BlockNode *currentNode, llvm::ArrayRef<BlockNode *> blocks) {
 
-  // Get current block node
-  BlockNode *currentNode = graph.getBlockNode(blockId);
-  if (!currentNode) {
-    return {};
+  llvm::DenseSet<BlockNode *> result;
+  if (!currentNode)
+    return result;
+
+  // Filter blocks: only keep blocks with a different type than currentNode.
+  for (BlockNode *blockNode : blocks) {
+    if (blockNode && blockNode->isCube != currentNode->isCube)
+      result.insert(blockNode);
   }
-
-  // Filter blocks: only keep blocks with different type from current block
-  llvm::SmallVector<int> filteredBlocks;
-  for (int blockId : blocks) {
-    BlockNode *blockNode = graph.getBlockNode(blockId);
-    if (blockNode && blockNode->isCube != currentNode->isCube) {
-      filteredBlocks.push_back(blockId);
-    }
-  }
-
-  return filteredBlocks;
+  return result;
 }
 
-bool MergeCubeBlockPass::checkNoCycle(int blockId1, int blockId2,
+bool MergeCubeBlockPass::checkNoCycle(BlockNode *node1, BlockNode *node2,
                                       BlockDependencyGraph &graph,
                                       const MemoryDependenceGraph &memGraph,
                                       ComputeBlockIdManager &bm) {
 
-  // Get all operations from blockId2 to be merged into blockId1
-  auto opsToUnify = bm.getOpsByBlockId(blockId2);
+  // Get all operations from node2 to be merged into node1
+  auto opsToUnify = bm.getOpsByBlockId(node2->blockId);
 
   // Use willCreateCycle to check if merging would create a cycle
-  return !willCreateCycle(opsToUnify, memGraph, blockId1, bm);
+  return !willCreateCycle(opsToUnify, memGraph, node1->blockId, bm);
 }
 
-bool MergeCubeBlockPass::hasCommonInputOrOutput(int blockId1, int blockId2,
+bool MergeCubeBlockPass::hasCommonInputOrOutput(BlockNode *node1,
+                                                BlockNode *node2,
                                                 BlockDependencyGraph &graph) {
 
-  // Get predecessors and successors
-  auto preds1 = graph.getPredecessors(blockId1);
-  auto preds2 = graph.getPredecessors(blockId2);
+  // Get predecessors and successors, then filter to opposite-type blocks.
+  // The filtered sets are already DenseSets, so set intersection is O(N).
+  auto filteredPreds1 =
+      getBlocksOfDifferentType(node1, graph.getPredecessors(node1));
+  auto filteredPreds2 =
+      getBlocksOfDifferentType(node2, graph.getPredecessors(node2));
+  auto filteredSuccs1 =
+      getBlocksOfDifferentType(node1, graph.getSuccessors(node1));
+  auto filteredSuccs2 =
+      getBlocksOfDifferentType(node2, graph.getSuccessors(node2));
 
-  auto succs1 = graph.getSuccessors(blockId1);
-  auto succs2 = graph.getSuccessors(blockId2);
+  // Check if there are common input nodes (predecessors).
+  bool hasCommonPred = llvm::any_of(
+      filteredPreds2, [&](BlockNode *p) { return filteredPreds1.count(p); });
 
-  // Filter blocks: only keep blocks with different type from current block
-  llvm::SmallVector<int> filteredPreds1 =
-      filterBlocksByType(blockId1, preds1, graph);
-  llvm::SmallVector<int> filteredPreds2 =
-      filterBlocksByType(blockId2, preds2, graph);
-  llvm::SmallVector<int> filteredSuccs1 =
-      filterBlocksByType(blockId1, succs1, graph);
-  llvm::SmallVector<int> filteredSuccs2 =
-      filterBlocksByType(blockId2, succs2, graph);
+  // Check if there are common output nodes (successors).
+  bool hasCommonSucc = llvm::any_of(
+      filteredSuccs2, [&](BlockNode *s) { return filteredSuccs1.count(s); });
 
-  // Check if there are common input nodes (predecessors)
-  llvm::DenseSet<int> predSet1(filteredPreds1.begin(), filteredPreds1.end());
-  bool hasCommonPred =
-      llvm::any_of(filteredPreds2, [&](int p) { return predSet1.count(p); });
-
-  // Check if there are common output nodes (successors)
-  llvm::DenseSet<int> succSet1(filteredSuccs1.begin(), filteredSuccs1.end());
-  bool hasCommonSucc =
-      llvm::any_of(filteredSuccs2, [&](int s) { return succSet1.count(s); });
-
-  // Return true if they have common input OR output nodes
+  // Return true if they have common input OR output nodes.
   return hasCommonPred || hasCommonSucc;
 }
 
-llvm::LogicalResult MergeCubeBlockPass::mergeBlocks(int targetBlockId,
-                                                    int sourceBlockId,
+llvm::LogicalResult MergeCubeBlockPass::mergeBlocks(BlockNode *target,
+                                                    BlockNode *source,
                                                     ComputeBlockIdManager &bm) {
 
-  // Merge all ops of sourceBlockId into targetBlockId
-  auto sourceOps = bm.getOpsByBlockId(sourceBlockId);
+  // Merge all ops of source into target
+  auto sourceOps = bm.getOpsByBlockId(source->blockId);
   for (Operation *op : sourceOps) {
-    bm.updateBlockId(op, targetBlockId);
+    bm.updateBlockId(op, target->blockId);
   }
 
   return llvm::success();
 }
 
-void MergeCubeBlockPass::printGraph(
-    BlockDependencyGraph &graph,
-    llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues) {
+void MergeCubeBlockPass::printGraph(BlockDependencyGraph &graph) {
 
   LDBG("Total blocks in graph: " << graph.blockNodes.size());
 
   // Print all block nodes
   for (auto &entry : graph.blockNodes) {
     int blockId = entry.first;
-    auto &node = entry.second;
+    BlockNode *node = entry.second.get();
 
     LDBG("Block " << blockId << ":");
-    LDBG("  Type: " << (node.isCube ? "CUBE" : "VECTOR"));
-    LDBG("  Depth: " << node.depth);
-    LDBG("  Num ops: " << node.ops.size());
+    LDBG("  Type: " << (node->isCube ? "CUBE" : "VECTOR"));
+    LDBG("  Depth: " << node->depth);
+    LDBG("  Num ops: " << node->ops.size());
 
     // Print predecessors
-    auto preds = graph.getPredecessors(blockId);
+    auto preds = graph.getPredecessors(node);
     if (!preds.empty()) {
       llvm::SmallVector<std::string> predStrs;
-      for (int p : preds) {
-        predStrs.push_back(std::to_string(p));
+      for (BlockNode *p : preds) {
+        predStrs.push_back(std::to_string(p->blockId));
       }
       LDBG("  Predecessors: [" << llvm::join(predStrs, ", ") << "]");
     } else {
@@ -524,11 +379,11 @@ void MergeCubeBlockPass::printGraph(
     }
 
     // Print successors
-    auto succs = graph.getSuccessors(blockId);
+    auto succs = graph.getSuccessors(node);
     if (!succs.empty()) {
       llvm::SmallVector<std::string> succStrs;
-      for (int s : succs) {
-        succStrs.push_back(std::to_string(s));
+      for (BlockNode *s : succs) {
+        succStrs.push_back(std::to_string(s->blockId));
       }
       LDBG("  Successors: [" << llvm::join(succStrs, ", ") << "]");
     } else {

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
@@ -1,0 +1,500 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/BlockDependencyGraph.h"
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+using namespace CVPipeline;
+
+static constexpr const char *DEBUG_TYPE = "merge-cube-block";
+#define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+#define LDBG(...) LLVM_DEBUG(DBGS() << __VA_ARGS__ << "\n")
+
+static const llvm::DenseSet<llvm::StringRef> kDisnbleMergeCubeKernel = {
+    "flex_attention_backward_dq_kernel",
+    "parallel_deltaformer_bwd_kernel_qk",
+    "_parallel_hstu_attn_bwd",
+    "chunk_kda_bwd_kernel_intra",
+    "chunk_gated_delta_rule_fwd_kernel_h_blockdim64",
+};
+
+void MergeCubeBlockPass::findInnermostLoopBlocksWithMatmul(
+    ModuleOp moduleOp, llvm::SmallVectorImpl<Block *> &innermostBlocks) {
+
+  // Find all matmul operations
+  llvm::SmallVector<linalg::MatmulOp> matmulOps;
+  moduleOp.walk([&](linalg::MatmulOp matmulOp) {
+    matmulOps.push_back(matmulOp);
+    return WalkResult::advance();
+  });
+
+  if (matmulOps.empty()) {
+    LDBG("No matmul operations found");
+    return;
+  }
+
+  // For each matmul, find its innermost loop and calculate depth
+  llvm::DenseMap<Block *, int> blockDepthMap;
+
+  for (auto matmulOp : matmulOps) {
+    // Walk up the parent chain to find all loops
+    llvm::SmallVector<Operation *> loops;
+    Operation *currentOp = matmulOp;
+
+    while (currentOp) {
+      if (auto forOp = dyn_cast<scf::ForOp>(currentOp)) {
+        loops.push_back(forOp);
+      } else if (auto whileOp = dyn_cast<scf::WhileOp>(currentOp)) {
+        loops.push_back(whileOp);
+      }
+      currentOp = currentOp->getParentOp();
+    }
+
+    // If this matmul is inside loops, record the innermost loop's block
+    if (!loops.empty()) {
+      Operation *innermostLoop =
+          loops.front(); // The first one is the innermost
+      int depth = loops.size();
+
+      // Get the block from the innermost loop
+      Block *block = nullptr;
+      if (auto forOp = dyn_cast<scf::ForOp>(innermostLoop)) {
+        block = forOp.getBody();
+      } else if (auto whileOp = dyn_cast<scf::WhileOp>(innermostLoop)) {
+        // WhileOp has a region, get the first block
+        block = whileOp.getAfterBody();
+      }
+
+      if (block) {
+        // Update depth map (keep the maximum depth for each block)
+        if (blockDepthMap.find(block) == blockDepthMap.end() ||
+            depth > blockDepthMap[block]) {
+          blockDepthMap[block] = depth;
+        }
+
+        LDBG("Matmul at " << matmulOp << " is in loop at depth " << depth);
+      }
+    }
+  }
+
+  // Find the maximum depth
+  int maxDepth = 0;
+  for (auto &entry : blockDepthMap) {
+    if (entry.second > maxDepth) {
+      maxDepth = entry.second;
+    }
+  }
+
+  LDBG("Maximum loop depth: " << maxDepth);
+
+  // Collect all blocks with maximum depth
+  for (auto &entry : blockDepthMap) {
+    if (entry.second == maxDepth) {
+      LDBG("Found innermost loop block with matmul");
+      innermostBlocks.push_back(entry.first);
+    }
+  }
+}
+
+void MergeCubeBlockPass::runOnOperation() {
+  auto moduleOp = getOperation();
+
+  if (hasFallbackAttr(moduleOp)) {
+    return;
+  }
+
+  for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
+    if (kDisnbleMergeCubeKernel.contains(funcOp.getSymName())) {
+      LDBG("Found unsupport kernel: " << funcOp.getSymName());
+      return;
+    }
+  }
+
+  auto &aa = getAnalysis<AliasAnalysis>();
+  auto memGraph = MemoryDependenceGraph(moduleOp, aa);
+  auto bm = ComputeBlockIdManager(moduleOp);
+
+  LDBG("Starting MergeCubeBlockPass\n" << moduleOp);
+
+  // Find innermost loop blocks with matmul operations
+  llvm::SmallVector<Block *> innermostBlocks;
+  findInnermostLoopBlocksWithMatmul(moduleOp, innermostBlocks);
+
+  LDBG("Found " << innermostBlocks.size()
+                << " innermost loop blocks with matmul\n");
+
+  // Process each innermost loop block
+  for (Block *block : innermostBlocks) {
+    if (failed(processBlock(block, memGraph, bm))) {
+      CVPipeline::setFallbackAttr(moduleOp, CVPipeline::ERRCODE_FAILED);
+      return;
+    }
+  }
+
+  LDBG("MergeCubeBlockPass completed\n" << moduleOp);
+}
+
+llvm::LogicalResult
+MergeCubeBlockPass::processBlock(Block *block,
+                                 const MemoryDependenceGraph &memGraph,
+                                 ComputeBlockIdManager &bm) {
+
+  // Print block information before processing
+  LDBG("Processing Block: " << *block);
+  if (Operation *parentOp = block->getParentOp()) {
+    LDBG("  Parent operation: " << parentOp->getName().getStringRef());
+  }
+
+  // Step 1: Build Block dependency graph
+  BlockDependencyGraph graph(block, memGraph, bm);
+  if (failed(graph.buildGraph())) {
+    LDBG("Failed to build dependency graph");
+    return llvm::failure();
+  }
+
+  LDBG("Built dependency graph with " << graph.blockNodes.size()
+                                      << " blocks\n");
+
+  llvm::DenseMap<int, llvm::DenseSet<Value>> blockLoadedValues;
+
+  // Step 2: Find merge candidates
+  llvm::SmallVector<std::pair<int, int>> candidates;
+  if (failed(findMergeCandidates(graph, blockLoadedValues, candidates))) {
+    LDBG("Failed to find merge candidates");
+    return llvm::failure();
+  }
+  LDBG("Found " << candidates.size() << " merge candidates\n");
+
+  // If merge candidates are found, print graph structure
+  if (!candidates.empty()) {
+    LDBG("=== Printing dependency graph for current region ===");
+    printGraph(graph, blockLoadedValues);
+  }
+
+  // Step 3: Perform iterative merging
+  if (failed(
+          performMerging(graph, memGraph, bm, blockLoadedValues, candidates))) {
+    LDBG("Failed to perform merging");
+    return llvm::failure();
+  }
+
+  return llvm::success();
+}
+
+llvm::LogicalResult MergeCubeBlockPass::performMerging(
+    BlockDependencyGraph &graph, const MemoryDependenceGraph &memGraph,
+    ComputeBlockIdManager &bm,
+    llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues,
+    llvm::SmallVectorImpl<std::pair<int, int>> &candidates) {
+
+  bool merged = true;
+  int mergeCount = 0;
+
+  while (merged) {
+    merged = false;
+    for (auto &pair : candidates) {
+      if (canMergeBlocks(pair.first, pair.second, graph, memGraph, bm,
+                         blockLoadedValues)) {
+        LDBG("Merging block " << pair.second << " into " << pair.first);
+
+        // Execute merge
+        if (failed(mergeBlocks(pair.first, pair.second, bm))) {
+          LDBG("Failed to merge blocks");
+          return llvm::failure();
+        }
+        merged = true;
+        mergeCount++;
+
+        // Update graph structure
+        graph.rebuildAfterMerge(pair.first, pair.second);
+
+        // Re-find candidates
+        candidates.clear();
+        if (failed(findMergeCandidates(graph, blockLoadedValues, candidates))) {
+          LDBG("Failed to re-find merge candidates");
+          return llvm::failure();
+        }
+        break;
+      }
+    }
+  }
+
+  LDBG("Merged " << mergeCount << " blocks\n");
+
+  return llvm::success();
+}
+
+llvm::LogicalResult MergeCubeBlockPass::findMergeCandidates(
+    BlockDependencyGraph &graph,
+    llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues,
+    llvm::SmallVectorImpl<std::pair<int, int>> &candidates) {
+
+  // Only get cube blocks (filtered from complete dependency graph)
+  llvm::SmallVector<int> cubeBlocks;
+  for (auto &entry : graph.blockNodes) {
+    if (entry.second.isCube) {
+      cubeBlocks.push_back(entry.first);
+    }
+  }
+
+  // Check all pairs of cube blocks for merge possibility
+  for (size_t i = 0; i < cubeBlocks.size(); ++i) {
+    for (size_t j = i + 1; j < cubeBlocks.size(); ++j) {
+      int blockId1 = cubeBlocks[i];
+      int blockId2 = cubeBlocks[j];
+
+      candidates.push_back({blockId1, blockId2});
+    }
+  }
+
+  return llvm::success();
+}
+
+bool MergeCubeBlockPass::canMergeBlocks(
+    int blockId1, int blockId2, BlockDependencyGraph &graph,
+    const MemoryDependenceGraph &memGraph, ComputeBlockIdManager &bm,
+    llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues) {
+
+  // Precondition: both blocks must be cube
+  BlockNode *node1 = graph.getBlockNode(blockId1);
+  BlockNode *node2 = graph.getBlockNode(blockId2);
+
+  if (!node1 || !node2 || !node1->isCube || !node2->isCube) {
+    return false;
+  }
+
+  // Step 1: Check if they have common input or output nodes
+  if (!hasCommonInputOrOutput(blockId1, blockId2, graph)) {
+    LDBG("Blocks " << blockId1 << " and " << blockId2
+                   << " cannot merge: no common input or output nodes\n");
+    return false;
+  }
+
+  // Step 2: Check if they have same source and sink with no other nodes
+  if (!checkSameSourceAndSink(blockId1, blockId2, graph)) {
+    LDBG("Blocks " << blockId1 << " and " << blockId2
+                   << " cannot merge: different source or sink\n");
+    return false;
+  }
+
+  // Step 3: Check if merging would create a cycle
+  if (checkNoCycle(blockId1, blockId2, graph, memGraph, bm)) {
+    LDBG("Blocks " << blockId1 << " and " << blockId2
+                   << " can merge: no cycle detected\n");
+    return true;
+  }
+
+  LDBG("Blocks " << blockId1 << " and " << blockId2
+                 << " cannot merge: would create cycle\n");
+  return false;
+}
+
+bool MergeCubeBlockPass::checkSameSourceAndSink(int blockId1, int blockId2,
+                                                BlockDependencyGraph &graph) {
+
+  // Get block nodes
+  BlockNode *node1 = graph.getBlockNode(blockId1);
+  BlockNode *node2 = graph.getBlockNode(blockId2);
+
+  if (!node1 || !node2) {
+    return false;
+  }
+
+  // Get predecessors and successors
+  auto preds1 = graph.getPredecessors(blockId1);
+  auto preds2 = graph.getPredecessors(blockId2);
+
+  auto succs1 = graph.getSuccessors(blockId1);
+  auto succs2 = graph.getSuccessors(blockId2);
+
+  // Filter blocks: only keep blocks with different type from current block
+  llvm::SmallVector<int> filteredPreds1 =
+      filterBlocksByType(blockId1, preds1, graph);
+  llvm::SmallVector<int> filteredPreds2 =
+      filterBlocksByType(blockId2, preds2, graph);
+  llvm::SmallVector<int> filteredSuccs1 =
+      filterBlocksByType(blockId1, succs1, graph);
+  llvm::SmallVector<int> filteredSuccs2 =
+      filterBlocksByType(blockId2, succs2, graph);
+
+  // Check if filtered predecessors are exactly the same
+  llvm::DenseSet<int> predSet1(filteredPreds1.begin(), filteredPreds1.end());
+  llvm::DenseSet<int> predSet2(filteredPreds2.begin(), filteredPreds2.end());
+
+  if (predSet1 != predSet2) {
+    return false;
+  }
+
+  // Check if filtered successors are exactly the same
+  llvm::DenseSet<int> succSet1(filteredSuccs1.begin(), filteredSuccs1.end());
+  llvm::DenseSet<int> succSet2(filteredSuccs2.begin(), filteredSuccs2.end());
+
+  if (succSet1 != succSet2) {
+    return false;
+  }
+
+  return true;
+}
+
+llvm::SmallVector<int> MergeCubeBlockPass::filterBlocksByType(
+    int blockId, llvm::SmallVector<int> blocks, BlockDependencyGraph &graph) {
+
+  // Get current block node
+  BlockNode *currentNode = graph.getBlockNode(blockId);
+  if (!currentNode) {
+    return {};
+  }
+
+  // Filter blocks: only keep blocks with different type from current block
+  llvm::SmallVector<int> filteredBlocks;
+  for (int blockId : blocks) {
+    BlockNode *blockNode = graph.getBlockNode(blockId);
+    if (blockNode && blockNode->isCube != currentNode->isCube) {
+      filteredBlocks.push_back(blockId);
+    }
+  }
+
+  return filteredBlocks;
+}
+
+bool MergeCubeBlockPass::checkNoCycle(int blockId1, int blockId2,
+                                      BlockDependencyGraph &graph,
+                                      const MemoryDependenceGraph &memGraph,
+                                      ComputeBlockIdManager &bm) {
+
+  // Get all operations from blockId2 to be merged into blockId1
+  auto opsToUnify = bm.getOpsByBlockId(blockId2);
+
+  // Use willCreateCycle to check if merging would create a cycle
+  return !willCreateCycle(opsToUnify, memGraph, blockId1, bm);
+}
+
+bool MergeCubeBlockPass::hasCommonInputOrOutput(int blockId1, int blockId2,
+                                                BlockDependencyGraph &graph) {
+
+  // Get predecessors and successors
+  auto preds1 = graph.getPredecessors(blockId1);
+  auto preds2 = graph.getPredecessors(blockId2);
+
+  auto succs1 = graph.getSuccessors(blockId1);
+  auto succs2 = graph.getSuccessors(blockId2);
+
+  // Filter blocks: only keep blocks with different type from current block
+  llvm::SmallVector<int> filteredPreds1 =
+      filterBlocksByType(blockId1, preds1, graph);
+  llvm::SmallVector<int> filteredPreds2 =
+      filterBlocksByType(blockId2, preds2, graph);
+  llvm::SmallVector<int> filteredSuccs1 =
+      filterBlocksByType(blockId1, succs1, graph);
+  llvm::SmallVector<int> filteredSuccs2 =
+      filterBlocksByType(blockId2, succs2, graph);
+
+  // Check if there are common input nodes (predecessors)
+  llvm::DenseSet<int> predSet1(filteredPreds1.begin(), filteredPreds1.end());
+  bool hasCommonPred =
+      llvm::any_of(filteredPreds2, [&](int p) { return predSet1.count(p); });
+
+  // Check if there are common output nodes (successors)
+  llvm::DenseSet<int> succSet1(filteredSuccs1.begin(), filteredSuccs1.end());
+  bool hasCommonSucc =
+      llvm::any_of(filteredSuccs2, [&](int s) { return succSet1.count(s); });
+
+  // Return true if they have common input OR output nodes
+  return hasCommonPred || hasCommonSucc;
+}
+
+llvm::LogicalResult MergeCubeBlockPass::mergeBlocks(int targetBlockId,
+                                                    int sourceBlockId,
+                                                    ComputeBlockIdManager &bm) {
+
+  // Merge all ops of sourceBlockId into targetBlockId
+  auto sourceOps = bm.getOpsByBlockId(sourceBlockId);
+  for (Operation *op : sourceOps) {
+    bm.updateBlockId(op, targetBlockId);
+  }
+
+  return llvm::success();
+}
+
+void MergeCubeBlockPass::printGraph(
+    BlockDependencyGraph &graph,
+    llvm::DenseMap<int, llvm::DenseSet<Value>> &blockLoadedValues) {
+
+  LDBG("Total blocks in graph: " << graph.blockNodes.size());
+
+  // Print all block nodes
+  for (auto &entry : graph.blockNodes) {
+    int blockId = entry.first;
+    auto &node = entry.second;
+
+    LDBG("Block " << blockId << ":");
+    LDBG("  Type: " << (node.isCube ? "CUBE" : "VECTOR"));
+    LDBG("  Depth: " << node.depth);
+    LDBG("  Num ops: " << node.ops.size());
+
+    // Print predecessors
+    auto preds = graph.getPredecessors(blockId);
+    if (!preds.empty()) {
+      llvm::SmallVector<std::string> predStrs;
+      for (int p : preds) {
+        predStrs.push_back(std::to_string(p));
+      }
+      LDBG("  Predecessors: [" << llvm::join(predStrs, ", ") << "]");
+    } else {
+      LDBG("  Predecessors: []");
+    }
+
+    // Print successors
+    auto succs = graph.getSuccessors(blockId);
+    if (!succs.empty()) {
+      llvm::SmallVector<std::string> succStrs;
+      for (int s : succs) {
+        succStrs.push_back(std::to_string(s));
+      }
+      LDBG("  Successors: [" << llvm::join(succStrs, ", ") << "]");
+    } else {
+      LDBG("  Successors: []");
+    }
+  }
+
+  LDBG("=== End of graph ===");
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::triton::createMergeCubeBlockPass() {
+  return std::make_unique<MergeCubeBlockPass>();
+}

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -25,6 +25,7 @@
 #include "DynamicCVPipeline/PlanComputeBlock/Passes.h"
 #include "DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h"
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlockPass.h"
 
@@ -79,6 +80,8 @@ void ComputeBlockOptPass::runOnOperation() {
   pm.addPass(createMergeComputeBlockPass());
   pm.addPass(createReorderOpsByBlockIdPass());
 
+  pm.addPass(createMergeCubeBlockPass());
+  pm.addPass(createReorderOpsByBlockIdPass());
   pm.addPass(createRelocateMemrefDeclPass());
 
   if (failed(runPipeline(pm, module))) {
@@ -115,6 +118,7 @@ void registerComputeBlockOptPasses() {
   registerPass(createMergeSmallBlockPass);
   registerPass(createSplitIfByBlockIdPass);
   registerPass(createMergeComputeBlockPass);
+  registerPass(createMergeCubeBlockPass);
   registerPass(createRelocateMemrefDeclPass);
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -675,6 +675,16 @@ InterCoreTransferAndSyncPass::getConsumerWaitPoint(int transferIndex) {
   return consumerWaitPoint;
 }
 
+mlir::Operation *InterCoreTransferAndSyncPass::getFixpipePointAfterProducer(
+    Value srcValue, int producerBlockId) {
+  mlir::Operation *fixpipePoint = srcValue.getDefiningOp();
+  int blockId = CVPipeline::getOpBlockId(fixpipePoint).value_or(-1);
+  if (blockId != producerBlockId) {
+    return nullptr;
+  }
+  return fixpipePoint;
+}
+
 Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
     OpBuilder &builder, Value normalizedValue, DependencyInfo &dep,
     Location loc, Operation **consumedDataOp) {
@@ -1560,6 +1570,14 @@ LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(
   LOG_DEBUG("[newProdEnd]" << *dep.producerEnd << "\n");
   LOG_DEBUG("[newConsStart]" << *dep.consumerStart << "\n");
   LOG_DEBUG("[newConsEnd]" << *dep.consumerEnd << "\n");
+
+  if (!isa<scf::ForOp, scf::WhileOp, scf::IfOp>(srcValue.getDefiningOp())) {
+    auto producerPoint =
+        getFixpipePointAfterProducer(srcValue, dep.iniProducerBlockId);
+    if (producerPoint) {
+      dep.producerEnd = producerPoint;
+    }
+  }
 
   // uses of srcValue. Only applied when the source op belongs to a
   // sub-block.

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_cube_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_cube_block.mlir
@@ -1,0 +1,233 @@
+// RUN: triton-opt --merge-cube-block %s | FileCheck %s
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  // ============================================
+  // Test Case 1: @test_merge_cube_blocks_with_vector
+  // ============================================
+  // Scenario: Two cube blocks with same vector predecessors and successors
+  // - Vector block 1 (block_id=1) produces vec_tensor1
+  // - Cube block 1 (block_id=2) uses vec_tensor1, produces cube_tensor1
+  // - Cube block 2 (block_id=3) uses vec_tensor1, produces cube_tensor2
+  // - Vector block 2 (block_id=4) uses cube_tensor1 and cube_tensor2
+  // Expected: The two cube blocks should be merged (block_id=3 -> block_id=2)
+  // Wrapped in two-layer for loop (only innermost should be processed)
+  // ============================================
+  // CHECK-LABEL: func.func @test_merge_cube_blocks_with_vector
+  func.func @test_merge_cube_blocks_with_vector(%arg0: memref<?xbf16>, %arg1: memref<?xbf16>, %arg2: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %cst_f32 = arith.constant 0.000000e+00 : f32
+
+    scf.for %i = %c0 to %c128 step %c1 {
+      scf.for %j = %c0 to %c128 step %c1 {
+        %vec_alloc1 = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16>
+        %vec_cond1 = arith.constant 1 : i1
+        scf.if %vec_cond1 {
+          linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : bf16) outs(%vec_alloc1 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 1 : i32}
+        %vec_tensor1 = bufferization.to_tensor %vec_alloc1 restrict writable {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16> to tensor<128x128xbf16>
+
+        // CHECK: %{{.*}} = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_alloc1 = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_cond1 = arith.constant 1 : i1
+        // CHECK: scf.if %{{.*}} {
+        // CHECK:   linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+        scf.if %cube_cond1 {
+          linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc1 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 2 : i32}
+        %cube_tensor1 = bufferization.to_tensor %cube_alloc1 restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+        %cube_out1 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_matmul1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor1 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out1 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+        // CHECK: %{{.*}} = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_alloc2 = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_cond2 = arith.constant 1 : i1
+        // CHECK: scf.if %{{.*}} {
+        // CHECK:   linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+        scf.if %cube_cond2 {
+          linalg.fill {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc2 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 3 : i32}
+        %cube_tensor2 = bufferization.to_tensor %cube_alloc2 restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+        %cube_out2 = tensor.empty() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_matmul2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor2 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+        %vec_alloc2 = memref.alloc() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32>
+        %vec_cond2 = arith.constant 1 : i1
+        scf.if %vec_cond2 {
+          linalg.fill {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_f32 : f32) outs(%vec_alloc2 : memref<128x128xf32>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 4 : i32}
+        // Uses both cube_matmul1 and cube_matmul2
+        %vec_add = arith.addf %cube_matmul1, %cube_matmul2 {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+        %vec_tensor2 = bufferization.to_tensor %vec_alloc2 restrict writable {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32> to tensor<128x128xf32>
+
+        scf.yield
+      }
+    }
+
+    return
+  }
+
+  // ============================================
+  // Test Case 2: @test_no_merge_with_extra_vector_dependency
+  // ============================================
+  // Scenario: Based on scenario 1, add an extra vector node pointing to one cube block
+  // - Vector block 5 (block_id=5) produces vec_tensor1
+  // - Vector block 9 (block_id=9) produces vec_tensor3
+  // - Cube block 6 (block_id=6) uses vec_tensor1, produces cube_matmul1
+  // - Cube block 7 (block_id=7) uses vec_tensor3, produces cube_matmul2
+  // - Vector block 8 (block_id=8) uses cube_matmul1 and cube_matmul2
+  // Expected: The two cube blocks should NOT be merged (different source nodes)
+  // Wrapped in two-layer for loop
+  // ============================================
+  // CHECK-LABEL: func.func @test_no_merge_with_extra_vector_dependency
+  func.func @test_no_merge_with_extra_vector_dependency(%arg0: memref<?xbf16>, %arg1: memref<?xbf16>, %arg2: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %cst_f32 = arith.constant 0.000000e+00 : f32
+
+    // Outer for loop
+    scf.for %i = %c0 to %c128 step %c1 {
+      // Inner for loop (innermost, should be processed)
+      scf.for %j = %c0 to %c128 step %c1 {
+        // Vector block 1 (predecessor for cube block 1)
+        %vec_alloc1 = memref.alloc() {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16>
+        %vec_cond1 = arith.constant 1 : i1
+        scf.if %vec_cond1 {
+          linalg.fill {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : bf16) outs(%vec_alloc1 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 5 : i32}
+        %vec_tensor1 = bufferization.to_tensor %vec_alloc1 restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16> to tensor<128x128xbf16>
+
+        // Cube block 1 (block_id=2) - uses vec_tensor1
+        // CHECK: memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_alloc1 = memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_cond1 = arith.constant 1 : i1
+        // CHECK: scf.if %{{.*}} {
+        // CHECK:   linalg.fill {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"}
+        scf.if %cube_cond1 {
+          linalg.fill {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc1 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 6 : i32}
+        %cube_tensor1 = bufferization.to_tensor %cube_alloc1 restrict writable {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+        %cube_out1 = tensor.empty() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_matmul1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor1 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out1 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+        // Extra vector block (block_id=5) - only used by cube block 2
+        %vec_alloc3 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16>
+        %vec_cond3 = arith.constant 1 : i1
+        scf.if %vec_cond3 {
+          linalg.fill {ssbuffer.block_id = 9 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : bf16) outs(%vec_alloc3 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 9 : i32}
+        %vec_tensor3 = bufferization.to_tensor %vec_alloc3 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16> to tensor<128x128xbf16>
+
+        // Cube block 2 (block_id=3) - should NOT be merged (different source nodes)
+        // Uses vec_tensor3
+        // CHECK: memref.alloc() {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_alloc2 = memref.alloc() {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_cond2 = arith.constant 1 : i1
+        // CHECK: scf.if %{{.*}} {
+        // CHECK:   linalg.fill {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
+        scf.if %cube_cond2 {
+          linalg.fill {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc2 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 7 : i32}
+        %cube_tensor2 = bufferization.to_tensor %cube_alloc2 restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+        %cube_out2 = tensor.empty() {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
+        // Uses vec_tensor3 as one of the inputs
+        %cube_matmul2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor3, %cube_tensor2 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+        // Vector block 2 (successor for both cube blocks)
+        // Uses both cube_matmul1 and cube_matmul2
+        %vec_alloc2 = memref.alloc() {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32>
+        %vec_cond2 = arith.constant 1 : i1
+        scf.if %vec_cond2 {
+          linalg.fill {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_f32 : f32) outs(%vec_alloc2 : memref<128x128xf32>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 8 : i32}
+        %vec_add = arith.addf %cube_matmul1, %cube_matmul2 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+        %vec_tensor2 = bufferization.to_tensor %vec_alloc2 restrict writable {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32> to tensor<128x128xf32>
+
+        scf.yield
+      }
+    }
+
+    return
+  }
+
+  // ============================================
+  // Test Case 3: @test_no_merge_single_layer_for
+  // ============================================
+  // Scenario: Same as scenario 1, but only one layer of for loop
+  // - Vector block 1 (block_id=1) produces vec_tensor1
+  // - Cube block 1 (block_id=2) uses vec_tensor1, produces cube_matmul1
+  // - Cube block 2 (block_id=3) uses vec_tensor1, produces cube_matmul2
+  // - Vector block 2 (block_id=4) uses cube_matmul1 and cube_matmul2
+  // Expected: The two cube blocks should NOT be merged (not innermost loop)
+  // Only one layer of for loop
+  // ============================================
+  // CHECK-LABEL: func.func @test_no_merge_single_layer_for
+  func.func @test_no_merge_single_layer_for(%arg0: memref<?xbf16>, %arg1: memref<?xbf16>, %arg2: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %cst_f32 = arith.constant 0.000000e+00 : f32
+
+    // Single layer for loop (not innermost, should NOT be processed)
+    scf.for %i = %c0 to %c128 step %c1 {
+      // Vector block 1 (predecessor for both cube blocks)
+      %vec_alloc1 = memref.alloc() {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16>
+      %vec_cond1 = arith.constant 1 : i1
+      scf.if %vec_cond1 {
+        linalg.fill {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : bf16) outs(%vec_alloc1 : memref<128x128xbf16>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 15 : i32}
+      %vec_tensor1 = bufferization.to_tensor %vec_alloc1 restrict writable {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16> to tensor<128x128xbf16>
+
+      // Cube block 1 (block_id=2) - should remain unchanged
+      // CHECK: memref.alloc() {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"}
+      %cube_alloc1 = memref.alloc() {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+      %cube_cond1 = arith.constant 1 : i1
+      // CHECK: scf.if %{{.*}} {
+      // CHECK:   linalg.fill {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"}
+      scf.if %cube_cond1 {
+        linalg.fill {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc1 : memref<128x128xbf16>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 16 : i32}
+      %cube_tensor1 = bufferization.to_tensor %cube_alloc1 restrict writable {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+      %cube_out1 = tensor.empty() {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+      // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"}
+      %cube_matmul1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor1 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out1 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+      // Cube block 2 (block_id=3) - should remain unchanged
+      // CHECK: memref.alloc() {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"}
+      %cube_alloc2 = memref.alloc() {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+      %cube_cond2 = arith.constant 1 : i1
+      // CHECK: scf.if %{{.*}} {
+      // CHECK:   linalg.fill {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"}
+      scf.if %cube_cond2 {
+        linalg.fill {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc2 : memref<128x128xbf16>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 17 : i32}
+      %cube_tensor2 = bufferization.to_tensor %cube_alloc2 restrict writable {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+      %cube_out2 = tensor.empty() {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+      // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"}
+      %cube_matmul2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor2 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+      // Vector block 2 (successor for both cube blocks)
+      // Uses both cube_matmul1 and cube_matmul2
+      %vec_alloc2 = memref.alloc() {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32>
+      %vec_cond2 = arith.constant 1 : i1
+      scf.if %vec_cond2 {
+        linalg.fill {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_f32 : f32) outs(%vec_alloc2 : memref<128x128xf32>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 18 : i32}
+      %vec_add = arith.addf %cube_matmul1, %cube_matmul2 {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+      %vec_tensor2 = bufferization.to_tensor %vec_alloc2 restrict writable {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32> to tensor<128x128xf32>
+
+      scf.yield
+    }
+
+    return
+  }
+}

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_cube_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_cube_block.mlir
@@ -104,17 +104,17 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
         %vec_tensor1 = bufferization.to_tensor %vec_alloc1 restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16> to tensor<128x128xbf16>
 
         // Cube block 1 (block_id=2) - uses vec_tensor1
-        // CHECK: memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"}
+        // CHECK: memref.alloc() {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
         %cube_alloc1 = memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
         %cube_cond1 = arith.constant 1 : i1
         // CHECK: scf.if %{{.*}} {
-        // CHECK:   linalg.fill {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"}
+        // CHECK:   linalg.fill {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
         scf.if %cube_cond1 {
           linalg.fill {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc1 : memref<128x128xbf16>)
         } {hivm.unlikely_condition, ssbuffer.block_id = 6 : i32}
         %cube_tensor1 = bufferization.to_tensor %cube_alloc1 restrict writable {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
         %cube_out1 = tensor.empty() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
-        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"}
+        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
         %cube_matmul1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor1 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out1 : tensor<128x128xf32>) -> tensor<128x128xf32>
 
         // Extra vector block (block_id=5) - only used by cube block 2
@@ -225,6 +225,18 @@ module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
       %vec_add = arith.addf %cube_matmul1, %cube_matmul2 {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
       %vec_tensor2 = bufferization.to_tensor %vec_alloc2 restrict writable {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32> to tensor<128x128xf32>
 
+
+      %cube_alloc3 = memref.alloc() {ssbuffer.block_id = 19 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf32>
+      %cube_cond3 = arith.constant 1 : i1
+      scf.if %cube_cond3 {
+        linalg.fill {ssbuffer.block_id = 19 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc3 : memref<128x128xf32>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 19 : i32}
+      %cube_tensor3 = bufferization.to_tensor %cube_alloc3 restrict writable {ssbuffer.block_id = 19 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf32> to tensor<128x128xf32>
+      %cube_out3 = tensor.empty() {ssbuffer.block_id = 19 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+      %cube_matmul3 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 19 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor2, %cube_tensor3 : tensor<128x128xf32>, tensor<128x128xf32>) outs(%cube_out3 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+
+      %vec_add3 = arith.addf %cube_matmul2, %cube_matmul3 {ssbuffer.block_id = 20 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
       scf.yield
     }
 


### PR DESCRIPTION
Add merge-cube-block pass in compute-block-opt of ssbuffer
if there are two cube blocks with restrict same vector predecessors and successors,
they are supposed to be merge into one block.

       V1                  V1     
     /     \                |
    ▼    ▼                  ▼
    C1   C2     ->          C
     \      /               |
      ▼ ▼                   ▼
        V2                  V2

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
