### PR TITLE
[ssbuffer](fix) skip reorder after disable mergeComputeBlock

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -87,6 +87,8 @@ inline constexpr llvm::StringLiteral kCoreTypeCube = "CUBE";
 inline constexpr llvm::StringLiteral kCoreTypeVector = "VECTOR";
 inline constexpr llvm::StringLiteral kFromMakeRange = "tt.from_make_range";
 inline constexpr llvm::StringLiteral kSubBlock = "ssbuffer.subBlock";
+inline constexpr llvm::StringLiteral kMergeComputeBlockApplied =
+    "ssbuffer.merge_compute_block_applied";
 
 inline constexpr const char *ERRCODE_ATTR =
     "triton_ascend.dynamic_cv_pipeline.rc";

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeComputeBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeComputeBlockPass.cpp
@@ -421,8 +421,9 @@ static bool tryCrossCubeCloneMerge(
 }
 
 /// Core merge logic for one scf::ForOp body Block.
-static void tryMergeInBlock(Block *block, CVPipeline::ComputeBlockIdManager &bm,
+static bool tryMergeInBlock(Block *block, CVPipeline::ComputeBlockIdManager &bm,
                             const CVPipeline::MemoryDependenceGraph &memGraph) {
+  bool mergedAny = false;
   while (true) {
     // Step 1: Group and build enhanced dependency graph
     /// computeBlocks: block_id → ComputeBlock
@@ -435,21 +436,21 @@ static void tryMergeInBlock(Block *block, CVPipeline::ComputeBlockIdManager &bm,
     groupAndBuildGraph(block, memGraph, computeBlocks, succs, preds,
                        blockEdges);
     if (computeBlocks.empty())
-      return;
+      return mergedAny;
 
     // Step 2: Collect VECTOR candidates
     SmallVector<int> vecCandidates =
         collectVectorCandidates(computeBlocks, succs, preds);
     if (vecCandidates.size() < 2) {
       LOG_DEBUG("MergeComputeBlock: vecCandidates.size() < 2, skipping");
-      return;
+      return mergedAny;
     }
 
     // Step 3: Find a pair of adjacent VECTOR blocks
     auto pairOpt = findAdjacentVectorPair(vecCandidates, succs);
     if (!pairOpt) {
       LOG_DEBUG("MergeComputeBlock: No adjacent VECTOR pair found, skipping");
-      return;
+      return mergedAny;
     }
     int predVId = pairOpt->first;
     int succVId = pairOpt->second;
@@ -460,14 +461,17 @@ static void tryMergeInBlock(Block *block, CVPipeline::ComputeBlockIdManager &bm,
 
     // Step 4: Try direct merge
     if (tryDirectMerge(opsToMerge, memGraph, predVId, succVId, computeBlocks,
-                       bm))
+                       bm)) {
+      mergedAny = true;
       continue;
+    }
 
     // Step 5: Try cross-Cube clone merge
     if (!tryCrossCubeCloneMerge(block, computeBlocks, preds, blockEdges,
                                 predVId, succVId, opsToMerge, memGraph, bm))
-      return;
+      return mergedAny;
     // continue to try next pair
+    mergedAny = true;
   }
 }
 
@@ -492,6 +496,11 @@ public:
     if (CVPipeline::hasFallbackAttr(module)) {
       return;
     }
+
+    // Record that this pass ran. Stays false unless a merge actually
+    // succeeds; the following ReorderOpsByBlockIdPass reads this marker.
+    module->setAttr(CVPipeline::kMergeComputeBlockApplied,
+                    BoolAttr::get(&getContext(), false));
 
     bool shouldRun = false;
     for (auto funcOp : module.getOps<func::FuncOp>()) {
@@ -533,9 +542,16 @@ public:
     auto &aa = getAnalysis<AliasAnalysis>();
     CVPipeline::MemoryDependenceGraph memGraph(module, aa);
     CVPipeline::ComputeBlockIdManager bm(module);
+    bool mergedAny = false;
     for (Block *block : blocksToProcess) {
       LOG_DEBUG("try merge in LoopBlock");
-      tryMergeInBlock(block, bm, memGraph);
+      mergedAny = tryMergeInBlock(block, bm, memGraph) || mergedAny;
+    }
+    if (mergedAny) {
+      // A merge actually happened; let the following
+      // ReorderOpsByBlockIdPass know it should run.
+      module->setAttr(CVPipeline::kMergeComputeBlockApplied,
+                      BoolAttr::get(&getContext(), true));
     }
 
     LOG_DEBUG("After MergeComputeBlockPass: " << *module);

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -461,6 +461,18 @@ void ReorderOpsByBlockIdPass::runOnOperation() {
     return;
   }
 
+  // MergeComputeBlockPass sets kMergeComputeBlockApplied to record whether it
+  // actually merged blocks. Skip reorder only when it ran but merged nothing;
+  // consume the marker either way so it does not leak into the output IR.
+  if (auto applied = moduleOp->getAttrOfType<BoolAttr>(
+          CVPipeline::kMergeComputeBlockApplied)) {
+    moduleOp->removeAttr(CVPipeline::kMergeComputeBlockApplied);
+    if (!applied.getValue()) {
+      LOG_DEBUG("Skip reorder: MergeComputeBlock ran but merged nothing");
+      return;
+    }
+  }
+
   LOG_DEBUG("Input mlir:\n" << moduleOp << "\n");
   llvm::dbgs().flush();
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
