### PR TITLE
[compiler](fix) restore disable_size_align_for_cast option

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -822,6 +822,12 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
                 f"--enable-ubuf-saving={enable_ubuf_saving}",
             ]
 
+        disable_size_align_for_cast = metadata["disable_size_align_for_cast"]
+        if disable_size_align_for_cast is not None:
+            _compile_option_list += [
+                f"--disable-size-align-for-cast={disable_size_align_for_cast}",
+            ]
+
         enable_preload = metadata["enable_preload"]
         if enable_preload is not None:
             _compile_option_list += [
@@ -1061,6 +1067,7 @@ class NPUOptions:
     multibuffer: bool = True
     vf_fusion_mode: str = None
     enable_ubuf_saving: bool = None
+    disable_size_align_for_cast: bool = None
     enable_preload: bool = None
     enable_auto_bind_sub_block: bool = None
     disable_tightly_coupled_buffer_reuse: bool = False

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -46,7 +46,6 @@ _DEPRECATED_NPU_OPTIONS = frozenset({
     "auto_tile_and_bind_subblock",
     "code_motion",
     "compile_on_910_95",
-    "disable_size_align_for_cast",
     "enable_auto_blockify",
     "enable_buffer_insert_optimization",
     "enable_cce_vf_auto_sync",
@@ -123,7 +122,6 @@ _DEPRECATED_NPU_OPTION_DETAILS = {
     "auto_tile_and_bind_subblock":
     "it is ignored; tiling and subblock binding are derived from Linalg IR and lock semantics.",
     "code_motion": "it is ignored; the removed vendor compiler control has no replacement.",
-    "disable_size_align_for_cast": "it is ignored; the removed vendor compiler control has no replacement.",
     "enable_auto_blockify": "it is ignored; automatic block mapping and its safety blacklist are backend-managed.",
     "enable_buffer_insert_optimization":
     "it is ignored; DynamicCV keeps buffer insertion optimization enabled internally.",


### PR DESCRIPTION
The compile-option cleanup incorrectly deprecated `disable_size_align_for_cast` even though NPU IR still consumes it on A2/A3. This PR restores the option in `NPUOptions`, removes it from the deprecated-option compatibility path, and forwards explicitly configured values through `--disable-size-align-for-cast=<bool>`. The option remains A2/A3-only, and the A5 compilation path is unchanged.