### PR TITLE
[Docs](fix) update community_technical_meeting icalendar

### DIFF
--- a/docs/en/community/community_technical_meeting.md
+++ b/docs/en/community/community_technical_meeting.md
@@ -14,12 +14,12 @@ Triton-Ascend holds regular community technical meetings as the core decision-ma
 
 - **Meeting Frequency**: Bi-weekly
 - **Meeting Time**: Thursday 14:15(UTC+8)
-- **Meeting Start Date**: 4 June, 2026
+- **Meeting Start Date**: 2026-09-03
 - **Meeting Link**: [Link](https://us06web.zoom.us/j/86540192059?pwd=X2N3pl5bnZH5CgiuX1zjyZoELItmjP.1)
 - **Meeting Room Number**: 865 4019 2059
 - **Meeting Room Password**: 123456
 - **Meeting Agenda and Minutes**: [Agenda&Minutes](https://docs.google.com/document/d/1qfat2wZtO2nfZb5FC2dWAcR6sTqgTNSvvh7MzTDoI4s/edit?pli=1&tab=t.0)
-- **Meeting iCalendar**: [iCalendar-ics](https://us06web.zoom.us/meeting/tZIoc-mppzkqH92hP7TBYHppsqZUxg9F8VPf/ics?icsToken=DObLUj7lyTNwJj6XJgAALAAAAOvNV2DJnuObI9tqQGt1c3aeqVgCdzMYHV0m_J0KHIX0i4QUrtvsJwMu_EMF5VKyBKdX4rPWh_raTxvF4jAwMDAwMQ&meetingMasterEventId=1PZVSVC8S8WIBZJ1e4wuZQ)
+- **Meeting iCalendar**: [iCalendar-ics](https://us06web.zoom.us/meeting/tZIoc-mppzkqH92hP7TBYHppsqZUxg9F8VPf/ics?icsToken=DBlmQBo-ZbCIRz2GWwAALAAAAH1WzqoLLdQ-3b1rNf3AN6DLmYOhAUMS4b1zaoD-mgyykQQcSeS7S4Sf27U3_r_pLLEVTWFd8P_zVnm1zzAwMDAwMg)
 
 ## Voting Rules
 

--- a/docs/zh/community/community_technical_meeting.md
+++ b/docs/zh/community/community_technical_meeting.md
@@ -14,12 +14,12 @@ Triton-Ascend 定期召开社区技术会议，作为项目治理的核心决策
 
 - **会议频率**：每两周一次
 - **会议时间**：周四 14:15（UTC+8）
-- **会议起始日期**：2026 年 6 月 4 日
+- **会议起始日期**：2026 年 9 月 3 日
 - **会议链接**：[链接](https://us06web.zoom.us/j/86540192059?pwd=X2N3pl5bnZH5CgiuX1zjyZoELItmjP.1)
 - **会议室号**：865 4019 2059
 - **会议室密码**：123456
 - **会议议程与纪要**：[议程&纪要](https://docs.google.com/document/d/1qfat2wZtO2nfZb5FC2dWAcR6sTqgTNSvvh7MzTDoI4s/edit?pli=1&tab=t.0)
-- **会议 iCalendar**：[iCalendar-ics](https://us06web.zoom.us/meeting/tZIoc-mppzkqH92hP7TBYHppsqZUxg9F8VPf/ics?icsToken=DObLUj7lyTNwJj6XJgAALAAAAOvNV2DJnuObI9tqQGt1c3aeqVgCdzMYHV0m_J0KHIX0i4QUrtvsJwMu_EMF5VKyBKdX4rPWh_raTxvF4jAwMDAwMQ&meetingMasterEventId=1PZVSVC8S8WIBZJ1e4wuZQ)
+- **会议 iCalendar**：[iCalendar-ics](https://us06web.zoom.us/meeting/tZIoc-mppzkqH92hP7TBYHppsqZUxg9F8VPf/ics?icsToken=DBlmQBo-ZbCIRz2GWwAALAAAAH1WzqoLLdQ-3b1rNf3AN6DLmYOhAUMS4b1zaoD-mgyykQQcSeS7S4Sf27U3_r_pLLEVTWFd8P_zVnm1zzAwMDAwMg)
 
 ## 投票规则
 


### PR DESCRIPTION
## Summary
Update the community technical meeting schedule to start on 3 Sep 2026 and continue bi-weekly, and refresh the Zoom iCalendar link in both Chinese and English docs.

## What Is Included
- `docs/zh/community/community_technical_meeting.md`: start date `2026-09-03`, new iCalendar URL
- `docs/en/community/community_technical_meeting.md`: same updates

## User Impact
No code behavior change. Documentation only.

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [x] This PR does not need a test because it only updates documentation.
  - [ ] I have added tests.
- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices).
