### PR TITLE
[ControlFlowOpt](fix) preserve opaque while backedges

### DIFF
--- a/third_party/ascend/lib/TritonToUnstructure/ReplaceArguments.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/ReplaceArguments.cpp
@@ -182,6 +182,9 @@ shouldPreserveScalarPointers(Operation *op, RewriterBase &rewriter,
     for (Value arg : whileOp.getAfterArguments())
       if (!canRewriteBoundary(arg, /*allowStableBase=*/false))
         return true;
+    for (Value value : whileOp.getYieldOp().getOperands())
+      if (isOpaqueScalarPointerIfResult(value))
+        return true;
     return false;
   } else if (auto loopOp = dyn_cast<LoopLikeOpInterface>(op)) {
     for (Value init : loopOp.getInits())

--- a/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/scalar_pointer_while_if_backedge.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToUnstructure/scalar_pointer_while_if_backedge.mlir
@@ -1,0 +1,38 @@
+// RUN: triton-opt %s --triton-to-unstructure -verify-each | FileCheck %s
+
+// A pointer selected by an scf.if is an opaque complete address. When that
+// value is yielded to an enclosing scf.while, every edge of the while boundary
+// must use the complete-address representation instead of mixing i64 region
+// arguments with a pointer backedge.
+tt.func public @scalar_pointer_while_if_backedge(
+    %initial: !tt.ptr<i32>, %alternate: !tt.ptr<i32>) -> i32 {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %result:2 = scf.while (%i = %c0, %ptr = %initial)
+      : (i32, !tt.ptr<i32>) -> (i32, !tt.ptr<i32>) {
+    %continue = arith.cmpi slt, %i, %c1 : i32
+    scf.condition(%continue) %i, %ptr : i32, !tt.ptr<i32>
+  } do {
+  ^bb0(%i: i32, %ptr: !tt.ptr<i32>):
+    %next_i = arith.addi %i, %c1 : i32
+    %take_alternate = arith.cmpi eq, %i, %c0 : i32
+    %next:2 = scf.if %take_alternate -> (!tt.ptr<i32>, i32) {
+      scf.yield %alternate, %next_i : !tt.ptr<i32>, i32
+    } else {
+      scf.yield %ptr, %next_i : !tt.ptr<i32>, i32
+    }
+    scf.yield %next#1, %next#0 : i32, !tt.ptr<i32>
+  }
+  %loaded = tt.load %result#1 : !tt.ptr<i32>
+  tt.return %loaded : i32
+}
+
+// CHECK-LABEL: tt.func public @scalar_pointer_while_if_backedge
+// CHECK:       scf.while
+// CHECK-SAME:  (i32, i64) -> (i32, i64)
+// CHECK:       scf.condition
+// CHECK-SAME:  i32, i64
+// CHECK:       arith.select {{.*}} : !tt.ptr<i32>
+// CHECK:       tt.ptr_to_int
+// CHECK:       scf.yield
+// CHECK-SAME:  i32, i64

--- a/third_party/ascend/unittest/pytest_ut/test_scalar_pointer_control_flow.py
+++ b/third_party/ascend/unittest/pytest_ut/test_scalar_pointer_control_flow.py
@@ -73,6 +73,22 @@ def scalar_pointer_while_from_function_args_kernel(x, out, steps_ptr):
 
 
 @triton.jit
+def scalar_pointer_while_if_backedge_kernel(x0, x1, out, steps_ptr, switch_at_ptr):
+    """Select a new scalar-pointer base on one while-loop backedge."""
+    steps = tl.load(steps_ptr)
+    switch_at = tl.load(switch_at_ptr)
+    pointer = x0 + 1
+    iteration = 0
+    while iteration < steps:
+        if iteration == switch_at:
+            pointer = x1 + 7
+        else:
+            pointer = pointer + 2
+        iteration += 1
+    tl.store(out, tl.load(pointer))
+
+
+@triton.jit
 def scalar_pointer_nested_if_for_kernel(x, out, predicate_ptr, steps_ptr):
     predicate = tl.load(predicate_ptr)
     steps = tl.load(steps_ptr)
@@ -195,6 +211,26 @@ def test_scalar_pointer_while_from_function_args(steps):
     expected = torch.zeros_like(out_cpu)
     expected[expected_output_index] = x0_cpu[expected_input_index]
     _assert_output(out, expected)
+
+
+@pytest.mark.parametrize("steps,switch_at", [(0, 0), (1, 0), (4, 1), (4, 7)])
+def test_scalar_pointer_while_if_backedge(steps, switch_at):
+    x0_cpu, x1_cpu, x0, x1 = _inputs()
+    out = torch.empty(1, dtype=torch.float32, device="npu")
+
+    scalar_pointer_while_if_backedge_kernel[(1, )](
+        x0,
+        x1,
+        out,
+        _device_i32(steps),
+        _device_i32(switch_at),
+    )
+
+    if switch_at < steps:
+        expected = x1_cpu[7 + 2 * (steps - switch_at - 1):]
+    else:
+        expected = x0_cpu[1 + 2 * steps:]
+    _assert_output(out, expected[:1])
 
 
 @pytest.mark.parametrize("predicate", [0, 1])


### PR DESCRIPTION
## Summary
- Preserve opaque scalar-pointer while backedges when an scf.if selects the pointer value.
- Add MLIR coverage for the while/if backedge representation.\n- Add an end-to-end pytest case covering zero-trip, switched, and unswitched iterations.
- 
- The branch contains one commit and is based on the current upstream main-dev.