### PR TITLE
[ssbuffer](fix) suppress ssbuffer diagnostic and reproducer

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AddDynamicCVPipeline.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddDynamicCVPipeline.h
@@ -28,6 +28,7 @@
 #include "bishengir/Dialect/Scope/IR/Scope.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/DialectRegistry.h"
 #include "mlir/Pass/Pass.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
@@ -55,8 +56,11 @@ using namespace triton;
 class AddDynamicCVPipelinePass
     : public ::impl::AddDynamicCVPipelineBase<AddDynamicCVPipelinePass> {
 public:
+  using Base = ::impl::AddDynamicCVPipelineBase<AddDynamicCVPipelinePass>;
+
   explicit AddDynamicCVPipelinePass(const AddDynamicCVPipelineOptions &options);
   void runOnOperation() override;
+  void getDependentDialects(DialectRegistry &registry) const override;
 };
 
 } // namespace

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflowPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflowPass.h
@@ -23,6 +23,10 @@
 #ifndef TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_SPLIT_DATAFLOW_PASS_H
 #define TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_SPLIT_DATAFLOW_PASS_H
 
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/Scope/IR/Scope.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 
@@ -39,6 +43,14 @@ public:
 
   // Run the pass
   void runOnOperation() override;
+
+  /// Return the dialect that must be loaded in the context before this pass.
+  void getDependentDialects(::mlir::DialectRegistry &registry) const override {
+    registry.insert<hivm::HIVMDialect>();
+    registry.insert<bufferization::BufferizationDialect>();
+    registry.insert<scope::ScopeDialect>();
+    registry.insert<annotation::AnnotationDialect>();
+  }
 };
 
 // Create the pass

--- a/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
@@ -24,7 +24,13 @@
 #include "llvm/Support/Debug.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/raw_ostream.h"
+
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/DialectRegistry.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/WalkResult.h"
 #include "llvm/Support/Debug.h"
@@ -47,7 +53,7 @@
 
 #include "DynamicCVPipeline/Common/FallbackHelper.h"
 
-static constexpr const char *DEBUG_TYPE = "AddDynamicCVPipeline";
+static constexpr const char *DEBUG_TYPE = "add-dynamic-cv-pipeline";
 static constexpr unsigned MAX_RETRY_TIMES = 2;
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << (X) << "\n")
@@ -59,14 +65,34 @@ namespace triton {
 } // namespace triton
 } // namespace mlir
 
-namespace {
-std::optional<int64_t> getErrorCode(ModuleOp moduleOp) {
+static std::optional<int64_t> getErrorCode(ModuleOp moduleOp) {
   auto errCodeAttr =
       moduleOp->getAttrOfType<IntegerAttr>(CVPipeline::ERRCODE_ATTR);
   return errCodeAttr ? std::optional<int64_t>(errCodeAttr.getInt())
                      : std::nullopt;
 }
-} // namespace
+
+static inline void addPasses(OpPassManager &pm) {
+  pm.addPass(createPreCheckAvailablePass());
+  pm.addPass(createStandardizeOpPass());
+  pm.addPass(createPlanComputeBlockPass());
+  pm.addPass(createComputeBlockOptPass());
+  pm.addPass(createSplitDataflowPass());
+  pm.addPass(createAnalyzeDataFlowPass());
+  pm.addPass(createAllocMultiCachePass());
+  pm.addPass(createAddControlFlowConditionPass());
+  pm.addPass(createSeparateMemoryFromComputePass());
+  pm.addPass(createRemoveSsbufAttrPass());
+}
+
+// must collect all sub-passes since they now are not added to pipeline
+void AddDynamicCVPipelinePass::getDependentDialects(
+    DialectRegistry &registry) const {
+  Base::getDependentDialects(registry);
+  OpPassManager tempPM(ModuleOp::getOperationName());
+  addPasses(tempPM);
+  tempPM.getDependentDialects(registry);
+}
 
 AddDynamicCVPipelinePass::AddDynamicCVPipelinePass(
     const AddDynamicCVPipelineOptions &options)
@@ -97,6 +123,17 @@ void AddDynamicCVPipelinePass::runOnOperation() {
     llvm::errs() << "Add-dynamic-cv-pipeline is only supported on 91095 now.\n";
     return;
   }
+
+  ScopedDiagnosticHandler handler(&getContext(), [&](Diagnostic &diag) {
+    LLVM_DEBUG({
+      // In debug mode, continue to other handlers, i.e. print to stderr
+      return llvm::failure();
+    });
+
+    // otherwise prohibit any other handler
+    return llvm::success();
+  });
+
   for (unsigned attempt = 0; attempt < MAX_RETRY_TIMES; ++attempt) {
     // restore() consumes the saved region bodies. Each attempt needs its own
     // snapshot, taken before changing buffer counts for the retry.
@@ -111,18 +148,10 @@ void AddDynamicCVPipelinePass::runOnOperation() {
 
     // Do not reuse pass instances or partially transformed IR on retry.
     PassManager pm(&getContext(), moduleOp.getOperationName());
-    pm.addPass(createPreCheckAvailablePass());
-    pm.addPass(createStandardizeOpPass());
-    pm.addPass(createPlanComputeBlockPass());
-    pm.addPass(createComputeBlockOptPass());
-    pm.addPass(createSplitDataflowPass());
-    pm.addPass(createAnalyzeDataFlowPass());
-    pm.addPass(createAllocMultiCachePass());
-    pm.addPass(createAddControlFlowConditionPass());
-    pm.addPass(createSeparateMemoryFromComputePass());
-    pm.addPass(createRemoveSsbufAttrPass());
+    addPasses(pm);
 
-    auto result = runPipeline(pm, moduleOp);
+    // run passes in separate pm, instead of the pipeline to suppress reproducer
+    auto result = pm.run(moduleOp);
     auto errCode = getErrorCode(moduleOp);
     if (succeeded(result) && !errCode.has_value()) {
       LDBG("Process successfully");

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddDynamicCVPipeline/fallback_no_matmul.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddDynamicCVPipeline/fallback_no_matmul.mlir
@@ -1,10 +1,10 @@
-// RUN: triton-opt '--add_dynamic_cv_pipeline=compile-on-910-95=True' %s 2>&1 | FileCheck %s --implicit-check-not='note: see current operation:'
+// RUN: triton-opt '--add_dynamic_cv_pipeline=compile-on-910-95=True' --debug-only=add-dynamic-cv-pipeline %s 2>&1 | FileCheck %s --implicit-check-not='note: see current operation:'
 
 // Test: Module with no linalg.matmul. PreCheckMatmul sets ERRCODE_IGNORED,
 // AddDynamicCVPipeline falls back with a "Kernel not applicable..." warning
 // that does NOT include the full module IR dump.
 
-// CHECK: warning: [AddDynamicCVPipeline] Kernel not applicable for dynamic CV pipeline
+// CHECK: warning: [add-dynamic-cv-pipeline] Kernel not applicable for dynamic CV pipeline
 module {
   func.func @fallback_no_matmul(%arg0: i32, %arg1: i32) -> i32 {
     %0 = arith.addi %arg0, %arg1 : i32


### PR DESCRIPTION
`[fix](ascend/dynamic-cv-pipeline): Suppress diagnostic logs and reproducer generation during fallback | 抑制回退流程中的诊断日志与 Reproducer 生成`

---

## 1. Overview / 概述
### English
This PR suppresses unnecessary MLIR diagnostic messages and pass crash/failure reproducer generation during the execution of `AddDynamicCVPipelinePass`. When the dynamic CV pipeline encounters unsupported patterns or preload failures, it relies on graceful fallback mechanisms; silencing non-debug diagnostics and isolating pass execution prevents noisy error dumps to `stderr` and reproducer generation while ensuring complete dialect registration across all sub-passes.

### 中文
本 PR 旨在消除 `AddDynamicCVPipelinePass` 执行及其回退过程中的非必要 MLIR 诊断信息输出和 Pass Reproducer 脚本生成。当动态 CV 流水线（Dynamic CV Pipeline）遇到不支持的模式或预加载失败时，原本具有预期的优雅降级机制（Fallback）；通过在非 Debug 模式下拦截诊断并将子流水线执行与父流水线解耦，可避免向 `stderr` 打印具有误导性的错误日志和生成 Reproducer，同时补全了所有子 Pass 所需的 Dialect 依赖注册。

---

## 2. Key Changes / 关键变更

### English
- **`DynamicCVPipeline/AddDynamicCVPipeline.h` & `.cpp`**:
  - Added a `ScopedDiagnosticHandler` in `AddDynamicCVPipelinePass::runOnOperation()` that consumes and suppresses all diagnostics during non-debug runs (returning `llvm::success()`), while allowing them through under `LLVM_DEBUG`.
  - Replaced `runPipeline(pm, moduleOp)` with `pm.run(moduleOp)` using an isolated `PassManager` to prevent triggering MLIR pass reproducer dumps on expected pass failures.
  - Extracted sub-pass construction into a static `addPasses(OpPassManager &pm)` helper.
  - Implemented `AddDynamicCVPipelinePass::getDependentDialects()` using a temporary `OpPassManager` to collect and register dialect dependencies from all child passes.
  - Renamed `DEBUG_TYPE` from `"AddDynamicCVPipeline"` to LLVM standard kebab-case `"add-dynamic-cv-pipeline"`.
- **`DynamicCVPipeline/SplitDataflowPass.h`**:
  - Implemented `getDependentDialects()` to register required dialects (`HIVMDialect`, `BufferizationDialect`, `ScopeDialect`, `AnnotationDialect`).
- **`unittest/.../fallback_no_matmul.mlir`**:
  - Updated the LIT test command with `--debug-only=add-dynamic-cv-pipeline` to verify fallback warning output, and updated check prefixes to match the new `DEBUG_TYPE`.

### 中文
- **`DynamicCVPipeline/AddDynamicCVPipeline.h` 与 `.cpp`**:
  - 在 `AddDynamicCVPipelinePass::runOnOperation()` 中引入 `ScopedDiagnosticHandler`：在非 Debug 模式下拦截并抑制所有诊断信息（返回 `llvm::success()`），而在 `LLVM_DEBUG` 开启时将诊断透传至标准处理器。
  - 将子流水线调用方式从 `runPipeline(pm, moduleOp)` 改为独立的 `pm.run(moduleOp)`，避免子 Pass 在预期的失败重试或回退时触发 MLIR Reproducer 生成机制。
  - 提取子 Pass 构建逻辑至静态辅助函数 `addPasses(OpPassManager &pm)`。
  - 重写 `AddDynamicCVPipelinePass::getDependentDialects()`，通过临时 `OpPassManager` 收集并向上注册所有子 Pass 的依赖 Dialect。
  - 将 `DEBUG_TYPE` 由 `"AddDynamicCVPipeline"` 标准化为 LLVM 风格的短横线命名 `"add-dynamic-cv-pipeline"`。
- **`DynamicCVPipeline/SplitDataflowPass.h`**:
  - 重写 `getDependentDialects()`，显式注册所依赖的 Dialect（`HIVMDialect`、`BufferizationDialect`、`ScopeDialect` 与 `AnnotationDialect`）。
- **`unittest/.../fallback_no_matmul.mlir`**:
  - 在 LIT 测试命令中增加 `--debug-only=add-dynamic-cv-pipeline` 以验证回退警告日志，并同步更新匹配前缀以适配新的 `DEBUG_TYPE`。

---

## 3. Technical Deep-Dive / 技术细节剖析
### English
1. **Diagnostic Suppression Mechanism**:
   During Dynamic CV Pipeline processing, certain patterns (e.g., missing `linalg.matmul` or tuple buffer preload failures) trigger a fallback flow managed by `CVPipeline::FallbackHelper`. In previous revisions, failing intermediate passes emitted MLIR diagnostics directly to standard error, appearing as compiler bugs to downstream users. By registering a `ScopedDiagnosticHandler`, the handler returns `llvm::success()` when `LLVM_DEBUG` is inactive, indicating that the diagnostic has been handled and suppressing output. When compiling with debug flags or passing `--debug-only=add-dynamic-cv-pipeline`, `LLVM_DEBUG` evaluates to `llvm::failure()`, preserving diagnostic emission for developer debugging.
2. **Reproducer Decoupling**:
   When invoking `Pass::runPipeline()`, sub-pipeline execution remains attached to the parent pass manager context. If an inner pass fails, MLIR's crash/failure reproducer generator can dump intermediate IR and command lines. By directly instantiating a standalone `PassManager pm(&getContext(), moduleOp.getOperationName())` and executing `pm.run(moduleOp)`, the pass execution is decoupled from outer reproducer hooks.
3. **Dialect Dependency Management**:
   Decoupling sub-passes from the parent pipeline's dynamic schedule necessitates explicit dialect registration. Because the passes are instantiated in an internal `PassManager` inside `runOnOperation`, `AddDynamicCVPipelinePass::getDependentDialects` constructs a temporary `OpPassManager`, populates it with `addPasses()`, and propagates all sub-pass dialect requirements to the outer pass registry. Simultaneously, `SplitDataflowPass` explicitly declares its dependencies on BiShengIR dialects (`hivm`, `scope`, `annotation`) and MLIR's `bufferization` dialect.

### 中文
1. **诊断抑制机制**：
   在动态 CV 流水线执行期间，缺少 `linalg.matmul` 或元组预加载失败等模式会触发由 `CVPipeline::FallbackHelper` 管理的内部回退流程。在此前的实现中，中间子 Pass 失败时会直接向标准错误输出 MLIR 诊断信息，容易被外部误判为编译器崩溃。通过注册 `ScopedDiagnosticHandler`，在未开启 `LLVM_DEBUG` 的常规编译环境下返回 `llvm::success()`，表示该诊断已被消费，从而完全静默输出；而在开启 Debug 标志（如指定 `--debug-only=add-dynamic-cv-pipeline`）时返回 `llvm::failure()`，恢复正常的错误输出以便于调试定位。
2. **Reproducer 生成解耦**：
   使用 `Pass::runPipeline()` 运行子流水线时，其处于父 Pass 管理器的上下文之中，一旦子 Pass 返回失败，容易触发 MLIR 内置的 Crash/Failure Reproducer 机制，在磁盘或终端输出调试复现脚本与 IR 转储。改用独立的 `PassManager pm(&getContext(), moduleOp.getOperationName())` 并调用 `pm.run(moduleOp)` 执行，隔离了子流水线执行过程，避免了非异常回退路径上的 Reproducer 生成。
3. **Dialect 依赖显式注册**：
   将子 Pass 的运行与父级流水线解耦后，必须确保所有子 Pass 依赖的 Dialect 在外层 Pass 调度前被正确加载。`AddDynamicCVPipelinePass::getDependentDialects` 通过创建临时的 `OpPassManager`，添加完整的 10 个子 Pass 并调用 `getDependentDialects`，统一向上层注册所需的 Dialect。同时，`SplitDataflowPass` 显式重写了 `getDependentDialects`，补全了对 BiShengIR（`hivm`、`scope`、`annotation`）与 MLIR `bufferization` 方言的依赖声明。

---

## 4. Impact & Risk Assessment / 影响与风险评估
### English
- **Breaking Changes**: No. There are no changes to public APIs, compilation outputs, or IR generation logic.
- **Performance Impact**: Neutral to slightly positive. Suppressing diagnostic formatting, stderr I/O, and reproducer file generation during pass fallbacks reduces compilation overhead.
- **Backward Compatibility**: Fully backward compatible. Debug diagnostic inspection is maintained via `--debug-only=add-dynamic-cv-pipeline`.

### 中文
- **破坏性变更**: 否。未修改任何公开 API、最终编译产物或 IR 生成逻辑。
- **性能影响**: 中性偏正向。在触发回退时减少了控制台 I/O 以及 Reproducer 文件的格式化与写入，可微幅降低编译期开销。
- **向后兼容性**: 完全向后兼容。在需要定位问题时，仍可通过 `--debug-only=add-dynamic-cv-pipeline` 完整恢复调试日志。

---

## 5. Verification & Testing / 测试与验证方法
### English
- **LIT Unit Testing**:
  - Run the updated unit test to confirm expected fallback warnings are produced when `--debug-only=add-dynamic-cv-pipeline` is enabled:
    ```bash
    triton-opt '--add_dynamic_cv_pipeline=compile-on-910-95=True' --debug-only=add-dynamic-cv-pipeline third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddDynamicCVPipeline/fallback_no_matmul.mlir
    ```
- **Silent Fallback Verification**:
  - Run `triton-opt` without `--debug-only` on fallback test cases and verify that no diagnostics, notes (`note: see current operation:`), or MLIR reproducer files are generated.

### 中文
- **LIT 单元测试**:
  - 运行已更新的单元测试，验证在开启 `--debug-only=add-dynamic-cv-pipeline` 时能够正确捕获预期的回退警告信息：
    ```bash
    triton-opt '--add_dynamic_cv_pipeline=compile-on-910-95=True' --debug-only=add-dynamic-cv-pipeline third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AddDynamicCVPipeline/fallback_no_matmul.mlir
    ```
- **静默回退验证**:
  - 在不带 `--debug-only` 选项的情况下运行触发回退的测试用例，确认终端无多余诊断日志（如 `note: see current operation:`），且不会生成 MLIR Reproducer 转储文件。