### PR TITLE
[CI](chore) Replace the runner cluster

### DIFF
--- a/.github/workflows/integration-tests-ascend.yml
+++ b/.github/workflows/integration-tests-ascend.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   integration-tests-ascend:
-    name: integration-tests-ascend (${{ matrix.config.name }}, py${{ matrix.config.python_version }})
+    name: integration-tests-ascend (${{ matrix.config.runs_on[0] }}, py${{ matrix.config.python_version }})
     runs-on: ${{ matrix.config.runs_on }}
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/triton:${{ matrix.config.cann_version }}-${{ matrix.config.chip_type }}-${{ matrix.config.os }}-py${{ matrix.config.python_version }}-latest

--- a/.github/workflows/runner-preparation.yml
+++ b/.github/workflows/runner-preparation.yml
@@ -95,33 +95,28 @@ jobs:
           if [ x"${{ github.repository }}" == x"triton-lang/triton-ascend" ]; then
             # One entry per (chip × python); each entry carries its full
             # environment (container image tag = cann_version-chip_type-os-pyX).
-            # Chips are distinguished by runner: a3 on linux-aarch64-a3-4,
-            # a5 (Ascend 950) on linux-amd64-a5-4.
+            # Chips are distinguished by runner: a3 pinned to cn12-001 via
+            # type + serial labels (self-hosted multi-label = AND), a5
+            # (Ascend 950) on linux-amd64-a5-4.
             # Heredoc delimiter syntax: the only multiline $GITHUB_OUTPUT
             # format supported on every runner version.
             echo 'matrix-ASCEND<<MATRIX_EOF' >> $GITHUB_OUTPUT
             echo '[
               {
-                "name": "linux-aarch64-a3-4",
-                "runner_type": "linux-aarch64-a3-4",
-                "runs_on": ["linux-aarch64-a3-4"],
+                "runs_on": ["linux-aarch64-a3-800i-4", "cn12-001"],
                 "chip_type": "a3",
                 "cann_version": "8.5.0",
                 "os": "ubuntu22.04",
                 "python_version": "3.10"
               },
               {
-                "name": "linux-aarch64-a3-4",
-                "runner_type": "linux-aarch64-a3-4",
-                "runs_on": ["linux-aarch64-a3-4"],
+                "runs_on": ["linux-aarch64-a3-800i-4", "cn12-001"],
                 "chip_type": "a3",
                 "cann_version": "8.5.0",
                 "os": "ubuntu22.04",
                 "python_version": "3.11"
               },
               {
-                "name": "linux-amd64-a5-4",
-                "runner_type": "linux-amd64-a5-4",
                 "runs_on": ["linux-amd64-a5-4"],
                 "chip_type": "950",
                 "cann_version": "9.1.0",

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: linux-aarch64-a3-4
+    runs-on: [linux-aarch64-a3-800i-4, cn12-001]
     container:
       image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/triton:8.5.0-a3-ubuntu22.04-py3.10-latest
     timeout-minutes: 600


### PR DESCRIPTION
### Summary
The a3 integration tests and the sync-upstream job were running on the
`linux-aarch64-a3-4` label, which no longer matches the device we intend
to use. This PR points them at the cn12-001 machine via its actually
registered labels, and trims redundant fields from the runner matrix.

### Change
- `runner-preparation.yml`: the two a3 matrix entries now use
  `runs_on: ["linux-aarch64-a3-800i-4", "cn12-001"]`. Self-hosted runners
  match multiple labels with AND semantics, so this pins the job to
  cn12-001 while keeping the device type visible in the job name.
- `sync-upstream.yml`: same runner change for the sync job.
- Removed the `name` and `runner_type` fields from the runner matrix:
  `runner_type` had no consumers, and the job display name in
  `integration-tests-ascend.yml` now derives from `runs_on[0]`, so a
  future device swap only needs to edit the serial number.

CI-only change; no tests needed.
