### PR TITLE
[ssbuffer](feat) Retrying with tuple buffer failed.

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -95,6 +95,7 @@ inline constexpr const char *ERRCODE_ATTR =
     "triton_ascend.dynamic_cv_pipeline.rc";
 static constexpr const int ERRCODE_FAILED = 1;
 static constexpr const int ERRCODE_IGNORED = 2;
+static constexpr const int ERRCODE_TUPLE_PRELOAD_FAILED = 3;
 constexpr int64_t CACHE_TABLE_BUFFER_SIZE = 4096;
 constexpr int64_t BYTE_SIZE = 8;
 static constexpr int crossCoreProducerId = 1;

--- a/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddDynamicCVPipeline.cpp
@@ -20,14 +20,16 @@
  * THE SOFTWARE.
  */
 
-#include "llvm/Support/Debug.h"
-
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/PassManager.h"
+#include "llvm/Support/Debug.h"
+#include <cstdint>
+#include <optional>
 
 #include "ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
 #include "ascend/include/DynamicCVPipeline/AllocMultiCache.h"
 #include "ascend/include/DynamicCVPipeline/AnalyzeDataFlow.h"
+#include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/Passes.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/Passes.h"
@@ -41,6 +43,7 @@
 #include "DynamicCVPipeline/Common/FallbackHelper.h"
 
 static constexpr const char *DEBUG_TYPE = "AddDynamicCVPipeline";
+static constexpr unsigned MAX_RETRY_TIMES = 2;
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << (X) << "\n")
 
@@ -50,6 +53,15 @@ namespace triton {
 #include "ascend/include/DynamicCVPipeline/Passes.h.inc"
 } // namespace triton
 } // namespace mlir
+
+namespace {
+std::optional<int64_t> getErrorCode(ModuleOp moduleOp) {
+  auto errCodeAttr =
+      moduleOp->getAttrOfType<IntegerAttr>(CVPipeline::ERRCODE_ATTR);
+  return errCodeAttr ? std::optional<int64_t>(errCodeAttr.getInt())
+                     : std::nullopt;
+}
+} // namespace
 
 AddDynamicCVPipelinePass::AddDynamicCVPipelinePass(
     const AddDynamicCVPipelineOptions &options)
@@ -67,61 +79,75 @@ void AddDynamicCVPipelinePass::runOnOperation() {
     llvm::errs() << "Add-dynamic-cv-pipeline is only supported on 91095 now.\n";
     return;
   }
+  for (unsigned attempt = 0; attempt < MAX_RETRY_TIMES; ++attempt) {
+    // restore() consumes the saved region bodies. Each attempt needs its own
+    // snapshot, taken before changing buffer counts for the retry.
+    CVPipeline::FallbackHelper fallback(moduleOp);
+    if (attempt > 0) {
+      BufferCountManager bufferCountManager(moduleOp);
+      bufferCountManager.setBufferCount(BufferCountManager::DepType::IntraCore,
+                                        2);
+      bufferCountManager.setBufferCount(BufferCountManager::DepType::InterCore,
+                                        1);
+    }
 
-  CVPipeline::FallbackHelper fallback(moduleOp);
-  PassManager pm(&getContext(), moduleOp.getOperationName());
+    // Do not reuse pass instances or partially transformed IR on retry.
+    PassManager pm(&getContext(), moduleOp.getOperationName());
+    pm.addPass(createPreCheckAvailablePass());
+    pm.addPass(createStandardizeOpPass());
+    pm.addPass(createPlanComputeBlockPass());
+    pm.addPass(createComputeBlockOptPass());
+    pm.addPass(createSplitDataflowPass());
+    pm.addPass(createAnalyzeDataFlowPass());
+    pm.addPass(createAllocMultiCachePass());
+    pm.addPass(createAddControlFlowConditionPass());
+    pm.addPass(createSeparateMemoryFromComputePass());
+    pm.addPass(createRemoveSsbufAttrPass());
 
-  pm.addPass(createPreCheckAvailablePass());
-  pm.addPass(createStandardizeOpPass());
-  pm.addPass(createPlanComputeBlockPass());
-  pm.addPass(createComputeBlockOptPass());
-  pm.addPass(createSplitDataflowPass());
-  pm.addPass(createAnalyzeDataFlowPass());
-  pm.addPass(createAllocMultiCachePass());
-  pm.addPass(createAddControlFlowConditionPass());
-  pm.addPass(createSeparateMemoryFromComputePass());
-  pm.addPass(createRemoveSsbufAttrPass());
+    auto result = runPipeline(pm, moduleOp);
+    auto errCode = getErrorCode(moduleOp);
+    if (succeeded(result) && !errCode.has_value()) {
+      LDBG("Process successfully");
+      return;
+    }
 
-  if (failed(runPipeline(pm, moduleOp)) ||
-      CVPipeline::hasFallbackAttr(moduleOp)) {
-    auto errCodeAttr =
-        moduleOp->getAttrOfType<IntegerAttr>(CVPipeline::ERRCODE_ATTR);
-    int errCode = errCodeAttr ? static_cast<int>(errCodeAttr.getInt())
-                              : CVPipeline::ERRCODE_FAILED;
-    if (!errCodeAttr) {
+    if (errCode == CVPipeline::ERRCODE_TUPLE_PRELOAD_FAILED) {
+      if (attempt + 1 < MAX_RETRY_TIMES) {
+        LDBG("Tuple-buffer failed; Retrying with tuple preload disabled.");
+        fallback.restore();
+        moduleOp->removeAttr(CVPipeline::ERRCODE_ATTR);
+        continue;
+      }
+      // Consume repeated retry requests instead of leaking code 3 to callers.
+      errCode = CVPipeline::ERRCODE_FAILED;
+    }
+
+    if (!errCode.has_value()) {
       moduleOp->emitWarning() << "[" << DEBUG_TYPE << "] "
                               << "Unexpected pass failure (no fallback attr "
                                  "set); fallback to compilation without "
                                  "dynamic CV pipeline.";
+    } else if (errCode == CVPipeline::ERRCODE_IGNORED) {
+      // This is an expected fallback: do not attach the full module IR.
+      mlir::emitWarning(moduleOp->getLoc())
+          << "[" << DEBUG_TYPE << "] "
+          << "Kernel not applicable for dynamic CV pipeline "
+             "(no matmul / already scope-optimized / unsupported "
+             "pattern); falling back to standard compilation.";
     } else {
-      if (errCode == CVPipeline::ERRCODE_IGNORED) {
-        // pipeline correctly decided this kernel is not a fit
-        // (no matmul, already scope-optimized, unsupported pattern) --
-        // just print a message, no IR.
-        mlir::emitWarning(moduleOp->getLoc())
-            << "[" << DEBUG_TYPE << "] "
-            << "Kernel not applicable for dynamic CV pipeline "
-               "(no matmul / already scope-optimized / unsupported "
-               "pattern); falling back to standard compilation.";
-      } else {
-        // a sub-pass genuinely failed (UB overflow, flag-budget
-        // exhaustion, unsupported while-condition, i1 cross-block dep, ...) --
-        // print a warning message and print module IR.
-        moduleOp->emitWarning()
-            << "[" << DEBUG_TYPE << "] " << "Pass failed (errcode=" << errCode
-            << "); "
-               "falling back to compilation without "
-               "dynamic CV pipeline.";
-      }
+      moduleOp->emitWarning()
+          << "[" << DEBUG_TYPE << "] " << "Pass failed (errcode=" << *errCode
+          << "); "
+             "falling back to compilation without "
+             "dynamic CV pipeline.";
     }
 
     fallback.restore();
     moduleOp->setAttr(CVPipeline::ERRCODE_ATTR,
-                      builder.getI32IntegerAttr(errCode));
+                      builder.getI32IntegerAttr(
+                          errCode.value_or(CVPipeline::ERRCODE_FAILED)));
     return;
   }
-
-  LDBG("Process successfully");
 }
 
 std::unique_ptr<OperationPass<ModuleOp>>


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

When a 3preload failure error code is detected, 3preload is disabled and retried, instead of directly disabling SSBuffer.
