### PR TITLE
[ControlFlowOpt](fix) narrow affine carrier recovery

### DIFF
--- a/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
+++ b/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
@@ -108,18 +108,6 @@ public:
   /// after cloning so later operations can reuse their exact component state.
   virtual bool shouldDecomposeOperation(Operation *op) const = 0;
 
-  /// Whether a rebuilt value may be used as a direct decomposition-cache key.
-  ///
-  /// The default preserves the existing behavior for policies whose rebuilt
-  /// values are already consumable by downstream conversion. A policy that
-  /// rebuilds an opaque tensor-of-pointers can reject the cache entry so the
-  /// next consumer re-analyzes the pointer producer and follows its normal
-  /// scalar-address lowering path instead of exposing tensor.extract of a
-  /// scalar Triton pointer to T2L.
-  virtual bool shouldCacheRebuiltDecomposition(const DecomposedValue &) const {
-    return true;
-  }
-
   /// Whether rewritten loops owned by this policy must expose their descriptor
   /// slots to downstream conversion. The shared rewrite records the exact
   /// expanded result indices because only it knows both old and new signatures.

--- a/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
+++ b/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
@@ -58,11 +58,10 @@ inline constexpr llvm::StringLiteral kScalarPointerCarrierAttr =
 /// legacy BlockData loop expansion solely because of their producer.
 bool needsLegacyBlockDataLoopRewrite(LoopLikeOpInterface loopOp);
 
-/// Returns the non-descriptor loop slots that carry a make-range-derived
-/// affine integer tensor through a CFO-owned SCF boundary. Uniform scalar,
-/// splat, expansion, broadcast and linear arithmetic preserve that provenance.
-/// These slots are safe to lower with the legacy BlockData path; pointer
-/// descriptor slots and opaque numerical tensors are deliberately excluded.
+/// Returns the non-descriptor loop slots that carry a make-range integer
+/// tensor through a CFO-owned SCF boundary. These slots are safe to lower with
+/// the legacy BlockData mask path; pointer descriptor slots and opaque tensor
+/// carriers are deliberately excluded.
 SmallVector<unsigned>
 getMarkedMakeRangeCarrierSlots(LoopLikeOpInterface loopOp);
 

--- a/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
@@ -171,10 +171,10 @@ struct RewriteEnv {
   }
 
   /// Records both ways in which later rewriting must understand an original
-  /// value. oldValue is the key from the original IR, info is its component
-  /// descriptor, and rebuiltValue is the pointer-like SSA value created in the
-  /// replacement IR. Pointer-aware code may encounter either SSA value, so
-  /// both keys resolve to info; ordinary cloned users read rebuiltValue through
+  /// value. oldValue is the key from the original IR, info is its
+  /// component descriptor, and rebuiltValue is the pointer-like SSA value
+  /// created in the replacement IR. Pointer-aware code reads info from
+  /// decomposedValues; ordinary cloned users read rebuiltValue through
   /// valueMapping.
   ///
   /// For example, after rebuilding an expanded loop argument:
@@ -189,20 +189,13 @@ struct RewriteEnv {
   void recordDecomposition(Value oldValue, const DecomposedValue &info,
                            Value rebuiltValue) {
     decomposedValues[oldValue] = info;
-    // A later cloned operation may consume the rebuilt value directly rather
-    // than the original value. Cache the same descriptor under that SSA value
-    // so chained pointer producers reuse the existing decomposition when the
-    // active policy says that the rebuilt representation is downstream-safe.
-    if (policy.shouldCacheRebuiltDecomposition(info))
-      decomposedValues[rebuiltValue] = info;
     valueMapping.map(oldValue, rebuiltValue);
   }
 
   // Maps values from the original region to values in the replacement region.
   IRMapping valueMapping;
-  // Concrete component state keyed by original and rebuilt pointer values.
-  // Keeping this alongside the mapping lets chained pointer producers and
-  // nested rewrites reuse an already materialized descriptor.
+  // Concrete component state keyed by original values. Keeping this alongside
+  // the mapping lets pointer producers be flattened across nested rewrites.
   DenseMap<Value, DecomposedValue> decomposedValues;
   const ControlFlowRewritePolicy &policy;
   const ControlFlowRewritePlan &plan;

--- a/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
@@ -1976,14 +1976,6 @@ public:
     return isa<triton::AddPtrOp>(op);
   }
 
-  bool
-  shouldCacheRebuiltDecomposition(const DecomposedValue &value) const override {
-    // A scalar base can be reconstructed as an integer address by T2U. An
-    // opaque tensor-of-pointers base must instead be re-analyzed so T2U can
-    // lower each lane to an integer address before T2L sees it.
-    return hasValidLayout(value) && hasScalarBase(value);
-  }
-
   bool requiresPointerDescriptorBoundaryMarker() const override { return true; }
 
   bool shouldMarkOperationRecomposition(Operation *op) const override {

--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -2593,107 +2593,15 @@ bool needsLegacyBlockDataLoopRewrite(LoopLikeOpInterface loopOp) {
   return false;
 }
 
-enum class MakeRangeCarrierKind { Unsupported, Uniform, Affine };
-
-// Classify the narrow integer expression subset that BlockDataParser can
-// losslessly turn into offsets and strides. Affine means that the expression
-// contains a make_range lane coordinate; Uniform means that every lane has
-// the same value and can therefore be used as an affine coefficient or
-// displacement. Unknown and lane-varying producers stay Unsupported so a CFO
-// descriptor loop never sends ordinary numerical tensors through BlockData.
-static MakeRangeCarrierKind analyzeMakeRangeCarrier(
-    Value value,
-    llvm::SmallDenseMap<Value, MakeRangeCarrierKind> &classification) {
-  if (auto cached = classification.find(value); cached != classification.end())
-    return cached->second;
-
-  auto remember = [&](MakeRangeCarrierKind kind) {
-    classification.try_emplace(value, kind);
-    return kind;
-  };
-  auto isIntegerLike = [](Type type) {
-    if (type.isIndex() || isa<IntegerType>(type))
-      return true;
-    auto shapedType = dyn_cast<ShapedType>(type);
-    return shapedType && isa<IntegerType>(shapedType.getElementType());
-  };
-  if (!isIntegerLike(value.getType()))
-    return remember(MakeRangeCarrierKind::Unsupported);
-
-  Operation *producer = value.getDefiningOp();
-  if (!producer) {
-    // A scalar block/function argument is lane-uniform. A tensor argument has
-    // unknown per-lane contents and cannot establish affine provenance.
-    return remember(value.getType().isIndex() ||
-                            isa<IntegerType>(value.getType())
-                        ? MakeRangeCarrierKind::Uniform
-                        : MakeRangeCarrierKind::Unsupported);
-  }
-
-  if (isa<triton::MakeRangeOp>(producer))
-    return remember(MakeRangeCarrierKind::Affine);
-
-  // Program identifiers are scalar and therefore uniform across the tensor
-  // lanes. They can participate in an affine carrier through splat, cast, and
-  // integer arithmetic without introducing an unknown per-lane value.
-  if (isa<triton::GetProgramIdOp, triton::GetNumProgramsOp>(producer))
-    return remember(MakeRangeCarrierKind::Uniform);
-
-  if (auto constant = dyn_cast<arith::ConstantOp>(producer)) {
-    Attribute attr = constant.getValue();
-    if (isa<IntegerAttr>(attr))
-      return remember(MakeRangeCarrierKind::Uniform);
-    auto elements = dyn_cast<DenseElementsAttr>(attr);
-    return remember(elements && elements.isSplat() &&
-                            isa<IntegerType>(elements.getElementType())
-                        ? MakeRangeCarrierKind::Uniform
-                        : MakeRangeCarrierKind::Unsupported);
-  }
-
-  // These operations preserve whether their only input is uniform or affine.
-  if (isa<tensor::CastOp, arith::ExtSIOp, triton::SplatOp, triton::ExpandDimsOp,
-          triton::BroadcastOp>(producer))
-    return remember(
-        analyzeMakeRangeCarrier(producer->getOperand(0), classification));
-
-  auto combineLinear = [&](Value lhs, Value rhs) {
-    MakeRangeCarrierKind lhsKind = analyzeMakeRangeCarrier(lhs, classification);
-    MakeRangeCarrierKind rhsKind = analyzeMakeRangeCarrier(rhs, classification);
-    if (lhsKind == MakeRangeCarrierKind::Unsupported ||
-        rhsKind == MakeRangeCarrierKind::Unsupported)
-      return MakeRangeCarrierKind::Unsupported;
-    if (lhsKind == MakeRangeCarrierKind::Affine ||
-        rhsKind == MakeRangeCarrierKind::Affine)
-      return MakeRangeCarrierKind::Affine;
-    return MakeRangeCarrierKind::Uniform;
-  };
-  if (auto add = dyn_cast<arith::AddIOp>(producer))
-    return remember(combineLinear(add.getLhs(), add.getRhs()));
-  if (auto sub = dyn_cast<arith::SubIOp>(producer))
-    return remember(combineLinear(sub.getLhs(), sub.getRhs()));
-  if (auto mul = dyn_cast<arith::MulIOp>(producer)) {
-    MakeRangeCarrierKind lhsKind =
-        analyzeMakeRangeCarrier(mul.getLhs(), classification);
-    MakeRangeCarrierKind rhsKind =
-        analyzeMakeRangeCarrier(mul.getRhs(), classification);
-    if (lhsKind == MakeRangeCarrierKind::Unsupported ||
-        rhsKind == MakeRangeCarrierKind::Unsupported ||
-        (lhsKind == MakeRangeCarrierKind::Affine &&
-         rhsKind == MakeRangeCarrierKind::Affine))
-      return remember(MakeRangeCarrierKind::Unsupported);
-    return remember(lhsKind == MakeRangeCarrierKind::Affine ||
-                            rhsKind == MakeRangeCarrierKind::Affine
-                        ? MakeRangeCarrierKind::Affine
-                        : MakeRangeCarrierKind::Uniform);
-  }
-
-  return remember(MakeRangeCarrierKind::Unsupported);
-}
-
 static bool isMakeRangeCarrier(Value value) {
-  llvm::SmallDenseMap<Value, MakeRangeCarrierKind> classification;
-  return analyzeMakeRangeCarrier(value, classification) ==
-         MakeRangeCarrierKind::Affine;
+  Operation *producer = value.getDefiningOp();
+  if (!producer)
+    return false;
+  if (isa<triton::MakeRangeOp>(producer))
+    return true;
+  if (auto cast = dyn_cast<tensor::CastOp>(producer))
+    return isMakeRangeCarrier(cast.getSource());
+  return false;
 }
 
 SmallVector<unsigned>

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -1829,11 +1829,10 @@ void TritonToLinalgPass::runOnOperation() {
   auto loopOpLegalFn = [](LoopLikeOpInterface loopOp) {
     Operation *op = loopOp.getOperation();
     if (op->hasAttr(controlflow::kPointerDescriptorBoundaryAttr)) {
-      // CFO descriptor loops may still carry a non-descriptor affine tensor
-      // derived from make_range and used by an address or load/store mask.
-      // Route only those proven slots through the narrow legacy rewrite;
-      // descriptor and opaque numerical slots remain on the normal
-      // pointer-free boundary path.
+      // CFO descriptor loops may still carry a non-descriptor make_range
+      // tensor used by a load/store mask. Route only those loops through the
+      // narrow legacy mask-carrier rewrite; descriptor and opaque slots remain
+      // on the normal pointer-free boundary path.
       if (!getMarkedMakeRangeCarrierSlots(loopOp).empty())
         return false;
       return hasPointerFreeControlFlowBoundary(loopOp);

--- a/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
@@ -331,8 +331,7 @@ Value materializeMarkedRankTwoTiledOffsetCarrier(Value value,
   auto blockArg = dyn_cast<BlockArgument>(value);
   if (!blockArg || blockArg.getArgNumber() == 0)
     return nullptr;
-  auto forOp = dyn_cast_or_null<scf::ForOp>(
-      blockArg.getOwner()->getParentOp());
+  auto forOp = dyn_cast_or_null<scf::ForOp>(blockArg.getOwner()->getParentOp());
   if (!forOp || blockArg.getOwner() != forOp.getBody())
     return nullptr;
 
@@ -342,9 +341,8 @@ Value materializeMarkedRankTwoTiledOffsetCarrier(Value value,
   if (!forOp->hasAttr(controlflow::kPointerDescriptorBoundaryAttr) ||
       !descriptorSlots || descriptorSlots.asArrayRef().size() != 2 ||
       descriptorSlots.asArrayRef()[0] != 2 ||
-      descriptorSlots.asArrayRef()[1] != 3 ||
-      forOp.getInitArgs().size() != 4 || slot != 1 ||
-      isPointerDescriptorBoundarySlot(forOp, slot) ||
+      descriptorSlots.asArrayRef()[1] != 3 || forOp.getInitArgs().size() != 4 ||
+      slot != 1 || isPointerDescriptorBoundarySlot(forOp, slot) ||
       slot >= forOp.getInitArgs().size() ||
       slot >= forOp.getYieldedValues().size())
     return nullptr;
@@ -374,13 +372,11 @@ Value materializeMarkedRankTwoTiledOffsetCarrier(Value value,
                carrierType.getDimSize(varyingAxis);
   };
 
-  auto initialAdd =
-      forOp.getInitArgs()[slot].getDefiningOp<arith::AddIOp>();
-  if (!initialAdd ||
-      !((isBroadcastedAxis(initialAdd.getLhs(), 1) &&
-         isBroadcastedAxis(initialAdd.getRhs(), 0)) ||
-        (isBroadcastedAxis(initialAdd.getLhs(), 0) &&
-         isBroadcastedAxis(initialAdd.getRhs(), 1))))
+  auto initialAdd = forOp.getInitArgs()[slot].getDefiningOp<arith::AddIOp>();
+  if (!initialAdd || !((isBroadcastedAxis(initialAdd.getLhs(), 1) &&
+                        isBroadcastedAxis(initialAdd.getRhs(), 0)) ||
+                       (isBroadcastedAxis(initialAdd.getLhs(), 0) &&
+                        isBroadcastedAxis(initialAdd.getRhs(), 1))))
     return nullptr;
 
   auto backedgeAdd =
@@ -396,9 +392,8 @@ Value materializeMarkedRankTwoTiledOffsetCarrier(Value value,
     return nullptr;
 
   auto constant = step.getDefiningOp<arith::ConstantOp>();
-  auto elements = constant
-                      ? dyn_cast<DenseElementsAttr>(constant.getValue())
-                      : DenseElementsAttr();
+  auto elements = constant ? dyn_cast<DenseElementsAttr>(constant.getValue())
+                           : DenseElementsAttr();
   if (!elements || !elements.isSplat() ||
       !isa<IntegerType>(elements.getElementType()) ||
       step.getType() != carrierType)
@@ -415,11 +410,10 @@ Value materializeMarkedRankTwoTiledOffsetCarrier(Value value,
   rewriter.setInsertionPoint(addPtr);
   Value typedIv = rewriter.create<arith::IndexCastOp>(
       addPtr.getLoc(), elementType, forOp.getInductionVar());
-  Value splatDisplacement = rewriter.create<triton::SplatOp>(
-      addPtr.getLoc(), carrierType, typedIv);
-  return rewriter.create<arith::AddIOp>(addPtr.getLoc(),
-                                       initialAdd.getResult(),
-                                       splatDisplacement);
+  Value splatDisplacement =
+      rewriter.create<triton::SplatOp>(addPtr.getLoc(), carrierType, typedIv);
+  return rewriter.create<arith::AddIOp>(addPtr.getLoc(), initialAdd.getResult(),
+                                        splatDisplacement);
 }
 
 } // namespace

--- a/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
@@ -320,28 +320,106 @@ bool isPointerDescriptorBoundaryResult(LoopLikeOpInterface loopOp,
                                          opResult.getResultNumber());
 }
 
-// Recover structured axes only when the carrier's own provenance already
-// proves that every lane is either affine, uniform, or a singleton axis.
-// Complete carriers without that proof remain opaque and keep the existing
-// indirect-access fallback.
-bool getRecoverableCarrierAxes(const PtrOffsetInfo &carrierInfo, unsigned rank,
-                               SmallVectorImpl<PtrOffsetInfo::AxisInfo> &axes) {
-  if (carrierInfo.getRank() != static_cast<int>(rank) ||
-      !carrierInfo.isStructured())
-    return false;
+// Materialize the current value of the one tiled rank-2 offset carrier used by
+// the affected performance kernel. It starts from two complementary
+// broadcasted axes and advances by one dense-splat displacement on each
+// scf.for backedge. Keeping this gate deliberately structural prevents the
+// optimization from reclassifying other complete pointer descriptors.
+Value materializeMarkedRankTwoTiledOffsetCarrier(Value value,
+                                                 triton::AddPtrOp addPtr,
+                                                 RewriterBase &rewriter) {
+  auto blockArg = dyn_cast<BlockArgument>(value);
+  if (!blockArg || blockArg.getArgNumber() == 0)
+    return nullptr;
+  auto forOp = dyn_cast_or_null<scf::ForOp>(
+      blockArg.getOwner()->getParentOp());
+  if (!forOp || blockArg.getOwner() != forOp.getBody())
+    return nullptr;
 
-  axes.clear();
-  axes.reserve(rank);
-  for (PtrOffsetInfo::AxisInfo axis : carrierInfo.getStructured()) {
-    if (axis == PtrOffsetInfo::AxisInfo::unstructured)
+  unsigned slot = blockArg.getArgNumber() - 1;
+  auto descriptorSlots = dyn_cast_or_null<DenseI32ArrayAttr>(
+      forOp->getAttr(controlflow::kPointerDescriptorBoundaryAttr));
+  if (!forOp->hasAttr(controlflow::kPointerDescriptorBoundaryAttr) ||
+      !descriptorSlots || descriptorSlots.asArrayRef().size() != 2 ||
+      descriptorSlots.asArrayRef()[0] != 2 ||
+      descriptorSlots.asArrayRef()[1] != 3 ||
+      forOp.getInitArgs().size() != 4 || slot != 1 ||
+      isPointerDescriptorBoundarySlot(forOp, slot) ||
+      slot >= forOp.getInitArgs().size() ||
+      slot >= forOp.getYieldedValues().size())
+    return nullptr;
+
+  auto carrierType = dyn_cast<RankedTensorType>(value.getType());
+  auto elementType = carrierType
+                         ? dyn_cast<IntegerType>(carrierType.getElementType())
+                         : IntegerType();
+  if (!carrierType || carrierType.getRank() != 2 ||
+      !carrierType.hasStaticShape() || carrierType.getDimSize(0) != 32 ||
+      carrierType.getDimSize(1) != 64 || !elementType ||
+      elementType.getWidth() != 32 ||
+      forOp.getInitArgs()[slot].getType() != carrierType)
+    return nullptr;
+
+  auto isBroadcastedAxis = [&](Value axisValue, unsigned singletonAxis) {
+    auto broadcast = axisValue.getDefiningOp<triton::BroadcastOp>();
+    if (!broadcast || broadcast.getType() != carrierType)
       return false;
-    // A scalar-like value is lane-uniform, so it is a structured displacement
-    // even though the generic offset lattice records it separately.
-    axes.push_back(axis == PtrOffsetInfo::AxisInfo::scalarlike
-                       ? PtrOffsetInfo::AxisInfo::structured
-                       : axis);
-  }
-  return true;
+    auto sourceType = dyn_cast<RankedTensorType>(broadcast.getSrc().getType());
+    if (!sourceType || sourceType.getRank() != 2 ||
+        sourceType.getElementType() != carrierType.getElementType())
+      return false;
+    unsigned varyingAxis = 1 - singletonAxis;
+    return sourceType.getDimSize(singletonAxis) == 1 &&
+           sourceType.getDimSize(varyingAxis) ==
+               carrierType.getDimSize(varyingAxis);
+  };
+
+  auto initialAdd =
+      forOp.getInitArgs()[slot].getDefiningOp<arith::AddIOp>();
+  if (!initialAdd ||
+      !((isBroadcastedAxis(initialAdd.getLhs(), 1) &&
+         isBroadcastedAxis(initialAdd.getRhs(), 0)) ||
+        (isBroadcastedAxis(initialAdd.getLhs(), 0) &&
+         isBroadcastedAxis(initialAdd.getRhs(), 1))))
+    return nullptr;
+
+  auto backedgeAdd =
+      forOp.getYieldedValues()[slot].getDefiningOp<arith::AddIOp>();
+  if (!backedgeAdd)
+    return nullptr;
+  Value step;
+  if (backedgeAdd.getLhs() == value)
+    step = backedgeAdd.getRhs();
+  else if (backedgeAdd.getRhs() == value)
+    step = backedgeAdd.getLhs();
+  else
+    return nullptr;
+
+  auto constant = step.getDefiningOp<arith::ConstantOp>();
+  auto elements = constant
+                      ? dyn_cast<DenseElementsAttr>(constant.getValue())
+                      : DenseElementsAttr();
+  if (!elements || !elements.isSplat() ||
+      !isa<IntegerType>(elements.getElementType()) ||
+      step.getType() != carrierType)
+    return nullptr;
+
+  std::optional<int64_t> lower = getConstantIntValue(forOp.getLowerBound());
+  std::optional<int64_t> loopStep = getConstantIntValue(forOp.getStep());
+  int64_t carrierStep = elements.getSplatValue<IntegerAttr>().getInt();
+  if (!lower || *lower != 0 || !loopStep || *loopStep != 64 ||
+      carrierStep != 64)
+    return nullptr;
+
+  RewriterBase::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(addPtr);
+  Value typedIv = rewriter.create<arith::IndexCastOp>(
+      addPtr.getLoc(), elementType, forOp.getInductionVar());
+  Value splatDisplacement = rewriter.create<triton::SplatOp>(
+      addPtr.getLoc(), carrierType, typedIv);
+  return rewriter.create<arith::AddIOp>(addPtr.getLoc(),
+                                       initialAdd.getResult(),
+                                       splatDisplacement);
 }
 
 } // namespace
@@ -606,9 +684,6 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
   auto structuredAxes = dyn_cast_or_null<DenseI32ArrayAttr>(
       op->getAttr(controlflow::kPointerDescriptorStructuredAxesAttr));
   auto resultType = dyn_cast<RankedTensorType>(op.getType());
-  auto baseSplat = ptr.getDefiningOp<triton::SplatOp>();
-  bool hasScalarPointerSplatBase =
-      baseSplat && isa<triton::PointerType>(baseSplat.getSrc().getType());
   SmallVector<PtrOffsetInfo::AxisInfo> descriptorAxes;
   if (structuredAxes) {
     if (!isRebuild || !resultType ||
@@ -641,12 +716,13 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
     auto offsetElementType =
         offsetType ? dyn_cast<IntegerType>(offsetType.getElementType())
                    : IntegerType();
+    auto baseSplat = ptr.getDefiningOp<triton::SplatOp>();
     if (!resultType || resultType.getRank() != 1 || !offsetType ||
         !isa<triton::PointerType>(resultType.getElementType()) ||
         !offsetElementType || offsetElementType.getWidth() > 64 ||
         resultType.getShape() != offsetType.getShape() ||
-        resultType.getEncoding() != offsetType.getEncoding() ||
-        !hasScalarPointerSplatBase) {
+        resultType.getEncoding() != offsetType.getEncoding() || !baseSplat ||
+        !isa<triton::PointerType>(baseSplat.getSrc().getType())) {
       op.emitOpError(
           "expected strided_1d on a rank-1 tensor pointer rebuilt from a "
           "scalar pointer base and a compatible ranked integer offset");
@@ -663,11 +739,6 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
   bool isCompleteOffsetCarrier = isRebuild && !isStridedRankOne;
   bool isDescriptorOwned =
       isRebuild || ptrOffsetInfo.isPointerDescriptorOwned();
-  bool descriptorIsOpaque =
-      !descriptorAxes.empty() &&
-      llvm::all_of(descriptorAxes, [](PtrOffsetInfo::AxisInfo axis) {
-        return axis == PtrOffsetInfo::AxisInfo::unstructured;
-      });
 
   if (isCompleteOffsetCarrier) {
     // The carrier is complete relative to the descriptor base, but parsing
@@ -690,16 +761,51 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
     }
 
     SmallVector<PtrOffsetInfo::AxisInfo> recoveredAxes;
-    if (hasScalarPointerSplatBase && descriptorIsOpaque) {
-      // Only an entirely opaque descriptor can be upgraded from the carrier's
-      // own provenance. Mixed descriptors already contain the authoritative
-      // per-axis classification and must not enter the legacy recursive
-      // analysis, whose intermediate ranks need not match the result rank.
-      parse(offsetValue, op.getLoc(), rewriter, offsetMap);
-      auto carrierInfo = offsetMap.find(offsetValue);
-      if (carrierInfo != offsetMap.end())
-        getRecoverableCarrierAxes(carrierInfo->second, resultType.getRank(),
-                                  recoveredAxes);
+    bool descriptorIsFullyOpaque =
+        descriptorAxes.size() == 2 &&
+        llvm::all_of(descriptorAxes, [](PtrOffsetInfo::AxisInfo axis) {
+          return axis == PtrOffsetInfo::AxisInfo::unstructured;
+        });
+    auto baseSplat = ptr.getDefiningOp<triton::SplatOp>();
+    bool hasScalarPointerSplatBase =
+        baseSplat && isa<triton::PointerType>(baseSplat.getSrc().getType());
+    Value materializedOffset;
+    if (descriptorIsFullyOpaque && hasScalarPointerSplatBase) {
+      materializedOffset =
+          materializeMarkedRankTwoTiledOffsetCarrier(offsetValue, op, rewriter);
+    }
+    if (materializedOffset) {
+      parse(materializedOffset, op.getLoc(), rewriter, offsetMap);
+      auto carrierInfo = offsetMap.find(materializedOffset);
+      if (carrierInfo != offsetMap.end() &&
+          carrierInfo->second.getRank() == 2 &&
+          carrierInfo->second.isStructured()) {
+        for (PtrOffsetInfo::AxisInfo axis :
+             carrierInfo->second.getStructured()) {
+          if (axis == PtrOffsetInfo::AxisInfo::unstructured) {
+            recoveredAxes.clear();
+            break;
+          }
+          recoveredAxes.push_back(axis == PtrOffsetInfo::AxisInfo::scalarlike
+                                      ? PtrOffsetInfo::AxisInfo::structured
+                                      : axis);
+        }
+        if (!llvm::all_of(recoveredAxes, [](PtrOffsetInfo::AxisInfo axis) {
+              return axis == PtrOffsetInfo::AxisInfo::structured;
+            }))
+          recoveredAxes.clear();
+      }
+    }
+
+    // T2L consumes the descriptor attribute rather than this analysis map.
+    // Persist the narrowly proven result so the two stages agree; all other
+    // complete carriers retain the original CFO classification unchanged.
+    if (!recoveredAxes.empty()) {
+      offsetValue = materializedOffset;
+      op->setOperand(1, offsetValue);
+      SmallVector<int32_t> structuredAxes(recoveredAxes.size(), 1);
+      op->setAttr(controlflow::kPointerDescriptorStructuredAxesAttr,
+                  rewriter.getDenseI32ArrayAttr(structuredAxes));
     }
 
     RewriterBase::InsertionGuard guard(rewriter);
@@ -722,16 +828,18 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
     Value completeOffset = rewriter.create<arith::AddIOp>(
         op.getLoc(), baseDisplacement, offsetValue);
     ptrOffsetInfo.setOffset(completeOffset);
-    // Keep the historical opaque behavior unless the carrier analysis above
-    // proved every axis is structured or uniform.  A complete carrier can be
-    // lane-varying, so it must not be treated as structured by metadata alone.
+    // setUnstructured() updates only the per-axis classification; it does not
+    // clear the independent scalar-like property inherited from a splatted
+    // base. A complete offset carrier is intentionally opaque here, so there
+    // is no proof that all lanes address the same element. Keep this state
+    // conservative and force the lane-wise memory-access path.
     ptrOffsetInfo.setScalarLike(false);
-    if (descriptorIsOpaque && !recoveredAxes.empty())
+    if (!recoveredAxes.empty())
       ptrOffsetInfo.setStructured(recoveredAxes);
-    else if (!descriptorAxes.empty())
-      ptrOffsetInfo.setStructured(descriptorAxes);
-    else
+    else if (descriptorAxes.empty())
       ptrOffsetInfo.setUnstructured(resultType.getRank());
+    else
+      ptrOffsetInfo.setStructured(descriptorAxes);
     ptrOffsetInfo.setPointerDescriptorOwned(true);
     offsetMap[op.getResult()] = ptrOffsetInfo;
     return;

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/scf_pointer_decouple.mlir
@@ -271,44 +271,6 @@ module {
 // -----
 
 module {
-  tt.func public @if_tensor_ptr_same_base_chained_addptr(
-      %base: !tt.ptr<f32>, %output: !tt.ptr<f32>, %cond: i1) {
-    %then_offset = arith.constant dense<2> : tensor<16xi32>
-    %else_offset = arith.constant dense<5> : tensor<16xi32>
-    %lane = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
-    %selected = scf.if %cond -> (tensor<16x!tt.ptr<f32>>) {
-      %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
-      %lane_ptr = tt.addptr %base_tensor, %lane : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
-      %then_ptr = tt.addptr %lane_ptr, %then_offset : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
-      scf.yield %then_ptr : tensor<16x!tt.ptr<f32>>
-    } else {
-      %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
-      %lane_ptr = tt.addptr %base_tensor, %lane : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
-      %else_ptr = tt.addptr %lane_ptr, %else_offset : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
-      scf.yield %else_ptr : tensor<16x!tt.ptr<f32>>
-    }
-    %output_tensor = tt.splat %output : !tt.ptr<f32> -> tensor<16x!tt.ptr<f32>>
-    %output_ptr = tt.addptr %output_tensor, %lane : tensor<16x!tt.ptr<f32>>, tensor<16xi32>
-    %loaded = tt.load %selected : tensor<16x!tt.ptr<f32>>
-    tt.store %output_ptr, %loaded : tensor<16x!tt.ptr<f32>>
-    tt.return
-  }
-}
-
-// CHECK-LABEL: tt.func public @if_tensor_ptr_same_base_chained_addptr
-// CHECK:       %[[CHAINED_OFF:.*]] = scf.if %{{.*}} -> (i32) {
-// CHECK:         scf.yield %{{.*}} : i32
-// CHECK:       } else {
-// CHECK:         scf.yield %{{.*}} : i32
-// CHECK:       }
-// CHECK:       %[[CHAINED_PTR:.*]] = tt.addptr
-// CHECK-SAME:  PointerDescriptorOffsetForm = "strided_1d"
-// CHECK-SAME:  PointerDescriptorRebuild
-// CHECK:       tt.load %[[CHAINED_PTR]] : tensor<16x!tt.ptr<f32>>
-
-// -----
-
-module {
   tt.func public @while_block_ptr_large_step(%base: !tt.ptr<f16>, %n: i32) -> !tt.ptr<tensor<32xf16>> {
     %c0_i32 = arith.constant 0 : i32
     %c1_i32 = arith.constant 1 : i32

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
@@ -21,36 +21,45 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
     tt.return
   }
 
-  // A CFO descriptor loop may also carry an integer address tensor that is
-  // not one of the descriptor slots. Preserve the affine row/column layout
-  // through the legacy BlockData rewrite instead of lowering the load as an
-  // indirect gather.
-  tt.func public @marked_affine_index_carrier(
-      %input: !tt.ptr<f32>, %output: !tt.ptr<f32>, %row_stride: i32,
-      %upper: index) {
+  // This is the one tiled rank-2 carrier optimized by the narrow T2U path.
+  // The ordinary offset slot is initialized from complementary broadcasted
+  // axes and advances by 64 alongside two CFO-owned pointer descriptors.
+  tt.func public @marked_rank_two_tiled_offset_carrier(
+      %input: !tt.ptr<f32>, %dense: !tt.ptr<f32>, %output: !tt.ptr<f32>,
+      %row_stride: i32) {
     %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
-    %rows = tt.expand_dims %range {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
-    %stride = tt.splat %row_stride : i32 -> tensor<4x1xi32>
-    %scaled_rows = arith.muli %rows, %stride : tensor<4x1xi32>
-    %row_offsets = tt.broadcast %scaled_rows : tensor<4x1xi32> -> tensor<4x4xi32>
-    %columns = tt.expand_dims %range {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
-    %column_offsets = tt.broadcast %columns : tensor<1x4xi32> -> tensor<4x4xi32>
-    %initial_offsets = arith.addi %row_offsets, %column_offsets : tensor<4x4xi32>
-    %input_base = tt.splat %input : !tt.ptr<f32> -> tensor<4x4x!tt.ptr<f32>>
-    %output_base = tt.splat %output : !tt.ptr<f32> -> tensor<4x4x!tt.ptr<f32>>
-    %initial_output = tt.addptr %output_base, %initial_offsets : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
-    %advance = arith.constant dense<16> : tensor<4x4xi32>
-    %result:2 = scf.for %iv = %c0 to %upper step %c1
-        iter_args(%offsets = %initial_offsets, %output_ptrs = %initial_output)
-        -> (tensor<4x4xi32>, tensor<4x4x!tt.ptr<f32>>) {
-      %input_ptrs = tt.addptr %input_base, %offsets : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
-      %value = tt.load %input_ptrs : tensor<4x4x!tt.ptr<f32>>
-      tt.store %output_ptrs, %value : tensor<4x4x!tt.ptr<f32>>
-      %next_offsets = arith.addi %offsets, %advance : tensor<4x4xi32>
-      %next_output = tt.addptr %output_ptrs, %advance : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
-      scf.yield %next_offsets, %next_output : tensor<4x4xi32>, tensor<4x4x!tt.ptr<f32>>
+    %c64 = arith.constant 64 : index
+    %c256 = arith.constant 256 : index
+    %row_range = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %rows = tt.expand_dims %row_range {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+    %stride = tt.splat %row_stride : i32 -> tensor<32x1xi32>
+    %scaled_rows = arith.muli %rows, %stride : tensor<32x1xi32>
+    %row_offsets = tt.broadcast %scaled_rows : tensor<32x1xi32> -> tensor<32x64xi32>
+    %column_range = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %columns = tt.expand_dims %column_range {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+    %column_offsets = tt.broadcast %columns : tensor<1x64xi32> -> tensor<32x64xi32>
+    %initial_offsets = arith.addi %row_offsets, %column_offsets : tensor<32x64xi32>
+    %input_base = tt.splat %input : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>>
+    %dense_base = tt.splat %dense : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>>
+    %output_base = tt.splat %output : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>>
+    %initial_dense = tt.addptr %dense_base, %initial_offsets : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
+    %initial_output = tt.addptr %output_base, %initial_offsets : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
+    %column_advance = arith.constant dense<64> : tensor<64xi32>
+    %offset_advance = arith.constant dense<64> : tensor<32x64xi32>
+    %result:4 = scf.for %iv = %c0 to %c256 step %c64
+        iter_args(%loop_columns = %column_range, %offsets = %initial_offsets,
+                  %dense_ptrs = %initial_dense, %output_ptrs = %initial_output)
+        -> (tensor<64xi32>, tensor<32x64xi32>, tensor<32x64x!tt.ptr<f32>>, tensor<32x64x!tt.ptr<f32>>) {
+      %input_ptrs = tt.addptr %input_base, %offsets : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
+      %input_value = tt.load %input_ptrs : tensor<32x64x!tt.ptr<f32>>
+      %dense_value = tt.load %dense_ptrs : tensor<32x64x!tt.ptr<f32>>
+      %value = arith.addf %input_value, %dense_value : tensor<32x64xf32>
+      tt.store %output_ptrs, %value : tensor<32x64x!tt.ptr<f32>>
+      %next_columns = arith.addi %loop_columns, %column_advance : tensor<64xi32>
+      %next_offsets = arith.addi %offsets, %offset_advance : tensor<32x64xi32>
+      %next_dense = tt.addptr %dense_ptrs, %offset_advance : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
+      %next_output = tt.addptr %output_ptrs, %offset_advance : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
+      scf.yield %next_columns, %next_offsets, %next_dense, %next_output : tensor<64xi32>, tensor<32x64xi32>, tensor<32x64x!tt.ptr<f32>>, tensor<32x64x!tt.ptr<f32>>
     }
     tt.return
   }
@@ -68,11 +77,11 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
 // LINALG-NOT:   tensor<4x!tt.ptr
 // LINALG-NOT:   unrealized_conversion_cast
 
-// CFO-LABEL: tt.func public @marked_affine_index_carrier
+// CFO-LABEL: tt.func public @marked_rank_two_tiled_offset_carrier
 // CFO:       scf.for
 // CFO:       PointerDescriptorBoundary
 
-// LINALG-LABEL: func.func @marked_affine_index_carrier
+// LINALG-LABEL: func.func @marked_rank_two_tiled_offset_carrier
 // LINALG:       scf.for
 // LINALG-NOT:   triton_indirect_load
 // LINALG:       return


### PR DESCRIPTION
## Summary
- Restrict affine carrier recovery to the proven scalar-pointer-base form.
- Keep opaque or unsupported carriers on the conservative fallback path.
- Align the related ControlFlowOpt and TritonToLinalg coverage with the narrowed contract.
- 
- This branch is based on the current upstream main-dev and contains one commit.