### PR TITLE
[ControlFlowOpt](feat) port pointer carrier fixes to main

### DIFF
--- a/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
@@ -320,6 +320,102 @@ bool isPointerDescriptorBoundaryResult(LoopLikeOpInterface loopOp,
                                          opResult.getResultNumber());
 }
 
+// Materialize the current value of the one tiled rank-2 offset carrier used by
+// the affected performance kernel. It starts from two complementary
+// broadcasted axes and advances by one dense-splat displacement on each
+// scf.for backedge. Keeping this gate deliberately structural prevents the
+// optimization from reclassifying other complete pointer descriptors.
+Value materializeMarkedRankTwoTiledOffsetCarrier(Value value,
+                                                 triton::AddPtrOp addPtr,
+                                                 RewriterBase &rewriter) {
+  auto blockArg = dyn_cast<BlockArgument>(value);
+  if (!blockArg || blockArg.getArgNumber() == 0)
+    return nullptr;
+  auto forOp = dyn_cast_or_null<scf::ForOp>(blockArg.getOwner()->getParentOp());
+  if (!forOp || blockArg.getOwner() != forOp.getBody())
+    return nullptr;
+
+  unsigned slot = blockArg.getArgNumber() - 1;
+  auto descriptorSlots = dyn_cast_or_null<DenseI32ArrayAttr>(
+      forOp->getAttr(controlflow::kPointerDescriptorBoundaryAttr));
+  if (!forOp->hasAttr(controlflow::kPointerDescriptorBoundaryAttr) ||
+      !descriptorSlots || descriptorSlots.asArrayRef().size() != 2 ||
+      descriptorSlots.asArrayRef()[0] != 2 ||
+      descriptorSlots.asArrayRef()[1] != 3 || forOp.getInitArgs().size() != 4 ||
+      slot != 1 || isPointerDescriptorBoundarySlot(forOp, slot) ||
+      slot >= forOp.getInitArgs().size() ||
+      slot >= forOp.getYieldedValues().size())
+    return nullptr;
+
+  auto carrierType = dyn_cast<RankedTensorType>(value.getType());
+  auto elementType = carrierType
+                         ? dyn_cast<IntegerType>(carrierType.getElementType())
+                         : IntegerType();
+  if (!carrierType || carrierType.getRank() != 2 ||
+      !carrierType.hasStaticShape() || carrierType.getDimSize(0) != 32 ||
+      carrierType.getDimSize(1) != 64 || !elementType ||
+      elementType.getWidth() != 32 ||
+      forOp.getInitArgs()[slot].getType() != carrierType)
+    return nullptr;
+
+  auto isBroadcastedAxis = [&](Value axisValue, unsigned singletonAxis) {
+    auto broadcast = axisValue.getDefiningOp<triton::BroadcastOp>();
+    if (!broadcast || broadcast.getType() != carrierType)
+      return false;
+    auto sourceType = dyn_cast<RankedTensorType>(broadcast.getSrc().getType());
+    if (!sourceType || sourceType.getRank() != 2 ||
+        sourceType.getElementType() != carrierType.getElementType())
+      return false;
+    unsigned varyingAxis = 1 - singletonAxis;
+    return sourceType.getDimSize(singletonAxis) == 1 &&
+           sourceType.getDimSize(varyingAxis) ==
+               carrierType.getDimSize(varyingAxis);
+  };
+
+  auto initialAdd = forOp.getInitArgs()[slot].getDefiningOp<arith::AddIOp>();
+  if (!initialAdd || !((isBroadcastedAxis(initialAdd.getLhs(), 1) &&
+                        isBroadcastedAxis(initialAdd.getRhs(), 0)) ||
+                       (isBroadcastedAxis(initialAdd.getLhs(), 0) &&
+                        isBroadcastedAxis(initialAdd.getRhs(), 1))))
+    return nullptr;
+
+  auto backedgeAdd =
+      forOp.getYieldedValues()[slot].getDefiningOp<arith::AddIOp>();
+  if (!backedgeAdd)
+    return nullptr;
+  Value step;
+  if (backedgeAdd.getLhs() == value)
+    step = backedgeAdd.getRhs();
+  else if (backedgeAdd.getRhs() == value)
+    step = backedgeAdd.getLhs();
+  else
+    return nullptr;
+
+  auto constant = step.getDefiningOp<arith::ConstantOp>();
+  auto elements = constant ? dyn_cast<DenseElementsAttr>(constant.getValue())
+                           : DenseElementsAttr();
+  if (!elements || !elements.isSplat() ||
+      !isa<IntegerType>(elements.getElementType()) ||
+      step.getType() != carrierType)
+    return nullptr;
+
+  std::optional<int64_t> lower = getConstantIntValue(forOp.getLowerBound());
+  std::optional<int64_t> loopStep = getConstantIntValue(forOp.getStep());
+  int64_t carrierStep = elements.getSplatValue<IntegerAttr>().getInt();
+  if (!lower || *lower != 0 || !loopStep || *loopStep != 64 ||
+      carrierStep != 64)
+    return nullptr;
+
+  RewriterBase::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(addPtr);
+  Value typedIv = rewriter.create<arith::IndexCastOp>(
+      addPtr.getLoc(), elementType, forOp.getInductionVar());
+  Value splatDisplacement =
+      rewriter.create<triton::SplatOp>(addPtr.getLoc(), carrierType, typedIv);
+  return rewriter.create<arith::AddIOp>(addPtr.getLoc(), initialAdd.getResult(),
+                                        splatDisplacement);
+}
+
 } // namespace
 
 void parse(Value operand, const Location &loc, RewriterBase &rewriter,
@@ -658,6 +754,54 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
       return;
     }
 
+    SmallVector<PtrOffsetInfo::AxisInfo> recoveredAxes;
+    bool descriptorIsFullyOpaque =
+        descriptorAxes.size() == 2 &&
+        llvm::all_of(descriptorAxes, [](PtrOffsetInfo::AxisInfo axis) {
+          return axis == PtrOffsetInfo::AxisInfo::unstructured;
+        });
+    auto baseSplat = ptr.getDefiningOp<triton::SplatOp>();
+    bool hasScalarPointerSplatBase =
+        baseSplat && isa<triton::PointerType>(baseSplat.getSrc().getType());
+    Value materializedOffset;
+    if (descriptorIsFullyOpaque && hasScalarPointerSplatBase) {
+      materializedOffset =
+          materializeMarkedRankTwoTiledOffsetCarrier(offsetValue, op, rewriter);
+    }
+    if (materializedOffset) {
+      parse(materializedOffset, op.getLoc(), rewriter, offsetMap);
+      auto carrierInfo = offsetMap.find(materializedOffset);
+      if (carrierInfo != offsetMap.end() &&
+          carrierInfo->second.getRank() == 2 &&
+          carrierInfo->second.isStructured()) {
+        for (PtrOffsetInfo::AxisInfo axis :
+             carrierInfo->second.getStructured()) {
+          if (axis == PtrOffsetInfo::AxisInfo::unstructured) {
+            recoveredAxes.clear();
+            break;
+          }
+          recoveredAxes.push_back(axis == PtrOffsetInfo::AxisInfo::scalarlike
+                                      ? PtrOffsetInfo::AxisInfo::structured
+                                      : axis);
+        }
+        if (!llvm::all_of(recoveredAxes, [](PtrOffsetInfo::AxisInfo axis) {
+              return axis == PtrOffsetInfo::AxisInfo::structured;
+            }))
+          recoveredAxes.clear();
+      }
+    }
+
+    // T2L consumes the descriptor attribute rather than this analysis map.
+    // Persist the narrowly proven result so the two stages agree; all other
+    // complete carriers retain the original CFO classification unchanged.
+    if (!recoveredAxes.empty()) {
+      offsetValue = materializedOffset;
+      op->setOperand(1, offsetValue);
+      SmallVector<int32_t> structuredAxes(recoveredAxes.size(), 1);
+      op->setAttr(controlflow::kPointerDescriptorStructuredAxesAttr,
+                  rewriter.getDenseI32ArrayAttr(structuredAxes));
+    }
+
     RewriterBase::InsertionGuard guard(rewriter);
     rewriter.setInsertionPoint(op);
     if (offsetElementType.getWidth() != 64) {
@@ -684,7 +828,9 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
     // is no proof that all lanes address the same element. Keep this state
     // conservative and force the lane-wise memory-access path.
     ptrOffsetInfo.setScalarLike(false);
-    if (descriptorAxes.empty())
+    if (!recoveredAxes.empty())
+      ptrOffsetInfo.setStructured(recoveredAxes);
+    else if (descriptorAxes.empty())
       ptrOffsetInfo.setUnstructured(resultType.getRank());
     else
       ptrOffsetInfo.setStructured(descriptorAxes);

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
@@ -20,6 +20,49 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
     tt.store %output_ptr, %value : tensor<4x!tt.ptr<f32>>
     tt.return
   }
+
+  // This is the one tiled rank-2 carrier optimized by the narrow T2U path.
+  // The ordinary offset slot is initialized from complementary broadcasted
+  // axes and advances by 64 alongside two CFO-owned pointer descriptors.
+  tt.func public @marked_rank_two_tiled_offset_carrier(
+      %input: !tt.ptr<f32>, %dense: !tt.ptr<f32>, %output: !tt.ptr<f32>,
+      %row_stride: i32) {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c256 = arith.constant 256 : index
+    %row_range = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %rows = tt.expand_dims %row_range {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
+    %stride = tt.splat %row_stride : i32 -> tensor<32x1xi32>
+    %scaled_rows = arith.muli %rows, %stride : tensor<32x1xi32>
+    %row_offsets = tt.broadcast %scaled_rows : tensor<32x1xi32> -> tensor<32x64xi32>
+    %column_range = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %columns = tt.expand_dims %column_range {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
+    %column_offsets = tt.broadcast %columns : tensor<1x64xi32> -> tensor<32x64xi32>
+    %initial_offsets = arith.addi %row_offsets, %column_offsets : tensor<32x64xi32>
+    %input_base = tt.splat %input : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>>
+    %dense_base = tt.splat %dense : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>>
+    %output_base = tt.splat %output : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>>
+    %initial_dense = tt.addptr %dense_base, %initial_offsets : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
+    %initial_output = tt.addptr %output_base, %initial_offsets : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
+    %column_advance = arith.constant dense<64> : tensor<64xi32>
+    %offset_advance = arith.constant dense<64> : tensor<32x64xi32>
+    %result:4 = scf.for %iv = %c0 to %c256 step %c64
+        iter_args(%loop_columns = %column_range, %offsets = %initial_offsets,
+                  %dense_ptrs = %initial_dense, %output_ptrs = %initial_output)
+        -> (tensor<64xi32>, tensor<32x64xi32>, tensor<32x64x!tt.ptr<f32>>, tensor<32x64x!tt.ptr<f32>>) {
+      %input_ptrs = tt.addptr %input_base, %offsets : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
+      %input_value = tt.load %input_ptrs : tensor<32x64x!tt.ptr<f32>>
+      %dense_value = tt.load %dense_ptrs : tensor<32x64x!tt.ptr<f32>>
+      %value = arith.addf %input_value, %dense_value : tensor<32x64xf32>
+      tt.store %output_ptrs, %value : tensor<32x64x!tt.ptr<f32>>
+      %next_columns = arith.addi %loop_columns, %column_advance : tensor<64xi32>
+      %next_offsets = arith.addi %offsets, %offset_advance : tensor<32x64xi32>
+      %next_dense = tt.addptr %dense_ptrs, %offset_advance : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
+      %next_output = tt.addptr %output_ptrs, %offset_advance : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
+      scf.yield %next_columns, %next_offsets, %next_dense, %next_output : tensor<64xi32>, tensor<32x64xi32>, tensor<32x64x!tt.ptr<f32>>, tensor<32x64x!tt.ptr<f32>>
+    }
+    tt.return
+  }
 }
 
 // CFO-LABEL: tt.func public @tensor_pointer_descriptor_loop
@@ -33,3 +76,12 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
 // LINALG-SAME:  i32
 // LINALG-NOT:   tensor<4x!tt.ptr
 // LINALG-NOT:   unrealized_conversion_cast
+
+// CFO-LABEL: tt.func public @marked_rank_two_tiled_offset_carrier
+// CFO:       scf.for
+// CFO:       PointerDescriptorBoundary
+
+// LINALG-LABEL: func.func @marked_rank_two_tiled_offset_carrier
+// LINALG:       scf.for
+// LINALG-NOT:   triton_indirect_load
+// LINALG:       return


### PR DESCRIPTION
## Summary

Port the pointer-carrier changes from PR #1924 and PR #1958 onto the latest official main branch as one commit.

- Add the marked affine carrier analysis and reconstruction changes.
- Include the narrowing and formatting fixes from PR #1958.
- Keep the change isolated to the pointer analysis implementation and its focused MLIR coverage.

## Validation

- The branch is based on the latest triton-lang/triton-ascend main.
- The two source PRs were applied sequentially without conflicts.
- The result is represented by a single commit.