### PR TITLE
[backend](fix) remove hfusion multiple-consumer option

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -734,12 +734,6 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
         if vf_merge_level is not None:
             _compile_option_list += [f"--enable-vf-merge-level={vf_merge_level}"]
 
-        hfusion_enable_multiple_consumer_fusion = metadata["hfusion_enable_multiple_consumer_fusion"]
-        if hfusion_enable_multiple_consumer_fusion:
-            _compile_option_list += [
-                f"--hfusion-enable-multiple-consumer-fusion={hfusion_enable_multiple_consumer_fusion}"
-            ]
-
         plan_memory_strategy = metadata["plan_memory_strategy"]
         if plan_memory_strategy is not None:
             _compile_option_list += [f"--plan-memory-strategy={plan_memory_strategy}"]
@@ -1084,7 +1078,6 @@ class NPUOptions:
     enable_vf_fusion: bool = None
     enable_dynamic_cv_pipeline: bool = None
     enable_cube_block_merge: bool = False
-    hfusion_enable_multiple_consumer_fusion: bool = False
     buf_slot_num_of_veccore: int = None
     buf_slot_num_of_crosscore: int = None
     buf_slot_num_of_gm: int = None

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -67,6 +67,7 @@ _DEPRECATED_NPU_OPTIONS = frozenset({
     "graph_optimize_ub_capacity_bytes",
     "grid_num_tiles",
     "has_auto_blockify_blacklist_op",
+    "hfusion_enable_multiple_consumer_fusion",
     "inter_cache_num",
     "intra_cache_num",
     "kernel_name",
@@ -144,6 +145,7 @@ _DEPRECATED_NPU_OPTION_DETAILS = {
     "graph_optimize_ub_capacity_bytes":
     "it is ignored; the backend derives the UB budget from the target (A2: 96 KiB, A5: 128 KiB).",
     "has_auto_blockify_blacklist_op": "it is ignored; the safety flag is derived by scanning TTIR.",
+    "hfusion_enable_multiple_consumer_fusion": "it is ignored; the removed vendor compiler control has no replacement.",
     "kernel_name": "it is ignored; the kernel name is derived from TTIR.",
     "llvm_version": "it is ignored; this option has no replacement because it had no effective consumer.",
     "mix_mode": "it is ignored; mix mode is derived from Linalg IR as internal metadata.",

--- a/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
@@ -83,8 +83,7 @@ class _FakePassManager:
 def compiler_module():
     """Load this checkout's compiler without depending on installed Ascend utils.
 
-    The test invokes only ``ttir_to_npubin`` and replaces all external tool
-    interactions below.  A tiny import-time shim keeps the source-level
+    The tests replace all external tool interactions below.  A tiny import-time shim keeps the source-level
     contract test runnable when the installed Triton wheel predates an import
     added by this checkout (for example ``_enable_msdebug``).
     """
@@ -645,6 +644,66 @@ def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
         assert Path(command[-1]).name == "kernel", case
 
 
+def test_91095_compile_argv_omits_removed_multiple_consumer_option(compiler_module, monkeypatch):
+    commands = []
+
+    class FakeNPUUtils:
+
+        def has_device_limit(self):
+            return False
+
+    def run_bisheng(command, **_kwargs):
+        commands.append(list(command))
+        Path(command[command.index("-o") + 1] + ".o").write_bytes(b"npubin")
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    metadata = {
+        "vf_fusion_mode": None,
+        "enable_preload": None,
+        "disable_tightly_coupled_buffer_reuse": False,
+        "enable_hivm_auto_cv_balance": None,
+        "sync_solver": None,
+        "unit_flag": None,
+        "inject_barrier_all": None,
+        "inject_block_all": None,
+        "limit_auto_multi_buffer_only_for_local_buffer": None,
+        "set_workspace_multibuffer": None,
+        "limit_auto_multi_buffer_of_local_buffer": None,
+        "limit_auto_multi_buffer_buffer": None,
+        "enable_mixed_cv": None,
+        "enable_vf_fusion": None,
+        "enable_dynamic_cv_pipeline": None,
+        "enable_flatten": None,
+        "enable_auto_vectorize_v2": None,
+        "auto_vectorize_v2_max_fused_ops_num": None,
+        "prevec_max_fused_ops_num": None,
+        "disable_auto_inject_block_sync": None,
+        "bitcodes": None,
+        "has_auto_blockify_blacklist_op": False,
+        "bisheng_options": None,
+        "vf_merge_level": None,
+        "plan_memory_strategy": None,
+    }
+
+    monkeypatch.setattr(compiler_module, "_parse_linalg_metadata", lambda linalg, metadata: (linalg, metadata))
+    monkeypatch.setattr(compiler_module, "get_common_bishengir_compile_options", lambda _metadata: [])
+    monkeypatch.setattr(compiler_module, "get_auto_bind_sub_block_option", lambda _metadata: False)
+    monkeypatch.setattr(compiler_module, "NPUUtils", FakeNPUUtils)
+    monkeypatch.setattr(compiler_module, "_check_bishengir_api_change", lambda: True)
+    monkeypatch.setattr(compiler_module, "_get_npucompiler_path", lambda: ("/fake/bishengir-compile", {}))
+    monkeypatch.setattr(compiler_module.subprocess, "run", run_bisheng)
+
+    result = compiler_module.linalg_to_bin_enable_npu_compile_910_95(
+        "module {}",
+        metadata,
+        SimpleNamespace(target_arch="Ascend910_9589", debug=False),
+    )
+
+    assert result == b"npubin"
+    assert len(commands) == 1
+    assert not any(option.startswith("--hfusion-enable-multiple-consumer-fusion=") for option in commands[0])
+
+
 def test_default_compile_mode_keeps_the_91095_layout_memory_gate_prepared(compiler_module):
     """The canonical default is portable and enables the A5 template gate."""
 
@@ -699,3 +758,4 @@ def test_default_compile_mode_keeps_the_91095_layout_memory_gate_prepared(compil
 
     assert "force_simt_only" not in compiler_module.NPUOptions.__dataclass_fields__
     assert "force_simt_template" not in compiler_module.NPUOptions.__dataclass_fields__
+    assert "hfusion_enable_multiple_consumer_fusion" not in compiler_module.NPUOptions.__dataclass_fields__

--- a/third_party/ascend/unittest/pytest_ut/test_runtime_utils.py
+++ b/third_party/ascend/unittest/pytest_ut/test_runtime_utils.py
@@ -116,6 +116,17 @@ def test_deprecated_simt_option_is_routed_once_during_in_place_normalization():
     assert options == {"compile_mode": "simt_only"}
 
 
+def test_removed_hfusion_multiple_consumer_option_warns_and_is_dropped():
+    option_name = "hfusion_enable_multiple_consumer_fusion"
+    options = {option_name: True}
+
+    with pytest.warns(FutureWarning, match=rf"{option_name}.*removed vendor compiler control"):
+        normalized = utils._remove_deprecated_npu_options(options)
+
+    assert normalized == {}
+    assert options == {option_name: True}
+
+
 def test_get_byte_per_numel_supports_unsigned_integer_dtypes():
     assert runtime_utils.get_byte_per_numel(torch.uint16) == 2
     assert runtime_utils.get_byte_per_numel(torch.uint32) == 4


### PR DESCRIPTION
## Summary
- Stop forwarding the removed multiple-consumer HFusion vendor compiler flag.
- Retain the public option as deprecated input: warn once and drop it.
- Cover compile argv, option layout, and compatibility normalization.

## Validation
- `/home/w00609825/miniconda/envs/pta210_ta36_0902/bin/python -m pytest -q third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py`
- `/home/w00609825/miniconda/envs/pta210_ta36_0902_row_assert/bin/pre-commit run --from-ref origin/main-dev --to-ref HEAD`
- Source-loaded runtime-option compatibility check