### PR TITLE
[simt_costmodel](fix) pass module to set_buffer_count

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -664,15 +664,15 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
 
         _intra_val = metadata.get("intra_cache_num")
         if _intra_val is not None:
-            ascend.passes.ttir.set_buffer_count("INTRA", _intra_val)
+            ascend.passes.ttir.set_buffer_count(mod, "INTRA", _intra_val)
 
         _inter_val = metadata.get("inter_cache_num")
         if _inter_val is not None:
-            ascend.passes.ttir.set_buffer_count("INTER", _inter_val)
+            ascend.passes.ttir.set_buffer_count(mod, "INTER", _inter_val)
 
         _load_val = metadata.get("load_cache_num")
         if _load_val is not None:
-            ascend.passes.ttir.set_buffer_count("LOAD", _load_val)
+            ascend.passes.ttir.set_buffer_count(mod, "LOAD", _load_val)
 
         if opt.debug:
             # Print the equivalent triton-opt command line so the pass

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -1232,10 +1232,10 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
         # Honor the linalg-level blacklist (e.g. hivm.sync_block_lock) as well:
         # the launcher disables the grid cap for blacklisted kernels, so
         # requesting the NPUIR persistent loop without that cap would deadlock.
-        npuir_v1_enabled = (metadata.get("auto_blockify_v1_enabled", False)
-                            and not metadata.get("ta_auto_blockify_v1_materialized", False)
-                            and not metadata.get("has_auto_blockify_blacklist_op", False))
-        if npuir_v1_enabled:
+        auto_blockify_npuir_v1_enabled = (metadata.get("auto_blockify_v1_enabled", False)
+                                          and not metadata.get("ta_auto_blockify_v1_materialized", False)
+                                          and not metadata.get("has_auto_blockify_blacklist_op", False))
+        if auto_blockify_npuir_v1_enabled:
             _compile_option_list += ["--enable-auto-blockify-loop"]
             # Only mixed/local-scope routes carry a SuperBlock factor; all-SIMD
             # and ordinary SIMD keep the historical F1 autoblockify behavior.
@@ -1515,10 +1515,10 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
         # Honor the linalg-level blacklist (e.g. hivm.sync_block_lock) as well:
         # the launcher disables the grid cap for blacklisted kernels, so
         # requesting the NPUIR persistent loop without that cap would deadlock.
-        npuir_v1_enabled = (metadata.get("auto_blockify_v1_enabled", False)
-                            and not metadata.get("ta_auto_blockify_v1_materialized", False)
-                            and not metadata.get("has_auto_blockify_blacklist_op", False))
-        if npuir_v1_enabled:
+        auto_blockify_npuir_v1_enabled = (metadata.get("auto_blockify_v1_enabled", False)
+                                          and not metadata.get("ta_auto_blockify_v1_materialized", False)
+                                          and not metadata.get("has_auto_blockify_blacklist_op", False))
+        if auto_blockify_npuir_v1_enabled:
             _compile_option_list += ["--enable-auto-blockify-loop"]
             # Only mixed/local-scope routes carry a SuperBlock factor; all-SIMD
             # and ordinary SIMD keep the historical F1 autoblockify behavior.

--- a/third_party/ascend/unittest/pytest_ut/test_set_buffer_count_mod_arg.py
+++ b/third_party/ascend/unittest/pytest_ut/test_set_buffer_count_mod_arg.py
@@ -1,0 +1,77 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Regression test for the ``set_buffer_count`` module argument.
+
+``ascend.passes.ttir.set_buffer_count`` takes the MLIR module as its first
+argument.  Kernels that set ``intra_cache_num``, ``inter_cache_num`` or
+``load_cache_num`` used to call it without that argument, so compilation failed
+with::
+
+    TypeError: set_buffer_count(): incompatible function arguments.
+
+The kernel below is intentionally minimal: the only thing under test is that a
+real compilation with each buffer-count option reaches the option handling in
+``ttir_to_linalg`` without raising.
+"""
+
+import pytest
+import torch
+import torch_npu  # noqa: F401  # register the "npu" device
+
+import triton
+import triton.language as tl
+from triton.backends.ascend.utils import is_compile_on_910_95
+
+pytestmark = pytest.mark.skipif(
+    not is_compile_on_910_95(),
+    reason="buffer-count compile options are validated on Ascend 910_95 only",
+)
+
+
+@triton.jit
+def _add_kernel(x_ptr, y_ptr, out_ptr, BLOCK: tl.constexpr):
+    offsets = tl.arange(0, BLOCK)
+    x = tl.load(x_ptr + offsets)
+    y = tl.load(y_ptr + offsets)
+    tl.store(out_ptr + offsets, x + y)
+
+
+@pytest.mark.parametrize(
+    "buffer_count_kwargs",
+    [
+        pytest.param({"intra_cache_num": 3}, id="intra_cache_num"),
+        pytest.param({"inter_cache_num": 2}, id="inter_cache_num"),
+        pytest.param({"load_cache_num": 1}, id="load_cache_num"),
+    ],
+)
+def test_set_buffer_count_receives_module(monkeypatch, buffer_count_kwargs):
+    # A cached compilation would skip the compiler path that contains the
+    # regression, so force one real compilation for every parametrization.
+    monkeypatch.setenv("TRITON_ALWAYS_COMPILE", "1")
+
+    size = 256
+    x = torch.randn(size, device="npu")
+    y = torch.randn(size, device="npu")
+    out = torch.empty_like(x)
+
+    _add_kernel[(1, )](x, y, out, BLOCK=size, **buffer_count_kwargs)
+    torch.npu.synchronize()
+
+    torch.testing.assert_close(out, x + y)


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it restores the required `mod` argument in
         existing `set_buffer_count` calls.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

## Why

`ascend.passes.ttir.set_buffer_count` expects the MLIR module as the first
argument. The current calls omit `mod`, so configuring `intra_cache_num`,
`inter_cache_num`, or `load_cache_num` can fail in the backend.

## What

Pass `mod` to all three `set_buffer_count` calls:

```python
ascend.passes.ttir.set_buffer_count(mod, "INTRA", _intra_val)
ascend.passes.ttir.set_buffer_count(mod, "INTER", _inter_val)
ascend.passes.ttir.set_buffer_count(mod, "LOAD", _load_val)