### PR TITLE
[triton-dist](fix) revert distributed version update

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -499,10 +499,6 @@ void TritonToLinalgPass::convertTTFunc(triton::FuncOp func,
   if (autoBlockifyAttr)
     funcFunc->setAttr("auto_blockify_size", autoBlockifyAttr);
 
-  auto coreRatioAttr = func->getAttr("hivm.core_ratio");
-  if (coreRatioAttr)
-    funcFunc->setAttr("hivm.core_ratio", coreRatioAttr);
-
   auto &funcFuncBody = funcFunc.getBody();
   auto &funcBody = func.getBody();
 


### PR DESCRIPTION
Backport of #1991 to `release/3.2.2`.

Reverts the `hivm.core_ratio` propagation introduced by the triton-distributed version update.

`setup_ascend.py` is absent from `release/3.2.2`, so its upstream revert hunk is intentionally not included.