### PR TITLE
[DynamicCVPipeline](fix) restore disabled-op list separator

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -221,8 +221,7 @@ CoreType getCoreTypeOfSimpleOpOrCf(Operation *op) {
   if (funcOp) {
     constexpr llvm::StringLiteral regionalDisabledOps[]{
         "chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64",
-        "chunk_gated_delta_rule_fwd_kernel_h_blockdim64"
-        "backward_dkdv",
+        "chunk_gated_delta_rule_fwd_kernel_h_blockdim64", "backward_dkdv",
         "chunk_ttt_linear_fwd_kernel_h", "chunk_ttt_linear_bwd_kernel_h"};
     if (llvm::is_contained(regionalDisabledOps, funcOp.getSymName())) {
       return CoreType::UNDETERMINED;


### PR DESCRIPTION
## Summary
- restore the missing comma between the `chunk_gated_delta_rule_fwd_kernel_h_blockdim64` and `backward_dkdv` entries in `regionalDisabledOps`
- prevent adjacent C++ string literals from being concatenated, so both kernels match the disabled-op list

## Validation
- `git diff --check`
- confirmed the corrected `Utils.cpp` is byte-identical to `origin/main`

Full build was not run: this isolated source worktree has no reusable matching build artifacts.