### PR TITLE
[ControlFlowOpt](fix) stabilize mixed uniform scalar carriers

### DIFF
--- a/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
+++ b/third_party/ascend/include/TritonControlFlowOpt/ControlFlowRewrite.h
@@ -143,6 +143,18 @@ public:
     return success();
   }
 
+  /// Normalizes a descriptor used at a loop boundary. The default preserves
+  /// the generic control-flow behavior. Policies may use the exact set of
+  /// loop-carried components to retain a more compact equivalent schema that
+  /// would not be valid for an if or scope result.
+  virtual LogicalResult
+  normalizeLoopCarriedValue(DecomposedValue &value,
+                            ArrayRef<unsigned> carriedComponents,
+                            ArrayRef<Attribute> targetAttributes,
+                            OpBuilder &builder, Location loc) const {
+    return normalizeControlFlowValue(value, targetAttributes, builder, loc);
+  }
+
   virtual FailureOr<DecomposedValue>
   decompose(Value value, const ControlFlowRewriteContext &context,
             OpBuilder &builder, Location loc) const = 0;

--- a/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
+++ b/third_party/ascend/include/TritonToLinalg/BlockPtrAnalysis.h
@@ -58,13 +58,6 @@ inline constexpr llvm::StringLiteral kScalarPointerCarrierAttr =
 /// legacy BlockData loop expansion solely because of their producer.
 bool needsLegacyBlockDataLoopRewrite(LoopLikeOpInterface loopOp);
 
-/// Returns the non-descriptor loop slots that carry a make-range integer
-/// tensor through a CFO-owned SCF boundary. These slots are safe to lower with
-/// the legacy BlockData mask path; pointer descriptor slots and opaque tensor
-/// carriers are deliberately excluded.
-SmallVector<unsigned>
-getMarkedMakeRangeCarrierSlots(LoopLikeOpInterface loopOp);
-
 enum class MemAccVal { Undefined = 0, StrucMemAcc = 1, UnstrucMemAcc = 2 };
 
 /// Creates a verifier-valid HIVM pointer cast for a scalar Triton pointer

--- a/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
+++ b/third_party/ascend/include/TritonToLinalg/TritonOpConverter.h
@@ -659,15 +659,13 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     // CFO-expanded descriptor loops already carry pointer-free policy values
     // and remain structurally unchanged. This legacy BlockData rewrite is only
-    // valid for explicitly marked loops.
-    SmallVector<unsigned> markedRangeSlots = getMarkedMakeRangeCarrierSlots(op);
-    if (!op->hasAttr("UnhandledLoopOp") && markedRangeSlots.empty())
+    // valid for explicitly marked legacy loops.
+    if (!op->hasAttr("UnhandledLoopOp"))
       return failure();
     llvm::SmallDenseMap<Value, BlockData> known;
 
     rewriter.modifyOpInPlace(op, [&]() { op->removeAttr("UnhandledLoopOp"); });
-    return BlockDataParser::rewriteLoopOp(op, rewriter, known,
-                                          markedRangeSlots);
+    return BlockDataParser::rewriteLoopOp(op, rewriter, known, {});
   }
 };
 

--- a/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/ControlFlowRewrite.cpp
@@ -467,9 +467,9 @@ static LogicalResult bindLoopCarriedPointer(Value oldRegionArgument,
   FailureOr<DecomposedValue> argumentInfo =
       withReplacedComponents(pointerInfo.initInfo, pointerInfo.componentIndices,
                              *carriedComponentValues);
-  if (failed(argumentInfo) ||
-      failed(regionEnv.policy.normalizeControlFlowValue(
-          *argumentInfo, pointerInfo.resultAttributes, builder, loc)))
+  if (failed(argumentInfo) || failed(regionEnv.policy.normalizeLoopCarriedValue(
+                                  *argumentInfo, pointerInfo.componentIndices,
+                                  pointerInfo.resultAttributes, builder, loc)))
     return failure();
 
   Value rebuiltPointer =
@@ -583,8 +583,9 @@ static LogicalResult rewriteLoopTerminatorOperands(
         failed(castPlannedComponents(*nextInfo, pointerInfo->componentIndices,
                                      pointerInfo->componentTypes, builder,
                                      loc)) ||
-        failed(regionEnv.policy.normalizeControlFlowValue(
-            *nextInfo, pointerInfo->resultAttributes, builder, loc))) {
+        failed(regionEnv.policy.normalizeLoopCarriedValue(
+            *nextInfo, pointerInfo->componentIndices,
+            pointerInfo->resultAttributes, builder, loc))) {
       allOperandsValid = false;
       appendFallbackComponents(*pointerInfo);
       continue;
@@ -649,9 +650,10 @@ rebuildAndMapLoopResults(ValueRange oldResults, ValueRange newResults,
     FailureOr<DecomposedValue> resultInfo = withReplacedComponents(
         pointerInfo->initInfo, pointerInfo->componentIndices,
         *resultComponentValues);
-    if (failed(resultInfo) || failed(env.policy.normalizeControlFlowValue(
-                                  *resultInfo, pointerInfo->resultAttributes,
-                                  builder, oldResult.getLoc())))
+    if (failed(resultInfo) ||
+        failed(env.policy.normalizeLoopCarriedValue(
+            *resultInfo, pointerInfo->componentIndices,
+            pointerInfo->resultAttributes, builder, oldResult.getLoc())))
       return failure();
 
     Value rebuiltPointer =
@@ -758,8 +760,9 @@ static LogicalResult rewriteForOp(scf::ForOp forOp, OpBuilder &builder,
     FailureOr<DecomposedValue> initInfo =
         env.decomposeValue(forOp.getInitArgs()[idx], builder, forOp.getLoc());
     if (failed(initInfo) ||
-        failed(env.policy.normalizeControlFlowValue(
-            *initInfo, slot.resultAttributes, builder, forOp.getLoc())) ||
+        failed(env.policy.normalizeLoopCarriedValue(
+            *initInfo, slot.componentIndices, slot.resultAttributes, builder,
+            forOp.getLoc())) ||
         failed(castPlannedComponents(*initInfo, slot.componentIndices,
                                      slot.componentTypes, builder,
                                      forOp.getLoc())))
@@ -868,8 +871,9 @@ static LogicalResult rewriteWhileOp(scf::WhileOp whileOp, OpBuilder &builder,
     FailureOr<DecomposedValue> initInfo =
         env.decomposeValue(whileOp.getInits()[idx], builder, whileOp.getLoc());
     if (failed(initInfo) ||
-        failed(env.policy.normalizeControlFlowValue(
-            *initInfo, slot.resultAttributes, builder, whileOp.getLoc())) ||
+        failed(env.policy.normalizeLoopCarriedValue(
+            *initInfo, slot.componentIndices, slot.resultAttributes, builder,
+            whileOp.getLoc())) ||
         failed(castPlannedComponents(*initInfo, slot.componentIndices,
                                      slot.componentTypes, builder,
                                      whileOp.getLoc())))

--- a/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
+++ b/third_party/ascend/lib/TritonControlFlowOpt/TensorPtrDecompose.cpp
@@ -872,6 +872,34 @@ static bool hasAnyOpaqueAxis(ArrayRef<AxisKind> kinds) {
   return llvm::is_contained(kinds, AxisKind::Opaque);
 }
 
+static bool hasMixedAxisKinds(ArrayRef<AxisKind> kinds) {
+  return hasAnyOpaqueAxis(kinds) &&
+         llvm::is_contained(kinds, AxisKind::Structured);
+}
+
+// A pure uniform update changes every pointer lane by the same scalar amount.
+// Keeping that amount in the scalar uniform-offset component avoids turning a
+// loop update into a full residual tensor when only some axes are opaque.
+static bool isPureUniformUpdate(const AnalyzedTensorOffset &offset) {
+  return llvm::all_of(
+             offset.axisKinds,
+             [](AxisKind kind) { return kind == AxisKind::Structured; }) &&
+         llvm::all_of(offset.strides,
+                      [](const AnalyzedComponent &stride) {
+                        return isZeroIdentity(stride.identity);
+                      }) &&
+         isZeroIdentity(offset.opaqueContribution.identity);
+}
+
+static bool isPureUniformUpdate(const TensorOffsetValues &offset) {
+  return llvm::all_of(
+             offset.axisKinds,
+             [](AxisKind kind) { return kind == AxisKind::Structured; }) &&
+         llvm::all_of(offset.strides,
+                      [](Value stride) { return isConstantZero(stride); }) &&
+         isConstantZero(offset.opaqueContribution);
+}
+
 static AnalyzedTensorOffset getOpaqueAnalyzedOffset(Value value) {
   auto tensorType = cast<RankedTensorType>(value.getType());
   Type scalarType = tensorType.getElementType();
@@ -1665,10 +1693,10 @@ getTensorPointerAttributes(MLIRContext *context, bool baseIsScalar,
           getAxisKindsAttr(context, axisKinds)};
 }
 
-static LogicalResult normalizeOffsetComponents(DecomposedValue &value,
-                                               ArrayRef<AxisKind> targetKinds,
-                                               OpBuilder &builder,
-                                               Location loc) {
+static LogicalResult
+normalizeOffsetComponents(DecomposedValue &value,
+                          ArrayRef<AxisKind> targetKinds, OpBuilder &builder,
+                          Location loc, bool preserveMixedUniform = false) {
   if (!hasValidLayout(value))
     return failure();
   unsigned rank = cast<RankedTensorType>(value.originalType).getRank();
@@ -1680,6 +1708,15 @@ static LogicalResult normalizeOffsetComponents(DecomposedValue &value,
         targetKinds[axis] == AxisKind::Structured)
       return failure();
   }
+
+  // A selected loop-carried uniform offset is already a canonical scalar
+  // component. When a mixed per-axis schema is unchanged, folding that scalar
+  // back into the opaque tensor would recreate a large residual on every
+  // backedge. This fast path is enabled only by the loop-specific policy hook;
+  // if and scope normalization retain the established complete-offset schema.
+  bool sameKinds = llvm::equal(*currentKinds, targetKinds);
+  if (preserveMixedUniform && sameKinds && hasMixedAxisKinds(targetKinds))
+    return success();
 
   Value complete = materializeTensorCompleteOffsets(value, builder, loc);
   if (!complete)
@@ -1814,7 +1851,20 @@ public:
                       getStrideComponent(axis))
                 : ComponentIdentity::zero(getStrideComponent(axis))};
       }
-      if (hasAnyOpaqueAxis(resultKinds)) {
+      bool preserveMixedUniform =
+          hasMixedAxisKinds(resultKinds) && isPureUniformUpdate(*delta) &&
+          isa<RankedTensorType>(
+              result->components[getOpaqueContributionComponent(rank)].type);
+      if (preserveMixedUniform) {
+        result->components[getUniformOffsetComponent(rank)] = {
+            scalarType,
+            getAddIdentity(
+                result->components[getUniformOffsetComponent(rank)].identity,
+                delta->uniformOffset.identity, value,
+                getUniformOffsetComponent(rank))};
+        result->components[getOpaqueContributionComponent(rank)].type =
+            joinedTensorType;
+      } else if (hasAnyOpaqueAxis(resultKinds)) {
         result->components[getUniformOffsetComponent(rank)] = {
             scalarType,
             ComponentIdentity::zero(getUniformOffsetComponent(rank))};
@@ -1912,17 +1962,33 @@ public:
       if (!forwardsCurrent && !restoresInitial)
         identityChangingComponents.push_back(component);
     }
-    FailureOr<SmallVector<unsigned>> transferred =
-        filterTransferredComponentsForJoinedAxes(initial, *joinedKinds,
-                                                 identityChangingComponents);
-    if (failed(transferred))
-      return failure();
-    for (unsigned component : *transferred) {
+    unsigned rank = cast<RankedTensorType>(initial.originalType).getRank();
+    unsigned uniformComponent = getUniformOffsetComponent(rank);
+    unsigned opaqueComponent = getOpaqueContributionComponent(rank);
+    bool carriesOnlyUniform =
+        hasMixedAxisKinds(*joinedKinds) &&
+        identityChangingComponents.size() == 1 &&
+        identityChangingComponents.front() == uniformComponent &&
+        next.components[opaqueComponent].identity ==
+            regionArgument.components[opaqueComponent].identity;
+
+    SmallVector<unsigned> transferred;
+    if (carriesOnlyUniform) {
+      transferred.push_back(uniformComponent);
+    } else {
+      FailureOr<SmallVector<unsigned>> filtered =
+          filterTransferredComponentsForJoinedAxes(initial, *joinedKinds,
+                                                   identityChangingComponents);
+      if (failed(filtered))
+        return failure();
+      transferred = std::move(*filtered);
+    }
+    for (unsigned component : transferred) {
       if (failed(joinComponentTypes(initial.components[component].type,
                                     next.components[component].type)))
         return failure();
     }
-    return *transferred;
+    return transferred;
   }
 
   FailureOr<SmallVector<unsigned>>
@@ -2003,6 +2069,45 @@ public:
       kinds.push_back(static_cast<AxisKind>(rawKind));
     }
     if (failed(normalizeOffsetComponents(value, kinds, builder, loc)))
+      return failure();
+    value.attributes.assign(targetAttributes.begin(), targetAttributes.end());
+    return success();
+  }
+
+  LogicalResult normalizeLoopCarriedValue(DecomposedValue &value,
+                                          ArrayRef<unsigned> carriedComponents,
+                                          ArrayRef<Attribute> targetAttributes,
+                                          OpBuilder &builder,
+                                          Location loc) const override {
+    if (!hasValidLayout(value) || targetAttributes.size() != 2)
+      return failure();
+    auto targetBase =
+        dyn_cast<BoolAttr>(targetAttributes[kBaseIsScalarAttribute]);
+    auto targetKinds =
+        dyn_cast<DenseI32ArrayAttr>(targetAttributes[kAxisKindsAttribute]);
+    unsigned rank = cast<RankedTensorType>(value.originalType).getRank();
+    // Keep the base representation selected by analysis.  Loop normalization
+    // may use the compact mixed-uniform path only for scalar bases, but tensor
+    // bases must remain valid loop values and follow the regular normalization
+    // below instead of being rejected solely because the target attribute is
+    // false.
+    if (!targetBase || !targetKinds || targetKinds.size() != rank ||
+        targetBase.getValue() != hasScalarBase(value))
+      return failure();
+
+    SmallVector<AxisKind> kinds;
+    for (int32_t rawKind : targetKinds.asArrayRef()) {
+      if (rawKind != static_cast<int32_t>(AxisKind::Opaque) &&
+          rawKind != static_cast<int32_t>(AxisKind::Structured))
+        return failure();
+      kinds.push_back(static_cast<AxisKind>(rawKind));
+    }
+
+    bool preserveMixedUniform =
+        hasScalarBase(value) && carriedComponents.size() == 1 &&
+        carriedComponents.front() == getUniformOffsetComponent(rank);
+    if (failed(normalizeOffsetComponents(value, kinds, builder, loc,
+                                         preserveMixedUniform)))
       return failure();
     value.attributes.assign(targetAttributes.begin(), targetAttributes.end());
     return success();
@@ -2120,6 +2225,64 @@ public:
         if (!stride)
           return failure();
         resultStrides.push_back(stride);
+      }
+
+      if (hasMixedAxisKinds(resultKinds) && isPureUniformUpdate(*delta)) {
+        auto opaqueType = dyn_cast<RankedTensorType>(
+            result->components[getOpaqueContributionComponent(rank)].getType());
+        FailureOr<Type> joinedType = getWiderIntegerLikeType(
+            result->components[getOpaqueContributionComponent(rank)].getType(),
+            delta->opaqueContribution.getType());
+        auto joinedOpaqueType = succeeded(joinedType)
+                                    ? dyn_cast<RankedTensorType>(*joinedType)
+                                    : RankedTensorType();
+        Type scalarType =
+            joinedOpaqueType ? joinedOpaqueType.getElementType() : Type();
+        FailureOr<Value> currentUniform = castIntegerLike(
+            builder, addPtr.getLoc(),
+            result->components[getUniformOffsetComponent(rank)], scalarType);
+        FailureOr<Value> deltaUniform = castIntegerLike(
+            builder, addPtr.getLoc(), delta->uniformOffset, scalarType);
+        if (opaqueType && joinedOpaqueType && succeeded(currentUniform) &&
+            succeeded(deltaUniform)) {
+          Value uniform = createIntegerAdd(builder, addPtr.getLoc(),
+                                           *currentUniform, *deltaUniform);
+          SmallVector<Value> normalizedStrides;
+          normalizedStrides.reserve(rank);
+          bool compatible = static_cast<bool>(uniform);
+          for (unsigned axis = 0; axis < rank && compatible; ++axis) {
+            FailureOr<Value> stride = castIntegerLike(
+                builder, addPtr.getLoc(), resultStrides[axis], scalarType);
+            if (failed(stride)) {
+              compatible = false;
+              break;
+            }
+            normalizedStrides.push_back(*stride);
+          }
+          Value normalizedOpaque;
+          if (compatible) {
+            FailureOr<Value> opaque = castIntegerLike(
+                builder, addPtr.getLoc(),
+                result->components[getOpaqueContributionComponent(rank)],
+                joinedOpaqueType);
+            if (failed(opaque))
+              compatible = false;
+            else
+              normalizedOpaque = *opaque;
+          }
+          if (compatible) {
+            for (unsigned axis = 0; axis < rank; ++axis)
+              result->components[getStrideComponent(axis)] =
+                  normalizedStrides[axis];
+            result->components[getOpaqueContributionComponent(rank)] =
+                normalizedOpaque;
+            result->components[getUniformOffsetComponent(rank)] = uniform;
+            result->originalType = value.getType();
+            result->attributes[kAxisKindsAttribute] =
+                getAxisKindsAttr(value.getContext(), resultKinds);
+            return *result;
+          }
+        }
       }
 
       Value currentComplete =

--- a/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/BlockPtrAnalysis.cpp
@@ -2593,56 +2593,6 @@ bool needsLegacyBlockDataLoopRewrite(LoopLikeOpInterface loopOp) {
   return false;
 }
 
-static bool isMakeRangeCarrier(Value value) {
-  Operation *producer = value.getDefiningOp();
-  if (!producer)
-    return false;
-  if (isa<triton::MakeRangeOp>(producer))
-    return true;
-  if (auto cast = dyn_cast<tensor::CastOp>(producer))
-    return isMakeRangeCarrier(cast.getSource());
-  return false;
-}
-
-SmallVector<unsigned>
-getMarkedMakeRangeCarrierSlots(LoopLikeOpInterface loopOp) {
-  SmallVector<unsigned> slots;
-  if (!loopOp || !loopOp->hasAttr(controlflow::kPointerDescriptorBoundaryAttr))
-    return slots;
-
-  auto marker = dyn_cast<DenseI32ArrayAttr>(
-      loopOp->getAttr(controlflow::kPointerDescriptorBoundaryAttr));
-  if (!marker)
-    return slots;
-
-  llvm::SmallDenseSet<unsigned> descriptorSlots;
-  for (int32_t slot : marker.asArrayRef()) {
-    if (slot >= 0)
-      descriptorSlots.insert(static_cast<unsigned>(slot));
-  }
-
-  auto isMaskOrAddressUse = [](OpOperand *use) {
-    Operation *user = use->getOwner();
-    return isa<triton::AddPtrOp>(user) ||
-           (isa<triton::LoadOp>(user) && use->getOperandNumber() == 1) ||
-           (isa<triton::StoreOp>(user) && use->getOperandNumber() == 2);
-  };
-
-  for (auto [slot, init] : llvm::enumerate(loopOp.getInits())) {
-    if (descriptorSlots.contains(slot) || !isMakeRangeCarrier(init))
-      continue;
-    auto tensorType = dyn_cast<RankedTensorType>(init.getType());
-    if (!tensorType || !tensorType.hasStaticShape())
-      continue;
-    auto elementType = dyn_cast<IntegerType>(tensorType.getElementType());
-    if (!elementType || elementType.getWidth() == 1)
-      continue;
-    if (isLoopCarriedValueUsedWithCondition(loopOp, slot, isMaskOrAddressUse))
-      slots.push_back(slot);
-  }
-  return slots;
-}
-
 // This function is util function for rewriteLoopOp that create value from data.
 // Assume data is structured, and from regionIterArg from LoopLikeOpInterface.
 //

--- a/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/TritonToLinalgPass.cpp
@@ -1829,12 +1829,6 @@ void TritonToLinalgPass::runOnOperation() {
   auto loopOpLegalFn = [](LoopLikeOpInterface loopOp) {
     Operation *op = loopOp.getOperation();
     if (op->hasAttr(controlflow::kPointerDescriptorBoundaryAttr)) {
-      // CFO descriptor loops may still carry a non-descriptor make_range
-      // tensor used by a load/store mask. Route only those loops through the
-      // narrow legacy mask-carrier rewrite; descriptor and opaque slots remain
-      // on the normal pointer-free boundary path.
-      if (!getMarkedMakeRangeCarrierSlots(loopOp).empty())
-        return false;
       return hasPointerFreeControlFlowBoundary(loopOp);
     }
     return !op->hasAttr("UnhandledLoopOp");
@@ -1869,12 +1863,11 @@ void TritonToLinalgPass::runOnOperation() {
     // that its init is produced by reinterpret_cast does not make it BlockData.
     bool hasExpandedPointerDescriptor =
         op->hasAttr(mlir::triton::controlflow::kPointerDescriptorBoundaryAttr);
-    auto markedRangeSlots = getMarkedMakeRangeCarrierSlots(loopOp);
     if (!op->hasAttr("ExtractedLoadOrStore") &&
-        (needsLegacyBlockDataLoopRewrite(loopOp) || !markedRangeSlots.empty()))
+        needsLegacyBlockDataLoopRewrite(loopOp))
       op->setAttr("UnhandledLoopOp", UnitAttr::get(op->getContext()));
 
-    if (hasExpandedPointerDescriptor && markedRangeSlots.empty())
+    if (hasExpandedPointerDescriptor)
       return;
 
     for (auto res : loopOp->getResults()) {

--- a/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
+++ b/third_party/ascend/lib/TritonToUnstructure/OffsetAnalysis.cpp
@@ -320,14 +320,13 @@ bool isPointerDescriptorBoundaryResult(LoopLikeOpInterface loopOp,
                                          opResult.getResultNumber());
 }
 
-// Materialize the current value of the one tiled rank-2 offset carrier used by
-// the affected performance kernel. It starts from two complementary
-// broadcasted axes and advances by one dense-splat displacement on each
-// scf.for backedge. Keeping this gate deliberately structural prevents the
-// optimization from reclassifying other complete pointer descriptors.
-Value materializeMarkedRankTwoTiledOffsetCarrier(Value value,
-                                                 triton::AddPtrOp addPtr,
-                                                 RewriterBase &rewriter) {
+// Materialize the current value of an ordinary tensor offset carried beside a
+// CFO pointer descriptor. T2L cannot recover layout from an scf.for block
+// argument, but it can analyze the equivalent affine expression. Keep this
+// deliberately narrow: the backedge must be an additive, constant-splat
+// recurrence, and the carrier slot itself must not belong to the descriptor.
+Value materializeAffineForOffsetCarrier(Value value, triton::AddPtrOp addPtr,
+                                        RewriterBase &rewriter) {
   auto blockArg = dyn_cast<BlockArgument>(value);
   if (!blockArg || blockArg.getArgNumber() == 0)
     return nullptr;
@@ -336,13 +335,8 @@ Value materializeMarkedRankTwoTiledOffsetCarrier(Value value,
     return nullptr;
 
   unsigned slot = blockArg.getArgNumber() - 1;
-  auto descriptorSlots = dyn_cast_or_null<DenseI32ArrayAttr>(
-      forOp->getAttr(controlflow::kPointerDescriptorBoundaryAttr));
   if (!forOp->hasAttr(controlflow::kPointerDescriptorBoundaryAttr) ||
-      !descriptorSlots || descriptorSlots.asArrayRef().size() != 2 ||
-      descriptorSlots.asArrayRef()[0] != 2 ||
-      descriptorSlots.asArrayRef()[1] != 3 || forOp.getInitArgs().size() != 4 ||
-      slot != 1 || isPointerDescriptorBoundarySlot(forOp, slot) ||
+      isPointerDescriptorBoundarySlot(forOp, slot) ||
       slot >= forOp.getInitArgs().size() ||
       slot >= forOp.getYieldedValues().size())
     return nullptr;
@@ -351,69 +345,68 @@ Value materializeMarkedRankTwoTiledOffsetCarrier(Value value,
   auto elementType = carrierType
                          ? dyn_cast<IntegerType>(carrierType.getElementType())
                          : IntegerType();
-  if (!carrierType || carrierType.getRank() != 2 ||
-      !carrierType.hasStaticShape() || carrierType.getDimSize(0) != 32 ||
-      carrierType.getDimSize(1) != 64 || !elementType ||
-      elementType.getWidth() != 32 ||
+  if (!carrierType || !elementType || elementType.getWidth() > 64 ||
       forOp.getInitArgs()[slot].getType() != carrierType)
-    return nullptr;
-
-  auto isBroadcastedAxis = [&](Value axisValue, unsigned singletonAxis) {
-    auto broadcast = axisValue.getDefiningOp<triton::BroadcastOp>();
-    if (!broadcast || broadcast.getType() != carrierType)
-      return false;
-    auto sourceType = dyn_cast<RankedTensorType>(broadcast.getSrc().getType());
-    if (!sourceType || sourceType.getRank() != 2 ||
-        sourceType.getElementType() != carrierType.getElementType())
-      return false;
-    unsigned varyingAxis = 1 - singletonAxis;
-    return sourceType.getDimSize(singletonAxis) == 1 &&
-           sourceType.getDimSize(varyingAxis) ==
-               carrierType.getDimSize(varyingAxis);
-  };
-
-  auto initialAdd = forOp.getInitArgs()[slot].getDefiningOp<arith::AddIOp>();
-  if (!initialAdd || !((isBroadcastedAxis(initialAdd.getLhs(), 1) &&
-                        isBroadcastedAxis(initialAdd.getRhs(), 0)) ||
-                       (isBroadcastedAxis(initialAdd.getLhs(), 0) &&
-                        isBroadcastedAxis(initialAdd.getRhs(), 1))))
     return nullptr;
 
   auto backedgeAdd =
       forOp.getYieldedValues()[slot].getDefiningOp<arith::AddIOp>();
   if (!backedgeAdd)
     return nullptr;
-  Value step;
+  Value carrierStep;
   if (backedgeAdd.getLhs() == value)
-    step = backedgeAdd.getRhs();
+    carrierStep = backedgeAdd.getRhs();
   else if (backedgeAdd.getRhs() == value)
-    step = backedgeAdd.getLhs();
+    carrierStep = backedgeAdd.getLhs();
   else
     return nullptr;
 
-  auto constant = step.getDefiningOp<arith::ConstantOp>();
+  auto constant = carrierStep.getDefiningOp<arith::ConstantOp>();
   auto elements = constant ? dyn_cast<DenseElementsAttr>(constant.getValue())
                            : DenseElementsAttr();
   if (!elements || !elements.isSplat() ||
       !isa<IntegerType>(elements.getElementType()) ||
-      step.getType() != carrierType)
-    return nullptr;
-
-  std::optional<int64_t> lower = getConstantIntValue(forOp.getLowerBound());
-  std::optional<int64_t> loopStep = getConstantIntValue(forOp.getStep());
-  int64_t carrierStep = elements.getSplatValue<IntegerAttr>().getInt();
-  if (!lower || *lower != 0 || !loopStep || *loopStep != 64 ||
-      carrierStep != 64)
+      carrierStep.getType() != carrierType)
     return nullptr;
 
   RewriterBase::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(addPtr);
-  Value typedIv = rewriter.create<arith::IndexCastOp>(
-      addPtr.getLoc(), elementType, forOp.getInductionVar());
-  Value splatDisplacement =
-      rewriter.create<triton::SplatOp>(addPtr.getLoc(), carrierType, typedIv);
-  return rewriter.create<arith::AddIOp>(addPtr.getLoc(), initialAdd.getResult(),
-                                        splatDisplacement);
+  Value iterationDistance = rewriter.create<arith::SubIOp>(
+      addPtr.getLoc(), forOp.getInductionVar(), forOp.getLowerBound());
+  Value iteration = rewriter.create<arith::DivUIOp>(
+      addPtr.getLoc(), iterationDistance, forOp.getStep());
+  Value typedIteration = rewriter.create<arith::IndexCastOp>(
+      addPtr.getLoc(), elementType, iteration);
+  Value splatIteration = rewriter.create<triton::SplatOp>(
+      addPtr.getLoc(), carrierType, typedIteration);
+  Value materializedStep =
+      rewriter.create<arith::ConstantOp>(addPtr.getLoc(), elements);
+  Value displacement = rewriter.create<arith::MulIOp>(
+      addPtr.getLoc(), splatIteration, materializedStep);
+  return rewriter.create<arith::AddIOp>(
+      addPtr.getLoc(), forOp.getInitArgs()[slot], displacement);
+}
+
+// Recover structured axes only when the carrier's own provenance proves that
+// every lane is either affine, uniform, or a singleton axis. Complete
+// carriers without that proof remain opaque and keep the existing indirect
+// access fallback.
+bool getRecoverableCarrierAxes(const PtrOffsetInfo &carrierInfo, unsigned rank,
+                               SmallVectorImpl<PtrOffsetInfo::AxisInfo> &axes) {
+  if (carrierInfo.getRank() != static_cast<int>(rank) ||
+      !carrierInfo.isStructured())
+    return false;
+
+  axes.clear();
+  axes.reserve(rank);
+  for (PtrOffsetInfo::AxisInfo axis : carrierInfo.getStructured()) {
+    if (axis == PtrOffsetInfo::AxisInfo::unstructured)
+      return false;
+    axes.push_back(axis == PtrOffsetInfo::AxisInfo::scalarlike
+                       ? PtrOffsetInfo::AxisInfo::structured
+                       : axis);
+  }
+  return true;
 }
 
 } // namespace
@@ -678,6 +671,9 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
   auto structuredAxes = dyn_cast_or_null<DenseI32ArrayAttr>(
       op->getAttr(controlflow::kPointerDescriptorStructuredAxesAttr));
   auto resultType = dyn_cast<RankedTensorType>(op.getType());
+  auto baseSplat = ptr.getDefiningOp<triton::SplatOp>();
+  bool hasScalarPointerSplatBase =
+      baseSplat && isa<triton::PointerType>(baseSplat.getSrc().getType());
   SmallVector<PtrOffsetInfo::AxisInfo> descriptorAxes;
   if (structuredAxes) {
     if (!isRebuild || !resultType ||
@@ -733,6 +729,11 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
   bool isCompleteOffsetCarrier = isRebuild && !isStridedRankOne;
   bool isDescriptorOwned =
       isRebuild || ptrOffsetInfo.isPointerDescriptorOwned();
+  bool descriptorIsOpaque =
+      !descriptorAxes.empty() &&
+      llvm::all_of(descriptorAxes, [](PtrOffsetInfo::AxisInfo axis) {
+        return axis == PtrOffsetInfo::AxisInfo::unstructured;
+      });
 
   if (isCompleteOffsetCarrier) {
     // The carrier is complete relative to the descriptor base, but parsing
@@ -755,46 +756,21 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
     }
 
     SmallVector<PtrOffsetInfo::AxisInfo> recoveredAxes;
-    bool descriptorIsFullyOpaque =
-        descriptorAxes.size() == 2 &&
-        llvm::all_of(descriptorAxes, [](PtrOffsetInfo::AxisInfo axis) {
-          return axis == PtrOffsetInfo::AxisInfo::unstructured;
-        });
-    auto baseSplat = ptr.getDefiningOp<triton::SplatOp>();
-    bool hasScalarPointerSplatBase =
-        baseSplat && isa<triton::PointerType>(baseSplat.getSrc().getType());
     Value materializedOffset;
-    if (descriptorIsFullyOpaque && hasScalarPointerSplatBase) {
-      materializedOffset =
-          materializeMarkedRankTwoTiledOffsetCarrier(offsetValue, op, rewriter);
-    }
-    if (materializedOffset) {
-      parse(materializedOffset, op.getLoc(), rewriter, offsetMap);
-      auto carrierInfo = offsetMap.find(materializedOffset);
+    if (descriptorIsOpaque && hasScalarPointerSplatBase) {
+      parse(offsetValue, op.getLoc(), rewriter, offsetMap);
+      auto carrierInfo = offsetMap.find(offsetValue);
       if (carrierInfo != offsetMap.end() &&
-          carrierInfo->second.getRank() == 2 &&
-          carrierInfo->second.isStructured()) {
-        for (PtrOffsetInfo::AxisInfo axis :
-             carrierInfo->second.getStructured()) {
-          if (axis == PtrOffsetInfo::AxisInfo::unstructured) {
-            recoveredAxes.clear();
-            break;
-          }
-          recoveredAxes.push_back(axis == PtrOffsetInfo::AxisInfo::scalarlike
-                                      ? PtrOffsetInfo::AxisInfo::structured
-                                      : axis);
-        }
-        if (!llvm::all_of(recoveredAxes, [](PtrOffsetInfo::AxisInfo axis) {
-              return axis == PtrOffsetInfo::AxisInfo::structured;
-            }))
+          getRecoverableCarrierAxes(carrierInfo->second, resultType.getRank(),
+                                    recoveredAxes)) {
+        materializedOffset =
+            materializeAffineForOffsetCarrier(offsetValue, op, rewriter);
+        if (!materializedOffset)
           recoveredAxes.clear();
       }
     }
 
-    // T2L consumes the descriptor attribute rather than this analysis map.
-    // Persist the narrowly proven result so the two stages agree; all other
-    // complete carriers retain the original CFO classification unchanged.
-    if (!recoveredAxes.empty()) {
+    if (materializedOffset) {
       offsetValue = materializedOffset;
       op->setOperand(1, offsetValue);
       SmallVector<int32_t> structuredAxes(recoveredAxes.size(), 1);
@@ -830,10 +806,10 @@ void parseAddPtr(triton::AddPtrOp op, const Location &loc,
     ptrOffsetInfo.setScalarLike(false);
     if (!recoveredAxes.empty())
       ptrOffsetInfo.setStructured(recoveredAxes);
-    else if (descriptorAxes.empty())
-      ptrOffsetInfo.setUnstructured(resultType.getRank());
-    else
+    else if (!descriptorAxes.empty())
       ptrOffsetInfo.setStructured(descriptorAxes);
+    else
+      ptrOffsetInfo.setUnstructured(resultType.getRank());
     ptrOffsetInfo.setPointerDescriptorOwned(true);
     offsetMap[op.getResult()] = ptrOffsetInfo;
     return;

--- a/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/d007_per_axis_structured_opaque_e2e.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonControlFlowOpt/d007_per_axis_structured_opaque_e2e.mlir
@@ -81,6 +81,36 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
     tt.store %output_ptr, %loaded : tensor<2x4x!tt.ptr<f32>>
     tt.return
   }
+
+  // A uniform backedge update must remain the scalar uniform-offset field.
+  // The invariant opaque-axis contribution stays outside the loop instead of
+  // becoming a full tensor loop carrier on every iteration.
+  tt.func public @d007_rank2_mixed_uniform_loop(
+      %base: !tt.ptr<f32>, %output: !tt.ptr<f32>,
+      %axis1: tensor<4xi32>, %upper: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %delta = arith.constant dense<32> : tensor<2x4xi32>
+    %axis0 = tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32>
+    %axis0_expanded = tt.expand_dims %axis0 {axis = 1 : i32} : tensor<2xi32> -> tensor<2x1xi32>
+    %axis0_broadcast = tt.broadcast %axis0_expanded : tensor<2x1xi32> -> tensor<2x4xi32>
+    %axis1_expanded = tt.expand_dims %axis1 {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    %axis1_broadcast = tt.broadcast %axis1_expanded : tensor<1x4xi32> -> tensor<2x4xi32>
+    %offset = arith.addi %axis0_broadcast, %axis1_broadcast : tensor<2x4xi32>
+    %base_tensor = tt.splat %base : !tt.ptr<f32> -> tensor<2x4x!tt.ptr<f32>>
+    %initial = tt.addptr %base_tensor, %offset : tensor<2x4x!tt.ptr<f32>>, tensor<2x4xi32>
+    %final = scf.for %iv = %c0 to %upper step %c1
+        iter_args(%pointer = %initial) -> (tensor<2x4x!tt.ptr<f32>>) {
+      %next = tt.addptr %pointer, %delta : tensor<2x4x!tt.ptr<f32>>, tensor<2x4xi32>
+      scf.yield %next : tensor<2x4x!tt.ptr<f32>>
+    }
+    %loaded = tt.load %final : tensor<2x4x!tt.ptr<f32>>
+    %output_offsets = arith.constant dense<[[0, 1, 2, 3], [4, 5, 6, 7]]> : tensor<2x4xi32>
+    %output_tensor = tt.splat %output : !tt.ptr<f32> -> tensor<2x4x!tt.ptr<f32>>
+    %output_ptr = tt.addptr %output_tensor, %output_offsets : tensor<2x4x!tt.ptr<f32>>, tensor<2x4xi32>
+    tt.store %output_ptr, %loaded : tensor<2x4x!tt.ptr<f32>>
+    tt.return
+  }
 }
 
 // CFO-LABEL: tt.func public @d007_rank1_structured
@@ -89,6 +119,11 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
 // CFO-LABEL: tt.func public @d007_rank1_opaque
 // CFO: PointerDescriptorStructuredAxes = array<i32: 0>
 // CFO-LABEL: tt.func public @d007_rank2_mixed
+// CFO: PointerDescriptorStructuredAxes = array<i32: 1, 0>
+// CFO-LABEL: tt.func public @d007_rank2_mixed_uniform_loop
+// CFO: scf.for
+// CFO-SAME: i32
+// CFO-NOT: scf.yield {{.*}}tensor<2x4xi32>
 // CFO: PointerDescriptorStructuredAxes = array<i32: 1, 0>
 
 // E2E-LABEL: func.func @d007_rank1_structured
@@ -113,6 +148,12 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
 // E2E: bufferization.materialize_in_destination
 // E2E: return
 // E2E-LABEL: func.func @d007_rank2_mixed
+// E2E: memref.load
+// E2E: bufferization.materialize_in_destination
+// E2E: return
+// E2E-LABEL: func.func @d007_rank2_mixed_uniform_loop
+// E2E: scf.for
+// E2E-SAME: iter_args(%{{.*}} = %{{.*}}) -> (i32)
 // E2E: memref.load
 // E2E: bufferization.materialize_in_destination
 // E2E: return

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/tensor_pointer_descriptor_loop.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt --triton-control-flow-opt %s -verify-each | FileCheck %s --check-prefix=CFO
+// RUN: triton-opt --triton-control-flow-opt --triton-to-unstructure %s -verify-each | FileCheck %s --check-prefix=T2U
 // RUN: triton-opt --triton-control-flow-opt --triton-to-unstructure --triton-to-linalg %s -verify-each | FileCheck %s --check-prefix=LINALG
 
 module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
@@ -21,45 +22,35 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
     tt.return
   }
 
-  // This is the one tiled rank-2 carrier optimized by the narrow T2U path.
-  // The ordinary offset slot is initialized from complementary broadcasted
-  // axes and advances by 64 alongside two CFO-owned pointer descriptors.
-  tt.func public @marked_rank_two_tiled_offset_carrier(
-      %input: !tt.ptr<f32>, %dense: !tt.ptr<f32>, %output: !tt.ptr<f32>,
-      %row_stride: i32) {
-    %c0 = arith.constant 0 : index
-    %c64 = arith.constant 64 : index
-    %c256 = arith.constant 256 : index
-    %row_range = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-    %rows = tt.expand_dims %row_range {axis = 1 : i32} : tensor<32xi32> -> tensor<32x1xi32>
-    %stride = tt.splat %row_stride : i32 -> tensor<32x1xi32>
-    %scaled_rows = arith.muli %rows, %stride : tensor<32x1xi32>
-    %row_offsets = tt.broadcast %scaled_rows : tensor<32x1xi32> -> tensor<32x64xi32>
-    %column_range = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
-    %columns = tt.expand_dims %column_range {axis = 0 : i32} : tensor<64xi32> -> tensor<1x64xi32>
-    %column_offsets = tt.broadcast %columns : tensor<1x64xi32> -> tensor<32x64xi32>
-    %initial_offsets = arith.addi %row_offsets, %column_offsets : tensor<32x64xi32>
-    %input_base = tt.splat %input : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>>
-    %dense_base = tt.splat %dense : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>>
-    %output_base = tt.splat %output : !tt.ptr<f32> -> tensor<32x64x!tt.ptr<f32>>
-    %initial_dense = tt.addptr %dense_base, %initial_offsets : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
-    %initial_output = tt.addptr %output_base, %initial_offsets : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
-    %column_advance = arith.constant dense<64> : tensor<64xi32>
-    %offset_advance = arith.constant dense<64> : tensor<32x64xi32>
-    %result:4 = scf.for %iv = %c0 to %c256 step %c64
-        iter_args(%loop_columns = %column_range, %offsets = %initial_offsets,
-                  %dense_ptrs = %initial_dense, %output_ptrs = %initial_output)
-        -> (tensor<64xi32>, tensor<32x64xi32>, tensor<32x64x!tt.ptr<f32>>, tensor<32x64x!tt.ptr<f32>>) {
-      %input_ptrs = tt.addptr %input_base, %offsets : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
-      %input_value = tt.load %input_ptrs : tensor<32x64x!tt.ptr<f32>>
-      %dense_value = tt.load %dense_ptrs : tensor<32x64x!tt.ptr<f32>>
-      %value = arith.addf %input_value, %dense_value : tensor<32x64xf32>
-      tt.store %output_ptrs, %value : tensor<32x64x!tt.ptr<f32>>
-      %next_columns = arith.addi %loop_columns, %column_advance : tensor<64xi32>
-      %next_offsets = arith.addi %offsets, %offset_advance : tensor<32x64xi32>
-      %next_dense = tt.addptr %dense_ptrs, %offset_advance : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
-      %next_output = tt.addptr %output_ptrs, %offset_advance : tensor<32x64x!tt.ptr<f32>>, tensor<32x64xi32>
-      scf.yield %next_columns, %next_offsets, %next_dense, %next_output : tensor<64xi32>, tensor<32x64xi32>, tensor<32x64x!tt.ptr<f32>>, tensor<32x64x!tt.ptr<f32>>
+  // A CFO descriptor loop may also carry an ordinary integer offset tensor.
+  // Recover its affine row/column layout from the carrier provenance instead
+  // of lowering the corresponding load as an indirect gather.
+  tt.func public @marked_affine_index_carrier(
+      %input: !tt.ptr<f32>, %output: !tt.ptr<f32>, %row_stride: i32,
+      %upper: index) {
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %range = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    %rows = tt.expand_dims %range {axis = 1 : i32} : tensor<4xi32> -> tensor<4x1xi32>
+    %stride = tt.splat %row_stride : i32 -> tensor<4x1xi32>
+    %scaled_rows = arith.muli %rows, %stride : tensor<4x1xi32>
+    %row_offsets = tt.broadcast %scaled_rows : tensor<4x1xi32> -> tensor<4x4xi32>
+    %columns = tt.expand_dims %range {axis = 0 : i32} : tensor<4xi32> -> tensor<1x4xi32>
+    %column_offsets = tt.broadcast %columns : tensor<1x4xi32> -> tensor<4x4xi32>
+    %initial_offsets = arith.addi %row_offsets, %column_offsets : tensor<4x4xi32>
+    %input_base = tt.splat %input : !tt.ptr<f32> -> tensor<4x4x!tt.ptr<f32>>
+    %output_base = tt.splat %output : !tt.ptr<f32> -> tensor<4x4x!tt.ptr<f32>>
+    %initial_output = tt.addptr %output_base, %initial_offsets : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+    %advance = arith.constant dense<16> : tensor<4x4xi32>
+    %result:2 = scf.for %iv = %c2 to %upper step %c3
+        iter_args(%offsets = %initial_offsets, %output_ptrs = %initial_output)
+        -> (tensor<4x4xi32>, tensor<4x4x!tt.ptr<f32>>) {
+      %input_ptrs = tt.addptr %input_base, %offsets : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+      %value = tt.load %input_ptrs : tensor<4x4x!tt.ptr<f32>>
+      tt.store %output_ptrs, %value : tensor<4x4x!tt.ptr<f32>>
+      %next_offsets = arith.addi %offsets, %advance : tensor<4x4xi32>
+      %next_output = tt.addptr %output_ptrs, %advance : tensor<4x4x!tt.ptr<f32>>, tensor<4x4xi32>
+      scf.yield %next_offsets, %next_output : tensor<4x4xi32>, tensor<4x4x!tt.ptr<f32>>
     }
     tt.return
   }
@@ -77,11 +68,19 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
 // LINALG-NOT:   tensor<4x!tt.ptr
 // LINALG-NOT:   unrealized_conversion_cast
 
-// CFO-LABEL: tt.func public @marked_rank_two_tiled_offset_carrier
+// CFO-LABEL: tt.func public @marked_affine_index_carrier
 // CFO:       scf.for
 // CFO:       PointerDescriptorBoundary
 
-// LINALG-LABEL: func.func @marked_rank_two_tiled_offset_carrier
+// T2U-LABEL: tt.func public @marked_affine_index_carrier
+// T2U:       scf.for %[[IV:[a-zA-Z0-9_]+]] =
+// T2U:       arith.subi %[[IV]],
+// T2U:       arith.divui
+// T2U:       tt.addptr {{.*}}PointerDescriptorRebuild
+// T2U-SAME:  PointerDescriptorStructuredAxes = array<i32: 1, 1>
+// T2U:       tt.load
+
+// LINALG-LABEL: func.func @marked_affine_index_carrier
 // LINALG:       scf.for
 // LINALG-NOT:   triton_indirect_load
 // LINALG:       return


### PR DESCRIPTION
## Summary

Apply the mixed-axis uniform scalar-carrier fix on top of the latest `main-dev`.

- Preserve mixed tensor-pointer opaque contributions while carrying pure uniform loop updates as scalar offsets.
- Keep the loop-specific normalization isolated from `if` and `scope` paths.
- Add focused rank-2 mixed-axis loop coverage.
- Include LLVM 22 casting compatibility and the corresponding FileCheck adjustment.

The temporary PR1958 changes are already part of the `main-dev` base and are not reintroduced as separate commits.

## Validation

- Rebased onto the latest official `main-dev`.
- Formatted the changed C++ files with the repository clang-format tool.
- Squashed into one commit.
- `git diff --cached --check` passed before commit.