### PR TITLE
[Docs](fix) Unify libdevice doc example precision to 1e-4

### DIFF
--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.abs.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.abs.py
@@ -42,7 +42,7 @@ def test_abs():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.acos.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.acos.py
@@ -38,7 +38,7 @@ def test_acos():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.acosh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.acosh.py
@@ -38,7 +38,7 @@ def test_acosh():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rd.py
@@ -48,7 +48,7 @@ def test_add_rd():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rn.py
@@ -48,7 +48,7 @@ def test_add_rn():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_ru.py
@@ -48,7 +48,7 @@ def test_add_ru():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.add_rz.py
@@ -48,7 +48,7 @@ def test_add_rz():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.asin.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.asin.py
@@ -38,7 +38,7 @@ def test_asin():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.asinh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.asinh.py
@@ -38,7 +38,7 @@ def test_asinh():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atan.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atan.py
@@ -38,7 +38,7 @@ def test_atan():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atan2.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atan2.py
@@ -40,7 +40,7 @@ def test_atan2():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atanh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.atanh.py
@@ -38,7 +38,7 @@ def test_atanh():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.brev.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.brev.py
@@ -46,7 +46,7 @@ def test_brev():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.byte_perm.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.byte_perm.py
@@ -59,7 +59,7 @@ def test_byte_perm():
     triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cbrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cbrt.py
@@ -43,7 +43,7 @@ def test_cbrt():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ceil.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ceil.py
@@ -41,7 +41,7 @@ def test_ceil():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.clz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.clz.py
@@ -47,7 +47,7 @@ def test_clz():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.copysign.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.copysign.py
@@ -40,7 +40,7 @@ def test_copysign():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cos.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cos.py
@@ -41,7 +41,7 @@ def test_cos():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cosh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cosh.py
@@ -38,7 +38,7 @@ def test_cosh():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cospi.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cospi.py
@@ -42,7 +42,7 @@ def test_cospi():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cyl_bessel_i0.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cyl_bessel_i0.py
@@ -38,7 +38,7 @@ def test_cyl_bessel_i0():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cyl_bessel_i1.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.cyl_bessel_i1.py
@@ -41,7 +41,7 @@ def test_cyl_bessel_i1():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rd.py
@@ -48,7 +48,7 @@ def test_div_rd():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rn.py
@@ -48,7 +48,7 @@ def test_div_rn():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_ru.py
@@ -48,7 +48,7 @@ def test_div_ru():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.div_rz.py
@@ -40,7 +40,7 @@ def test_div_rz():
     expected = x0 / x1
     out = out.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(out, expected, rtol=1e-03, atol=1e-03)
+    torch.testing.assert_close(out, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erf.py
@@ -41,7 +41,7 @@ def test_erf():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfc.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfc.py
@@ -41,7 +41,7 @@ def test_erfc():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcinv.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcinv.py
@@ -41,7 +41,7 @@ def test_erfcinv():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcx.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfcx.py
@@ -41,7 +41,7 @@ def test_erfcx():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfinv.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.erfinv.py
@@ -38,7 +38,7 @@ def test_erfinv():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp.py
@@ -41,7 +41,7 @@ def test_exp():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp10.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp10.py
@@ -41,7 +41,7 @@ def test_exp10():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp2.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.exp2.py
@@ -41,7 +41,7 @@ def test_exp2():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.expm1.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.expm1.py
@@ -38,7 +38,7 @@ def test_expm1():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_cosf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_cosf.py
@@ -41,7 +41,7 @@ def test_fast_cosf():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_dividef.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_dividef.py
@@ -40,7 +40,7 @@ def test_fast_dividef():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_exp10f.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_exp10f.py
@@ -41,7 +41,7 @@ def test_fast_exp10f():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_expf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_expf.py
@@ -38,7 +38,7 @@ def test_fast_expf():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_log10f.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_log10f.py
@@ -41,7 +41,7 @@ def test_fast_log10f():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_log2f.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_log2f.py
@@ -41,7 +41,7 @@ def test_fast_log2f():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_logf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_logf.py
@@ -41,7 +41,7 @@ def test_fast_logf():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_powf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_powf.py
@@ -48,7 +48,7 @@ def test_fast_powf():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_sinf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_sinf.py
@@ -41,7 +41,7 @@ def test_fast_sinf():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_tanf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_tanf.py
@@ -41,7 +41,7 @@ def test_fast_tanf():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_tanhf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fast_tanhf.py
@@ -42,7 +42,7 @@ def test_fast_tanhf():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fdim.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fdim.py
@@ -48,7 +48,7 @@ def test_fdim():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ffs.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ffs.py
@@ -52,7 +52,7 @@ def test_ffs():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.finitef.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.finitef.py
@@ -32,15 +32,20 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_finitef():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32)
+    expected = (torch_finitef_reference(x0)).npu()
+    x0 = x0.npu()
+    output = torch.empty(8, dtype=torch.bool, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32)
-        expected = (torch_finitef_reference(x0)).npu()
-        x0 = x0.npu()
-        output = torch.empty(8, dtype=torch.bool, device='npu')
-        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        test_finitef()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2half_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2half_rn.py
@@ -42,7 +42,7 @@ def test_float2half_rn():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rd.py
@@ -43,7 +43,7 @@ def test_float2int_rd():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rn.py
@@ -43,7 +43,7 @@ def test_float2int_rn():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_ru.py
@@ -43,7 +43,7 @@ def test_float2int_ru():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2int_rz.py
@@ -43,7 +43,7 @@ def test_float2int_rz():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rd.py
@@ -43,7 +43,7 @@ def test_float2ll_rd():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rn.py
@@ -43,7 +43,7 @@ def test_float2ll_rn():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_ru.py
@@ -43,7 +43,7 @@ def test_float2ll_ru():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ll_rz.py
@@ -43,7 +43,7 @@ def test_float2ll_rz():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rd.py
@@ -34,15 +34,20 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2uint_rd():
+    x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
+    expected = (torch_float2uint_rd_reference(x0)).npu()
+    x0 = x0.npu()
+    output = torch.empty(8, dtype=torch.uint32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
-        expected = (torch_float2uint_rd_reference(x0)).npu()
-        x0 = x0.npu()
-        output = torch.empty(8, dtype=torch.uint32, device='npu')
-        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        test_float2uint_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rn.py
@@ -34,15 +34,20 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2uint_rn():
+    x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
+    expected = (torch_float2uint_rn_reference(x0)).npu()
+    x0 = x0.npu()
+    output = torch.empty(8, dtype=torch.uint32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
-        expected = (torch_float2uint_rn_reference(x0)).npu()
-        x0 = x0.npu()
-        output = torch.empty(8, dtype=torch.uint32, device='npu')
-        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        test_float2uint_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_ru.py
@@ -34,15 +34,20 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2uint_ru():
+    x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
+    expected = (torch_float2uint_ru_reference(x0)).npu()
+    x0 = x0.npu()
+    output = torch.empty(8, dtype=torch.uint32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
-        expected = (torch_float2uint_ru_reference(x0)).npu()
-        x0 = x0.npu()
-        output = torch.empty(8, dtype=torch.uint32, device='npu')
-        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        test_float2uint_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2uint_rz.py
@@ -34,15 +34,20 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2uint_rz():
+    x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
+    expected = (torch_float2uint_rz_reference(x0)).npu()
+    x0 = x0.npu()
+    output = torch.empty(8, dtype=torch.uint32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
-        expected = (torch_float2uint_rz_reference(x0)).npu()
-        x0 = x0.npu()
-        output = torch.empty(8, dtype=torch.uint32, device='npu')
-        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        test_float2uint_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rd.py
@@ -34,15 +34,20 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2ull_rd():
+    x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
+    expected = (torch_float2ull_rd_reference(x0)).npu()
+    x0 = x0.npu()
+    output = torch.empty(8, dtype=torch.uint64, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
-        expected = (torch_float2ull_rd_reference(x0)).npu()
-        x0 = x0.npu()
-        output = torch.empty(8, dtype=torch.uint64, device='npu')
-        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        test_float2ull_rd()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rn.py
@@ -34,15 +34,20 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2ull_rn():
+    x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
+    expected = (torch_float2ull_rn_reference(x0)).npu()
+    x0 = x0.npu()
+    output = torch.empty(8, dtype=torch.uint64, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
-        expected = (torch_float2ull_rn_reference(x0)).npu()
-        x0 = x0.npu()
-        output = torch.empty(8, dtype=torch.uint64, device='npu')
-        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        test_float2ull_rn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_ru.py
@@ -34,15 +34,20 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2ull_ru():
+    x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
+    expected = (torch_float2ull_ru_reference(x0)).npu()
+    x0 = x0.npu()
+    output = torch.empty(8, dtype=torch.uint64, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
-        expected = (torch_float2ull_ru_reference(x0)).npu()
-        x0 = x0.npu()
-        output = torch.empty(8, dtype=torch.uint64, device='npu')
-        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        test_float2ull_ru()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float2ull_rz.py
@@ -34,15 +34,20 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float2ull_rz():
+    x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
+    expected = (torch_float2ull_rz_reference(x0)).npu()
+    x0 = x0.npu()
+    output = torch.empty(8, dtype=torch.uint64, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = torch.abs((torch.rand((8, )) * 3.0 - 1.5).to(torch.float32))
-        expected = (torch_float2ull_rz_reference(x0)).npu()
-        x0 = x0.npu()
-        output = torch.empty(8, dtype=torch.uint64, device='npu')
-        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        test_float2ull_rz()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float_as_int.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float_as_int.py
@@ -41,7 +41,7 @@ def test_float_as_int():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float_as_uint.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.float_as_uint.py
@@ -32,15 +32,20 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_float_as_uint():
+    x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32)
+    expected = (torch_float_as_uint_reference(x0)).npu()
+    x0 = x0.npu()
+    output = torch.empty(8, dtype=torch.uint32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = (torch.rand((8, )) * 3.0 - 1.5).to(torch.float32)
-        expected = (torch_float_as_uint_reference(x0)).npu()
-        x0 = x0.npu()
-        output = torch.empty(8, dtype=torch.uint32, device='npu')
-        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        test_float_as_uint()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.floor.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.floor.py
@@ -41,7 +41,7 @@ def test_floor():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma.py
@@ -53,7 +53,7 @@ def test_fma():
     triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rd.py
@@ -53,7 +53,7 @@ def test_fma_rd():
     triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rn.py
@@ -53,7 +53,7 @@ def test_fma_rn():
     triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_ru.py
@@ -53,7 +53,7 @@ def test_fma_ru():
     triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fma_rz.py
@@ -53,7 +53,7 @@ def test_fma_rz():
     triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fmod.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.fmod.py
@@ -40,7 +40,7 @@ def test_fmod():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.gamma.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.gamma.py
@@ -38,7 +38,7 @@ def test_gamma():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.hadd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.hadd.py
@@ -48,7 +48,7 @@ def test_hadd():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.half2float.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.half2float.py
@@ -42,7 +42,7 @@ def test_half2float():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.hypot.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.hypot.py
@@ -40,7 +40,7 @@ def test_hypot():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ilogb.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ilogb.py
@@ -38,7 +38,7 @@ def test_ilogb():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=0, atol=0, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rd.py
@@ -42,7 +42,7 @@ def test_int2float_rd():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rn.py
@@ -42,7 +42,7 @@ def test_int2float_rn():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_ru.py
@@ -42,7 +42,7 @@ def test_int2float_ru():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int2float_rz.py
@@ -42,7 +42,7 @@ def test_int2float_rz():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int_as_float.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.int_as_float.py
@@ -33,16 +33,21 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_int_as_float():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32)
+    expected = (torch_int_as_float_reference(x0)).npu()
+    x0 = x0.npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
+    assert torch.equal(output.cpu().view(torch.int32), expected.cpu().view(torch.int32))
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = (torch.randint(1, 16, (8, ))).to(torch.int32)
-        expected = (torch_int_as_float_reference(x0)).npu()
-        x0 = x0.npu()
-        output = torch.empty(8, dtype=torch.float32, device='npu')
-        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
-        assert torch.equal(output.cpu().view(torch.int32), expected.cpu().view(torch.int32))
+        test_int_as_float()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.isinf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.isinf.py
@@ -41,7 +41,7 @@ def test_isinf():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=0, atol=0)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.isnan.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.isnan.py
@@ -41,7 +41,7 @@ def test_isnan():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=0, atol=0)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.j0.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.j0.py
@@ -43,7 +43,7 @@ def test_j0():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.j1.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.j1.py
@@ -43,7 +43,7 @@ def test_j1():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.jn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.jn.py
@@ -78,17 +78,22 @@ def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLO
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_jn():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32)
+    x1 = (torch.rand((8, )) + 0.1).to(torch.float32)
+    expected = (torch_jn_reference(x0, x1)).npu()
+    x0 = x0.npu()
+    x1 = x1.npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = (torch.randint(1, 16, (8, ))).to(torch.int32)
-        x1 = (torch.rand((8, )) + 0.1).to(torch.float32)
-        expected = (torch_jn_reference(x0, x1)).npu()
-        x0 = x0.npu()
-        x1 = x1.npu()
-        output = torch.empty(8, dtype=torch.float32, device='npu')
-        triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+        test_jn()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ldexp.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ldexp.py
@@ -50,7 +50,7 @@ def test_ldexp():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.lgamma.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.lgamma.py
@@ -38,7 +38,7 @@ def test_lgamma():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rd.py
@@ -41,7 +41,7 @@ def test_ll2float_rd():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rn.py
@@ -41,7 +41,7 @@ def test_ll2float_rn():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_ru.py
@@ -41,7 +41,7 @@ def test_ll2float_ru():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ll2float_rz.py
@@ -41,7 +41,7 @@ def test_ll2float_rz():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.llrint.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.llrint.py
@@ -41,7 +41,7 @@ def test_llrint():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.llround.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.llround.py
@@ -41,7 +41,7 @@ def test_llround():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log.py
@@ -41,7 +41,7 @@ def test_log():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log10.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log10.py
@@ -38,7 +38,7 @@ def test_log10():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log1p.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log1p.py
@@ -38,7 +38,7 @@ def test_log1p():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log2.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.log2.py
@@ -41,7 +41,7 @@ def test_log2():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.logb.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.logb.py
@@ -45,7 +45,7 @@ def test_logb():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul24.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul24.py
@@ -50,7 +50,7 @@ def test_mul24():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rd.py
@@ -48,7 +48,7 @@ def test_mul_rd():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rn.py
@@ -48,7 +48,7 @@ def test_mul_rn():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_ru.py
@@ -48,7 +48,7 @@ def test_mul_ru():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mul_rz.py
@@ -48,7 +48,7 @@ def test_mul_rz():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mulhi.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.mulhi.py
@@ -49,7 +49,7 @@ def test_mulhi():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nan.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nan.py
@@ -42,7 +42,7 @@ def test_nan():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
     assert torch.isnan(output.cpu()).all()
 
 

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nearbyint.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nearbyint.py
@@ -38,7 +38,7 @@ def test_nearbyint():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nextafter.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.nextafter.py
@@ -40,7 +40,7 @@ def test_nextafter():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.norm3d.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.norm3d.py
@@ -53,7 +53,7 @@ def test_norm3d():
     triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.norm4d.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.norm4d.py
@@ -59,7 +59,7 @@ def test_norm4d():
     triton_kernel[(1, )](x0, x1, x2, x3, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.normcdf.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.normcdf.py
@@ -41,7 +41,7 @@ def test_normcdf():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.normcdfinv.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.normcdfinv.py
@@ -42,7 +42,7 @@ def test_normcdfinv():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.popc.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.popc.py
@@ -46,7 +46,7 @@ def test_popc():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.pow.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.pow.py
@@ -40,7 +40,7 @@ def test_pow():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcbrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcbrt.py
@@ -42,7 +42,7 @@ def test_rcbrt():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rd.py
@@ -41,7 +41,7 @@ def test_rcp_rd():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rn.py
@@ -41,7 +41,7 @@ def test_rcp_rn():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_ru.py
@@ -41,7 +41,7 @@ def test_rcp_ru():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rcp_rz.py
@@ -41,7 +41,7 @@ def test_rcp_rz():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.reciprocal.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.reciprocal.py
@@ -38,7 +38,7 @@ def test_reciprocal():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.relu.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.relu.py
@@ -38,7 +38,7 @@ def test_relu():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.remainder.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.remainder.py
@@ -48,7 +48,7 @@ def test_remainder():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhadd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhadd.py
@@ -48,7 +48,7 @@ def test_rhadd():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhypot.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rhypot.py
@@ -48,7 +48,7 @@ def test_rhypot():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rint.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rint.py
@@ -38,7 +38,7 @@ def test_rint():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rnorm3d.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rnorm3d.py
@@ -53,7 +53,7 @@ def test_rnorm3d():
     triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rnorm4d.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rnorm4d.py
@@ -59,7 +59,7 @@ def test_rnorm4d():
     triton_kernel[(1, )](x0, x1, x2, x3, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.round.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.round.py
@@ -38,7 +38,7 @@ def test_round():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rsqrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rsqrt.py
@@ -41,7 +41,7 @@ def test_rsqrt():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rsqrt_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.rsqrt_rn.py
@@ -41,7 +41,7 @@ def test_rsqrt_rn():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sad.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sad.py
@@ -53,7 +53,7 @@ def test_sad():
     triton_kernel[(1, )](x0, x1, x2, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.saturatef.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.saturatef.py
@@ -42,7 +42,7 @@ def test_saturatef():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.scalbn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.scalbn.py
@@ -48,7 +48,7 @@ def test_scalbn():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.signbit.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.signbit.py
@@ -38,7 +38,7 @@ def test_signbit():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=0, atol=0, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sin.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sin.py
@@ -41,7 +41,7 @@ def test_sin():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sinh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sinh.py
@@ -38,7 +38,7 @@ def test_sinh():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sinpi.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sinpi.py
@@ -42,7 +42,7 @@ def test_sinpi():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt.py
@@ -41,7 +41,7 @@ def test_sqrt():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rd.py
@@ -41,7 +41,7 @@ def test_sqrt_rd():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rn.py
@@ -41,7 +41,7 @@ def test_sqrt_rn():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_ru.py
@@ -41,7 +41,7 @@ def test_sqrt_ru():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sqrt_rz.py
@@ -41,7 +41,7 @@ def test_sqrt_rz():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rd.py
@@ -48,7 +48,7 @@ def test_sub_rd():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rn.py
@@ -48,7 +48,7 @@ def test_sub_rn():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_ru.py
@@ -48,7 +48,7 @@ def test_sub_ru():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.sub_rz.py
@@ -48,7 +48,7 @@ def test_sub_rz():
     triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-02, atol=1e-02, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tan.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tan.py
@@ -38,7 +38,7 @@ def test_tan():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tanh.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tanh.py
@@ -38,7 +38,7 @@ def test_tanh():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tgamma.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.tgamma.py
@@ -43,7 +43,7 @@ def test_tgamma():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.trunc.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.trunc.py
@@ -38,7 +38,7 @@ def test_trunc():
 
     torch_res = torch_res.cpu()
     triton_res = triton_res.cpu()
-    torch.testing.assert_close(torch_res, triton_res, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(torch_res, triton_res, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rd.py
@@ -42,7 +42,7 @@ def test_uint2float_rd():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rn.py
@@ -42,7 +42,7 @@ def test_uint2float_rn():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_ru.py
@@ -42,7 +42,7 @@ def test_uint2float_ru():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint2float_rz.py
@@ -42,7 +42,7 @@ def test_uint2float_rz():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint_as_float.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.uint_as_float.py
@@ -32,16 +32,21 @@ def triton_kernel(input0, output, n_elements, XBLOCK: tl.constexpr, XBLOCK_SUB: 
         tl.store(output + (x0), tmp1, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_uint_as_float():
+    x0 = (torch.randint(0, 100, (8, ))).to(torch.uint32)
+    expected = (torch_uint_as_float_reference(x0)).npu()
+    x0 = x0.npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
+    assert torch.equal(output.cpu().view(torch.int32), expected.cpu().view(torch.int32))
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = (torch.randint(0, 100, (8, ))).to(torch.uint32)
-        expected = (torch_uint_as_float_reference(x0)).npu()
-        x0 = x0.npu()
-        output = torch.empty(8, dtype=torch.float32, device='npu')
-        triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
-        assert torch.equal(output.cpu().view(torch.int32), expected.cpu().view(torch.int32))
+        test_uint_as_float()

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rd.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rd.py
@@ -41,7 +41,7 @@ def test_ull2float_rd():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rn.py
@@ -41,7 +41,7 @@ def test_ull2float_rn():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_ru.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_ru.py
@@ -41,7 +41,7 @@ def test_ull2float_ru():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rz.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.ull2float_rz.py
@@ -41,7 +41,7 @@ def test_ull2float_rz():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.y0.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.y0.py
@@ -43,7 +43,7 @@ def test_y0():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.y1.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.y1.py
@@ -43,7 +43,7 @@ def test_y1():
     triton_kernel[(1, )](x0, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
     output = output.cpu()
     expected = expected.cpu()
-    torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
 
 
 if __name__ == "__main__":

--- a/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.yn.py
+++ b/docs/zh/python-api/_examples/triton.language.extra.cann.libdevice.yn.py
@@ -65,17 +65,22 @@ def triton_kernel(input0, input1, output, n_elements, XBLOCK: tl.constexpr, XBLO
         tl.store(output + (x0), tmp2, mask=mask)
 
 
+@pytest.mark.skipif(not triton_enable_libdevice_simt(), reason=_SIMT_SKIP_MSG)
+def test_yn():
+    x0 = (torch.randint(1, 16, (8, ))).to(torch.int32)
+    x1 = (torch.rand((8, )) + 0.1).to(torch.float32)
+    expected = (torch_yn_reference(x0, x1)).npu()
+    x0 = x0.npu()
+    x1 = x1.npu()
+    output = torch.empty(8, dtype=torch.float32, device='npu')
+    triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
+    output = output.cpu()
+    expected = expected.cpu()
+    torch.testing.assert_close(output, expected, rtol=1e-04, atol=1e-04, equal_nan=True)
+
+
 if __name__ == "__main__":
     if not triton_enable_libdevice_simt():
         print(_SIMT_SKIP_MSG)
     else:
-        x0 = (torch.randint(1, 16, (8, ))).to(torch.int32)
-        x1 = (torch.rand((8, )) + 0.1).to(torch.float32)
-        expected = (torch_yn_reference(x0, x1)).npu()
-        x0 = x0.npu()
-        x1 = x1.npu()
-        output = torch.empty(8, dtype=torch.float32, device='npu')
-        triton_kernel[(1, )](x0, x1, output, 8, XBLOCK=8, XBLOCK_SUB=8, compile_mode='simt_only')
-        output = output.cpu()
-        expected = expected.cpu()
-        torch.testing.assert_close(output, expected, rtol=1e-03, atol=1e-03, equal_nan=True)
+        test_yn()


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
## Summary
Unify the accuracy standard of the libdevice API doc examples and fix the ones the CI pytest job could not run.
## Background
- Doc examples under `docs/zh/python-api/_examples/` are executed by the `docs-examples-npu` CI job via `pytest --override-ini="python_files=triton.*.py"`.
- The libdevice examples used inconsistent comparison tolerances: `rtol=atol` ranged over 0 (bit-exact), 1e-02 and 1e-03.
- 14 libdevice examples kept their test logic only inside `if __name__ == "__main__":`. Under pytest they were imported but never executed, so the CI silently ran 0 tests for them.
# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
