### PR TITLE
[TritonToLinalg](fix) keep masked scalar loads scalar

### DIFF
--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -475,26 +475,39 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
     auto resTy = op.getResult().getType();
     auto idxZero =
         rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
-    auto loadedValue = rewriter
-                           .create<memref::LoadOp>(loc, resTy, scalarMemref,
-                                                   idxZero.getResult())
-                           .getResult();
-    propagateWasBoolToInt8Attr(op.getOperation(), loadedValue.getDefiningOp(),
-                               rewriter);
-    if (mask && other) {
-      mask = rewriter.create<triton::SplatOp>(
-          loc, RankedTensorType::get({1}, mask.getType()), mask);
-      loadedValue = rewriter.create<triton::SplatOp>(
-          loc, RankedTensorType::get({1}, loadedValue.getType()), loadedValue);
-      other = rewriter.create<triton::SplatOp>(
-          loc, RankedTensorType::get({1}, other.getType()), other);
-      loadedValue =
-          rewriter.create<arith::SelectOp>(loc, mask, loadedValue, other);
-      rewriter.replaceOpWithNewOp<tensor::ExtractOp>(op, loadedValue,
-                                                     ValueRange({idxZero}));
-    } else {
-      rewriter.replaceOp(op, loadedValue);
+    auto createScalarLoad = [&]() -> Value {
+      auto load = rewriter.create<memref::LoadOp>(loc, resTy, scalarMemref,
+                                                  idxZero.getResult());
+      propagateWasBoolToInt8Attr(op.getOperation(), load.getOperation(),
+                                 rewriter);
+      return load.getResult();
+    };
+    if (!mask) {
+      rewriter.replaceOp(op, createScalarLoad());
+      return success();
     }
+
+    // Keep scalar results scalar, and guard the access itself: a select after
+    // an unconditional load would still read a masked-off, possibly invalid
+    // address.
+    auto ifOp = rewriter.create<scf::IfOp>(loc, TypeRange{resTy},
+                                           adaptor.getMask(), true);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
+      rewriter.create<scf::YieldOp>(loc, createScalarLoad());
+
+      rewriter.setInsertionPointToStart(&ifOp.getElseRegion().front());
+      Value inactiveValue = adaptor.getOther();
+      if (!inactiveValue) {
+        // Without `other`, the inactive value is undefined. Choose zero
+        // without accessing memory or introducing a tensor temporary.
+        inactiveValue = rewriter.create<arith::ConstantOp>(
+            loc, resTy, rewriter.getZeroAttr(resTy));
+      }
+      rewriter.create<scf::YieldOp>(loc, inactiveValue);
+    }
+    rewriter.replaceOp(op, ifOp.getResults());
     return success();
   }
 

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/scalar_masked_load.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/scalar_masked_load.mlir
@@ -1,0 +1,102 @@
+// RUN: triton-opt %s --triton-to-linalg -verify-each | FileCheck %s --implicit-check-not='tensor<' --implicit-check-not='arith.select'
+// RUN: triton-opt %s --triton-to-linalg='named-ops=true' -verify-each | FileCheck %s --implicit-check-not='tensor<' --implicit-check-not='arith.select'
+// RUN: sed 's/Ascend910B2/Ascend950DT_9582/' %s | triton-opt --triton-to-linalg='compile-on-910-95=true' -verify-each | FileCheck %s --implicit-check-not='tensor<' --implicit-check-not='arith.select'
+
+// Scalar masked loads must keep their result scalar and only read memory in
+// the active branch. In particular, selecting the result of an unconditional
+// load does not protect an invalid masked-off address.
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  // CHECK-LABEL: func.func @masked_i32(
+  // CHECK-SAME: %[[MASK:[^:]+]]: i1, %[[OTHER:[^:]+]]: i32
+  // CHECK-NOT: memref.load
+  // CHECK: %[[RESULT:.*]] = scf.if %[[MASK]] -> (i32) {
+  // CHECK-NEXT: %[[VALUE:.*]] = memref.load
+  // CHECK-NEXT: scf.yield %[[VALUE]] : i32
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT: scf.yield %[[OTHER]] : i32
+  // CHECK-NEXT: }
+  // CHECK-NOT: memref.load
+  // CHECK: return %[[RESULT]] : i32
+  tt.func public @masked_i32(%ptr: !tt.ptr<i32>, %mask: i1, %other: i32, %offset: i32) -> i32 {
+    %address = tt.addptr %ptr, %offset : !tt.ptr<i32>, i32
+    %value = tt.load %address, %mask, %other : !tt.ptr<i32>
+    tt.return %value : i32
+  }
+
+  // CHECK-LABEL: func.func @masked_f32(
+  // CHECK-SAME: %[[MASK:[^:]+]]: i1, %[[OTHER:[^:]+]]: f32
+  // CHECK-NOT: memref.load
+  // CHECK: %[[RESULT:.*]] = scf.if %[[MASK]] -> (f32) {
+  // CHECK-NEXT: %[[VALUE:.*]] = memref.load
+  // CHECK-NEXT: scf.yield %[[VALUE]] : f32
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT: scf.yield %[[OTHER]] : f32
+  // CHECK-NEXT: }
+  // CHECK-NOT: memref.load
+  // CHECK: return %[[RESULT]] : f32
+  tt.func public @masked_f32(%ptr: !tt.ptr<f32>, %mask: i1, %other: f32) -> f32 {
+    %value = tt.load %ptr, %mask, %other : !tt.ptr<f32>
+    tt.return %value : f32
+  }
+
+  // No `other` leaves the inactive result unspecified, but the load must
+  // still be conditional. Do not require a particular inactive result value.
+  // CHECK-LABEL: func.func @masked_without_other(
+  // CHECK-SAME: %[[MASK:[^:]+]]: i1
+  // CHECK-NOT: memref.load
+  // CHECK: %[[RESULT:.*]] = scf.if %[[MASK]] -> (i32) {
+  // CHECK-NEXT: %[[VALUE:.*]] = memref.load
+  // CHECK-NEXT: scf.yield %[[VALUE]] : i32
+  // CHECK-NEXT: } else {
+  // CHECK-NOT: memref.load
+  // CHECK: scf.yield %{{.*}} : i32
+  // CHECK-NEXT: }
+  // CHECK-NOT: memref.load
+  // CHECK: return %[[RESULT]] : i32
+  tt.func public @masked_without_other(%ptr: !tt.ptr<i32>, %mask: i1) -> i32 {
+    %value = tt.load %ptr, %mask : !tt.ptr<i32>
+    tt.return %value : i32
+  }
+
+  // CHECK-LABEL: func.func @unmasked(
+  // CHECK-NOT: scf.if
+  // CHECK: %[[VALUE:.*]] = memref.load
+  // CHECK-NOT: scf.if
+  // CHECK: return %[[VALUE]] : i32
+  tt.func public @unmasked(%ptr: !tt.ptr<i32>) -> i32 {
+    %value = tt.load %ptr : !tt.ptr<i32>
+    tt.return %value : i32
+  }
+
+  // CHECK-LABEL: func.func @mask_true(
+  // CHECK-NOT: scf.if
+  // CHECK: %[[VALUE:.*]] = memref.load
+  // CHECK-NOT: scf.if
+  // CHECK: return %[[VALUE]] : i32
+  tt.func public @mask_true(%ptr: !tt.ptr<i32>, %other: i32) -> i32 {
+    %true = arith.constant true
+    %value = tt.load %ptr, %true, %other : !tt.ptr<i32>
+    tt.return %value : i32
+  }
+
+  // CHECK-LABEL: func.func @mask_false(
+  // CHECK-SAME: %[[OTHER:[^:]+]]: i32
+  // CHECK-NOT: memref.load
+  // CHECK-NOT: scf.if
+  // CHECK: return %[[OTHER]] : i32
+  tt.func public @mask_false(%ptr: !tt.ptr<i32>, %other: i32) -> i32 {
+    %false = arith.constant false
+    %value = tt.load %ptr, %false, %other : !tt.ptr<i32>
+    tt.return %value : i32
+  }
+
+  // CHECK-LABEL: func.func @mask_false_without_other(
+  // CHECK-NOT: memref.load
+  // CHECK-NOT: scf.if
+  // CHECK: return %{{.*}} : f32
+  tt.func public @mask_false_without_other(%ptr: !tt.ptr<f32>) -> f32 {
+    %false = arith.constant false
+    %value = tt.load %ptr, %false : !tt.ptr<f32>
+    tt.return %value : f32
+  }
+}

--- a/third_party/ascend/unittest/pytest_ut/test_scalar_masked_load.py
+++ b/third_party/ascend/unittest/pytest_ut/test_scalar_masked_load.py
@@ -1,0 +1,51 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+import triton
+import triton.language as tl
+
+
+@triton.jit(do_not_specialize=["active_count"])
+def scalar_masked_load_kernel(src, dst, active_count, WITH_OTHER: tl.constexpr):
+    pid = tl.program_id(0)
+    active = pid < active_count
+    if WITH_OTHER:
+        value = tl.load(src + pid, mask=active, other=0)
+        tl.store(dst + pid, value)
+    else:
+        value = tl.load(src + pid, mask=active)
+        # The inactive load result is unspecified; leave the destination alone.
+        tl.store(dst + pid, value, mask=active)
+
+
+@pytest.mark.parametrize("dtype", [torch.int8, torch.int32, torch.float32, torch.bool])
+@pytest.mark.parametrize("active_count", [0, 5, 32])
+@pytest.mark.parametrize("with_other", [False, True])
+def test_scalar_masked_load(dtype, active_count, with_other):
+    source = (torch.arange(32) % 7 - 3).to(dtype)
+    src = source.npu()
+    dst = torch.full((32, ), 1, dtype=dtype, device="npu")
+    scalar_masked_load_kernel[(32, )](src, dst, active_count, with_other)
+    expected = torch.full((32, ), 0 if with_other else 1, dtype=dtype)
+    expected[:active_count] = source[:active_count]
+    torch.testing.assert_close(dst.cpu(), expected, rtol=0, atol=0)


### PR DESCRIPTION
Replace the single-element tensor splat/select/extract sequence with a scalar scf.if that guards the memory access. Use zero for unspecified inactive values when other is absent.