### PR TITLE
[ssbuffer](fix) Add new known NoMemoryEffectCall

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
@@ -48,9 +48,9 @@ static constexpr llvm::StringLiteral interceptrFunc[]{
     "_sparse_decode_kernel",
     "_sparse_decode_model1_kernel",
     "sparse_flash_attention_grad_kernel",
-    "parallel_path_fwd_kernel",
     "flex_attention_backward_dkdv_kernel",
     "flex_attention_backward_dkdv_kernel_tasklist",
+    "chunkwise_bwd_kernel_dhg",
 };
 
 static LogicalResult verifyFuncNames(ModuleOp module) {

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
@@ -123,7 +123,8 @@ remapEffectValue(const MemoryEffects::EffectInstance &effect, Value value) {
 
 bool isKnownNoMemoryEffectCall(Operation *op) {
   auto callOp = dyn_cast<func::CallOp>(op);
-  return callOp && callOp.getCallee().starts_with("triton_indirect_load");
+  return callOp && (callOp.getCallee().starts_with("triton_indirect_load") ||
+                    callOp.getCallee().starts_with("triton_stride_load"));
 }
 
 bool shouldAnalyzeAsLeaf(Operation *op) {

--- a/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable/PreCheckDisablePreload.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable/PreCheckDisablePreload.cpp
@@ -42,12 +42,8 @@ static const llvm::SmallVector<llvm::StringRef> kBlacklistFuncNames = {
     "kernel_sdpa_bwd_q",
     "_swa_paged_decode_kernel",
     "_mqa_logits_kernel",
-    "parallel_path_fwd_kernel",
-    "chunk_bwd_kernel_dv_local",
     "chunk_fwd_kernel_h",
     "_jagged_dense_flash_attention_bwd_dk_kernel",
-    "_gqa_sparse_decode_kernel",
-    "paged_decode_fd_reduce_kernel",
     "paged_decode_fd_kernel"};
 
 static constexpr const char *DEBUG_TYPE = "pre-check-disable-preload";


### PR DESCRIPTION
some function have noe memoryeffect, we skip them.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
