### PR TITLE
[ssbuffer](feat) add merge-cube-block pass

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/BlockDependencyGraph.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/BlockDependencyGraph.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_BLOCK_DEPENDENCY_GRAPH_H
+#define TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_BLOCK_DEPENDENCY_GRAPH_H
+
+#include "mlir/IR/Block.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include <memory>
+
+namespace mlir {
+namespace CVPipeline {
+
+// Forward declarations
+class MemoryDependenceGraph;
+class ComputeBlockIdManager;
+
+struct BlockNode {
+  int blockId;
+  llvm::SmallVector<Operation *> ops;
+  bool isCube;
+  int depth;
+
+  // Neighbour sets are stored directly on the node so that traversal and
+  // edge rewiring can avoid the extra hash lookup a separate map would
+  // require. Because each BlockNode is heap-allocated behind a unique_ptr,
+  // pointers stored here stay stable across insertions/erases in
+  // `BlockDependencyGraph::blockNodes`.
+  llvm::DenseSet<BlockNode *> predecessors;
+  llvm::DenseSet<BlockNode *> successors;
+};
+
+class BlockDependencyGraph {
+public:
+  BlockDependencyGraph(Block *block, const MemoryDependenceGraph &memGraph,
+                       ComputeBlockIdManager &bm);
+
+  // Build block-level dependency graph (only includes dependencies within
+  // current MLIR Block)
+  llvm::LogicalResult buildGraph();
+
+  BlockNode *getBlockNode(int blockId);
+  llvm::SmallVector<BlockNode *> getPredecessors(BlockNode *node);
+  llvm::SmallVector<BlockNode *> getSuccessors(BlockNode *node);
+
+  // computeDepth
+  void computeDepths();
+  int getDepth(int blockId);
+
+  // rebuildgraph
+  llvm::LogicalResult rebuildAfterMerge(BlockNode *target, BlockNode *source);
+
+  // BlockNode objects are owned by unique_ptr so that the address of a
+  // BlockNode is stable across insertions/erases in the DenseMap. The
+  // pointers stored in each BlockNode's predecessor/successor sets
+  // therefore remain valid for the lifetime of the graph.
+  llvm::DenseMap<int, std::unique_ptr<BlockNode>> blockNodes;
+
+private:
+  Block *block;
+  const MemoryDependenceGraph &memGraph;
+  ComputeBlockIdManager &bm;
+
+  void addEdge(BlockNode *from, BlockNode *to);
+
+  bool isInCurrentBlock(Operation *op);
+
+  // Recompute depths starting from `start` and propagating forward through
+  // its successor chain. Assumes predecessors of `start` already hold
+  // correct depths.
+  void recomputeDepthsFrom(BlockNode *start);
+};
+
+} // namespace CVPipeline
+} // namespace mlir
+
+#endif // TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_COMMON_BLOCK_DEPENDENCY_GRAPH_H

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_MERGE_CUBE_BLOCK_PASS_H
+#define TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_MERGE_CUBE_BLOCK_PASS_H
+
+#include "DynamicCVPipeline/Common/BlockDependencyGraph.h"
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+namespace CVPipeline {
+
+class MergeCubeBlockPass
+    : public PassWrapper<MergeCubeBlockPass, OperationPass<ModuleOp>> {
+public:
+  MergeCubeBlockPass() = default;
+
+  StringRef getArgument() const override { return "merge-cube-block"; }
+  StringRef getDescription() const override {
+    return "Merge cube blocks with same loaded data";
+  }
+
+  void runOnOperation() override;
+
+private:
+  llvm::LogicalResult processBlock(Block *block,
+                                   const MemoryDependenceGraph &memGraph,
+                                   ComputeBlockIdManager &bm);
+
+  bool canMergeBlocks(BlockNode *target, BlockNode *source,
+                      BlockDependencyGraph &graph,
+                      const MemoryDependenceGraph &memGraph,
+                      ComputeBlockIdManager &bm);
+
+  // Execute merge
+  llvm::LogicalResult mergeBlocks(BlockNode *target, BlockNode *source,
+                                  ComputeBlockIdManager &bm);
+
+  // Perform iterative merging by repeatedly scanning the live cube blocks.
+  llvm::LogicalResult performMerging(BlockDependencyGraph &graph,
+                                     const MemoryDependenceGraph &memGraph,
+                                     ComputeBlockIdManager &bm);
+
+  // Print graph structure
+  void printGraph(BlockDependencyGraph &graph);
+
+  bool hasCommonInputOrOutput(BlockNode *node1, BlockNode *node2,
+                              BlockDependencyGraph &graph);
+  bool hasSameDepth(BlockNode *node1, BlockNode *node2,
+                    BlockDependencyGraph &graph);
+  bool checkNoCycle(BlockNode *node1, BlockNode *node2,
+                    BlockDependencyGraph &graph,
+                    const MemoryDependenceGraph &memGraph,
+                    ComputeBlockIdManager &bm);
+
+  // Return the subset of `blocks` whose type (cube/vector) differs from
+  // `currentNode`'s. Returned as a DenseSet so callers can do O(N) set
+  // intersection directly.
+  llvm::DenseSet<BlockNode *>
+  getBlocksOfDifferentType(BlockNode *currentNode,
+                           llvm::ArrayRef<BlockNode *> blocks);
+};
+
+} // namespace CVPipeline
+} // namespace mlir
+
+namespace mlir {
+namespace triton {
+std::unique_ptr<OperationPass<ModuleOp>> createMergeCubeBlockPass();
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_ADAPTER_DYNAMIC_CV_PIPELINE_PLAN_COMPUTE_BLOCK_MERGE_CUBE_BLOCK_PASS_H

--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h
@@ -49,6 +49,7 @@ public:
 
   llvm::LogicalResult markOpBlockId(Operation *op);
   llvm::LogicalResult markOpsWithNewId(llvm::ArrayRef<Operation *> ops);
+  void updateBlockIdWithInner(Operation *parentOp, int targetId);
   void updateBlockId(Operation *op, int blockId);
 
   bool shouldInheritFromParent(Block *block, CoreType requiredCoreType) const;

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -167,6 +167,8 @@ private:
   mlir::Operation *getCopyPointBeforeStore(Value depValue,
                                            Operation *vectorEndOp,
                                            int iniProducerBlockId);
+  mlir::Operation *getFixpipePointAfterProducer(Value depValue,
+                                                int iniProducerBlockId);
   mlir::Operation *insertVectorToCubeTransfer(
       mlir::OpBuilder &builder, mlir::Value srcValue,
       mlir::Value normalizedValue, mlir::Operation *vectorEndOp,

--- a/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AnalyzeDataFlow/AnalyzeName.cpp
@@ -41,11 +41,19 @@ using namespace triton;
 namespace {
 
 static constexpr llvm::StringLiteral interceptrFunc[]{
-    "chunk_abc_bwd_kernel_dh",      "flash_varlen_fwd_kernel",
-    "chunk_gsa_bwd_k_kernel_dqkvg", "_jagged_flash_attention_bwd_basic_kernel",
-    "_sparse_decode_kernel",        "chunk_gsa_fwd_k_kernel_intra",
-    "_sparse_decode_model1_kernel", "sparse_flash_attention_grad_kernel",
-    "parallel_path_fwd_kernel"};
+    "chunk_abc_bwd_kernel_dh",
+    "flash_varlen_fwd_kernel",
+    "chunk_gsa_bwd_k_kernel_dqkvg",
+    "_jagged_flash_attention_bwd_basic_kernel",
+    "_sparse_decode_kernel",
+    "chunk_gsa_fwd_k_kernel_intra",
+    "_sparse_decode_model1_kernel",
+    "sparse_flash_attention_grad_kernel",
+    "parallel_path_fwd_kernel",
+    "_swa_bwd_dkdv_kernel",
+    "flex_attention_backward_dkdv_kernel",
+    "flex_attention_backward_dkdv_kernel_tasklist",
+};
 
 static LogicalResult verifyFuncNames(ModuleOp module) {
   bool intercepted = false;

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/BlockDependencyGraph.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/BlockDependencyGraph.cpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/BlockDependencyGraph.h"
+#include "DynamicCVPipeline/Common/DependencyHelper.h"
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "llvm/Support/Debug.h"
+#include <queue>
+
+using namespace mlir;
+using namespace CVPipeline;
+
+static constexpr const char *DEBUG_TYPE = "block-dependency-graph";
+#define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+#define LDBG(...) LLVM_DEBUG(DBGS() << __VA_ARGS__ << "\n")
+
+static bool isCubeSimpleOpOrCf(Operation *op) {
+  return !isSyncOp(op) && getCoreTypeOfSimpleOpOrCf(op) == CoreType::CUBE_ONLY;
+}
+
+BlockDependencyGraph::BlockDependencyGraph(
+    Block *block, const MemoryDependenceGraph &memGraph,
+    ComputeBlockIdManager &bm)
+    : block(block), memGraph(memGraph), bm(bm) {}
+
+llvm::LogicalResult BlockDependencyGraph::buildGraph() {
+  // Step 1: Collect all compute blocks (including cube and vector) in current
+  // MLIR Block
+  for (Operation &op : *block) {
+    int blockId = bm.getBlockIdByOp(&op);
+    if (blockId == -1)
+      continue;
+
+    if (!blockNodes.contains(blockId)) {
+      auto node = std::make_unique<BlockNode>();
+      node->blockId = blockId;
+      node->isCube = isCubeSimpleOpOrCf(&op);
+      node->depth = 0;
+      blockNodes[blockId] = std::move(node);
+    }
+
+    blockNodes[blockId]->ops.push_back(&op);
+  }
+
+  LDBG("Collected " << blockNodes.size() << " blocks");
+
+  // Step 2: Build dependency relationships between blocks (only in current MLIR
+  // Block)
+  DependencyHelper depHelper(memGraph);
+  for (auto &entry : blockNodes) {
+    BlockNode *consumerNode = entry.second.get();
+
+    for (Operation *op : consumerNode->ops) {
+      // Use DependencyHelper to iterate all source ops (SSA defs + memory
+      // exec-before) in one pass.
+      depHelper.forEachSource<DependencyHelper::SourceMode::Default>(
+          op, [&](Operation *source) {
+            if (!isInCurrentBlock(source))
+              return;
+
+            int sourceBlockId = bm.getBlockIdByOp(source);
+            if (sourceBlockId == -1 || sourceBlockId == consumerNode->blockId)
+              return;
+
+            BlockNode *producerNode = getBlockNode(sourceBlockId);
+            if (producerNode)
+              addEdge(producerNode, consumerNode);
+          });
+    }
+  }
+
+  // Step 3: Compute depths (for all blocks)
+  computeDepths();
+
+  return llvm::success();
+}
+
+bool BlockDependencyGraph::isInCurrentBlock(Operation *op) {
+  if (!op)
+    return false;
+
+  // Get the MLIR Block where op is located
+  Block *opBlock = op->getBlock();
+
+  // Check if it's in current MLIR Block
+  return opBlock == block;
+}
+
+void BlockDependencyGraph::addEdge(BlockNode *from, BlockNode *to) {
+  to->predecessors.insert(from);
+  from->successors.insert(to);
+}
+
+void BlockDependencyGraph::computeDepths() {
+  // Use topological sort to compute depth for each node
+  // Depth definition: maximum steps from nodes with zero in-degree
+  // Special rule: depth only increases when cube and vector type conversion
+  // occurs
+
+  llvm::DenseMap<BlockNode *, int> indegree;
+  std::queue<BlockNode *> queue;
+
+  // Initialize in-degree directly from each node's predecessor set.
+  for (auto &entry : blockNodes) {
+    BlockNode *node = entry.second.get();
+    indegree[node] = node->predecessors.size();
+    if (indegree[node] == 0) {
+      queue.push(node);
+      node->depth = 0;
+    }
+  }
+
+  // BFS to compute depths
+  while (!queue.empty()) {
+    BlockNode *current = queue.front();
+    queue.pop();
+
+    for (BlockNode *succ : current->successors) {
+      // Compute depth from current to succ
+      // If types are different (cube->vector or vector->cube), depth+1
+      // If types are the same, depth remains unchanged
+      int newDepth = current->depth;
+      if (current->isCube != succ->isCube) {
+        newDepth++;
+      }
+
+      // Update successor's depth (take maximum)
+      succ->depth = std::max(succ->depth, newDepth);
+
+      indegree[succ]--;
+      if (indegree[succ] == 0) {
+        queue.push(succ);
+      }
+    }
+  }
+
+  LDBG("Computed depths for all blocks");
+}
+
+int BlockDependencyGraph::getDepth(int blockId) {
+  auto it = blockNodes.find(blockId);
+  if (it != blockNodes.end()) {
+    return it->second->depth;
+  }
+  return -1;
+}
+
+BlockNode *BlockDependencyGraph::getBlockNode(int blockId) {
+  auto it = blockNodes.find(blockId);
+  if (it != blockNodes.end()) {
+    return it->second.get();
+  }
+  return nullptr;
+}
+
+llvm::SmallVector<BlockNode *>
+BlockDependencyGraph::getPredecessors(BlockNode *node) {
+  if (!node)
+    return {};
+  return llvm::SmallVector<BlockNode *>(node->predecessors.begin(),
+                                        node->predecessors.end());
+}
+
+llvm::SmallVector<BlockNode *>
+BlockDependencyGraph::getSuccessors(BlockNode *node) {
+  if (!node)
+    return {};
+  return llvm::SmallVector<BlockNode *>(node->successors.begin(),
+                                        node->successors.end());
+}
+
+void BlockDependencyGraph::recomputeDepthsFrom(BlockNode *start) {
+  // Walk forward through the successor chain starting at `start`. For each
+  // visited node, the new depth is propagated to its successors; a successor
+  // is enqueued again only when its depth actually grows. Since depth is
+  // monotonically non-decreasing, this terminates.
+  std::queue<BlockNode *> queue;
+  queue.push(start);
+  while (!queue.empty()) {
+    BlockNode *current = queue.front();
+    queue.pop();
+
+    for (BlockNode *succ : current->successors) {
+      int newDepth = current->depth;
+      if (current->isCube != succ->isCube)
+        newDepth++;
+      if (succ->depth < newDepth) {
+        succ->depth = newDepth;
+        queue.push(succ);
+      }
+    }
+  }
+
+  LDBG("Recomputed depths from block " << start->blockId);
+}
+
+llvm::LogicalResult BlockDependencyGraph::rebuildAfterMerge(BlockNode *target,
+                                                            BlockNode *source) {
+  // Merge node information: append source ops into target.
+  target->ops.append(source->ops.begin(), source->ops.end());
+
+  // Sanity check: source must be connected to the graph (either has at
+  // least one predecessor or one successor). Merging an isolated node is
+  // meaningless and indicates an unsupported scenario.
+  if (source->predecessors.empty() && source->successors.empty()) {
+    LDBG("Cannot merge block " << source->blockId
+                               << ": no predecessors or successors\n");
+    return llvm::failure();
+  }
+
+  // Re-direct every edge touching source so that it points to target.
+  // DenseSet::insert de-duplicates, so any edge target already owns from
+  // before the merge is preserved naturally.
+  //
+  // Note: the iteration loops read `source->predecessors` / `source->
+  // successors` while we mutate them in place. To avoid invalidating the
+  // current iterator we drain them into temporary vectors first. Using
+  // range insert on the destination keeps this O(N) overall.
+  llvm::SmallVector<BlockNode *> sourcePreds(source->predecessors.begin(),
+                                             source->predecessors.end());
+  llvm::SmallVector<BlockNode *> sourceSuccs(source->successors.begin(),
+                                             source->successors.end());
+
+  for (BlockNode *pred : sourcePreds) {
+    pred->successors.erase(source);
+    pred->successors.insert(target);
+  }
+  target->predecessors.insert(sourcePreds.begin(), sourcePreds.end());
+
+  for (BlockNode *succ : sourceSuccs) {
+    succ->predecessors.erase(source);
+    succ->predecessors.insert(target);
+  }
+  target->successors.insert(sourceSuccs.begin(), sourceSuccs.end());
+
+  // Drop the source node from blockNodes. The BlockNode object itself is
+  // destroyed here (unique_ptr is reset); only `source`'s local pointer
+  // value is invalidated, which we are done using.
+  int sourceId = source->blockId;
+  blockNodes.erase(source->blockId);
+
+  // Only the successor chain reachable from target is affected by the
+  // merge; recompute depth locally rather than walking the entire graph.
+  recomputeDepthsFrom(target);
+
+  LDBG("Rebuilt graph after merging block " << sourceId << " into "
+                                            << target->blockId);
+  return llvm::success();
+}

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeComputeBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeComputeBlockPass.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "ComputeBlockOpt/SplitIfByBlockId/Common.h"
+#include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
 #include "ascend/include/DynamicCVPipeline/Common/DependencyHelper.h"
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
@@ -516,12 +517,12 @@ public:
       return;
     }
 
-    auto intraBufCount =
-        module->getAttrOfType<IntegerAttr>(CVPipeline::kIntraBufCount);
-    auto interCoreBufCount =
-        module->getAttrOfType<IntegerAttr>(CVPipeline::kInterCoreBufCount);
-    if (!intraBufCount || !interCoreBufCount || intraBufCount.getInt() < 3 ||
-        interCoreBufCount.getInt() < 2) {
+    BufferCountManager bufMgr(module);
+    int intraBufCount =
+        bufMgr.getBufferCountByType(BufferCountManager::DepType::IntraCore);
+    int interCoreBufCount =
+        bufMgr.getBufferCountByType(BufferCountManager::DepType::InterCore);
+    if (intraBufCount < 3 || interCoreBufCount < 2) {
       LOG_DEBUG("MergeComputeBlock disabled: intraBufCount < 3 or "
                 "interCoreBufCount < 2");
       return;

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "ComputeBlockOpt/SplitIfByBlockId/Common.h"
+#include "DynamicCVPipeline/Common/BlockDependencyGraph.h"
+#include "DynamicCVPipeline/Common/MemoryEffectsTracker.h"
+#include "DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Common.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h"
+#include "mlir/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+using namespace CVPipeline;
+
+static constexpr const char *DEBUG_TYPE = "merge-cube-block";
+#define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
+#define LDBG(...) LLVM_DEBUG(DBGS() << __VA_ARGS__ << "\n")
+
+static const llvm::DenseSet<llvm::StringRef> kDisableMergeCubeKernel = {
+    "flex_attention_backward_dq_kernel",
+    "parallel_deltaformer_bwd_kernel_qk",
+    "_parallel_hstu_attn_bwd",
+    "chunk_kda_bwd_kernel_intra",
+    "chunk_gated_delta_rule_fwd_kernel_h_blockdim64",
+};
+
+void MergeCubeBlockPass::runOnOperation() {
+  auto moduleOp = getOperation();
+
+  if (hasFallbackAttr(moduleOp)) {
+    return;
+  }
+
+  for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
+    if (kDisableMergeCubeKernel.contains(funcOp.getSymName())) {
+      LDBG("Found unsupport kernel: " << funcOp.getSymName());
+      return;
+    }
+  }
+
+  auto &aa = getAnalysis<AliasAnalysis>();
+  auto memGraph = MemoryDependenceGraph(moduleOp, aa);
+  auto bm = ComputeBlockIdManager(moduleOp);
+
+  LDBG("Starting MergeCubeBlockPass\n" << moduleOp);
+
+  // Collect main loop body blocks via the shared walkMainLoop helper.
+  llvm::SmallVector<Block *> mainLoopBlocks;
+  if (failed(CVPipeline::SplitIf::walkMainLoop(
+          moduleOp, [&](Operation *loop) -> llvm::LogicalResult {
+            mainLoopBlocks.push_back(&loop->getRegion(0).front());
+            return llvm::success();
+          }))) {
+    CVPipeline::setFallbackAttr(moduleOp, CVPipeline::ERRCODE_FAILED);
+    return;
+  }
+
+  LDBG("Found " << mainLoopBlocks.size() << " main loop blocks\n");
+
+  // Process each main loop block
+  for (Block *block : mainLoopBlocks) {
+    if (failed(processBlock(block, memGraph, bm))) {
+      CVPipeline::setFallbackAttr(moduleOp, CVPipeline::ERRCODE_FAILED);
+      return;
+    }
+  }
+
+  LDBG("MergeCubeBlockPass completed\n" << moduleOp);
+}
+
+llvm::LogicalResult
+MergeCubeBlockPass::processBlock(Block *block,
+                                 const MemoryDependenceGraph &memGraph,
+                                 ComputeBlockIdManager &bm) {
+  LDBG("Processing Block: " << *block);
+  if (Operation *parentOp = block->getParentOp()) {
+    LDBG("  Parent operation: " << parentOp->getName().getStringRef());
+  }
+
+  // Step 1: Build Block dependency graph
+  BlockDependencyGraph graph(block, memGraph, bm);
+  if (failed(graph.buildGraph())) {
+    LDBG("Failed to build dependency graph");
+    return llvm::failure();
+  }
+
+  LDBG("Built dependency graph with " << graph.blockNodes.size()
+                                      << " blocks\n");
+
+  // If there are at least two cube blocks, print the graph for debugging.
+  LLVM_DEBUG({
+    unsigned cubeCount = 0;
+    for (auto &entry : graph.blockNodes)
+      if (entry.second->isCube)
+        ++cubeCount;
+    if (cubeCount >= 2) {
+      LDBG("=== Printing dependency graph for current region ===");
+      printGraph(graph);
+    }
+  });
+
+  // Step 2: Perform iterative merging. The nested loop inside performs the
+  // candidate selection itself by re-scanning the live cube blocks every
+  // round, so there is no separate findMergeCandidates phase.
+  if (failed(performMerging(graph, memGraph, bm))) {
+    LDBG("Failed to perform merging");
+    return llvm::failure();
+  }
+
+  return llvm::success();
+}
+
+llvm::LogicalResult
+MergeCubeBlockPass::performMerging(BlockDependencyGraph &graph,
+                                   const MemoryDependenceGraph &memGraph,
+                                   ComputeBlockIdManager &bm) {
+
+  // Collect the live cube blocks once. After every merge we simply drop
+  // the merged-out source from this list, so we never need to re-scan
+  // graph.blockNodes during the merging rounds.
+  llvm::SmallVector<BlockNode *> cubeBlocks;
+  for (auto &entry : graph.blockNodes) {
+    if (entry.second->isCube)
+      cubeBlocks.push_back(entry.second.get());
+  }
+
+  bool merged = true;
+  int mergeCount = 0;
+
+  while (merged) {
+    merged = false;
+
+    // Nested scan: outer index plays the role of target, inner index the
+    // role of source. As soon as one (target, source) pair is mergeable we
+    // commit, drop `source` from the list, and restart from the top of the
+    // round.
+    for (size_t i = 0; i < cubeBlocks.size() && !merged; ++i) {
+      for (size_t j = 0; j < cubeBlocks.size(); ++j) {
+        if (i == j)
+          continue;
+        BlockNode *target = cubeBlocks[i];
+        BlockNode *source = cubeBlocks[j];
+        if (!canMergeBlocks(target, source, graph, memGraph, bm))
+          continue;
+
+        LDBG("Merging block " << source->blockId << " into "
+                              << target->blockId);
+
+        // Execute merge
+        if (failed(mergeBlocks(target, source, bm))) {
+          LDBG("Failed to merge blocks");
+          return llvm::failure();
+        }
+        merged = true;
+        mergeCount++;
+
+        // Update graph structure. After this call, the BlockNode pointed to
+        // by `source` has been destroyed; the pointer value itself remains
+        // usable for equality checks, but any dereference is unsafe. The
+        // pointers for `target` and unrelated nodes stay valid because
+        // blockNodes.erase() does not rehash or relocate other entries.
+        //
+        // Note: mergeBlocks above has already re-tagged source's ops to
+        // target via the ComputeBlockIdManager, which is not transactional.
+        // A rebuildAfterMerge failure therefore leaves the graph and the
+        // blockIdManager in an inconsistent state, so we abort the whole
+        // merging pass and surface the error to processBlock.
+        if (failed(graph.rebuildAfterMerge(target, source))) {
+          LDBG("Failed to rebuild graph after merging "
+               << source->blockId << " into " << target->blockId);
+          return llvm::failure();
+        }
+
+        // Drop the merged-out source from the candidate list in place; we
+        // already know it lives at index j. The pointer itself is dangling
+        // after the rebuild but we only use its value for erase, which
+        // shifts elements down to fill the gap.
+        cubeBlocks.erase(cubeBlocks.begin() + j);
+        break;
+      }
+    }
+  }
+
+  LDBG("Merged " << mergeCount << " blocks\n");
+
+  return llvm::success();
+}
+
+bool MergeCubeBlockPass::canMergeBlocks(BlockNode *target, BlockNode *source,
+                                        BlockDependencyGraph &graph,
+                                        const MemoryDependenceGraph &memGraph,
+                                        ComputeBlockIdManager &bm) {
+
+  // Precondition: both blocks must be cube
+  if (!target || !source || !target->isCube || !source->isCube) {
+    return false;
+  }
+
+  // Step 1: Check if they have common input or output nodes
+  if (!hasCommonInputOrOutput(target, source, graph)) {
+    LDBG("Blocks " << target->blockId << " and " << source->blockId
+                   << " cannot merge: no common input or output nodes\n");
+    return false;
+  }
+
+  // Step 2: Check if merging would create a cycle
+  if (!checkNoCycle(target, source, graph, memGraph, bm)) {
+    LDBG("Blocks " << target->blockId << " and " << source->blockId
+                   << " cannot merge: would create cycle\n");
+    return false;
+  }
+
+  // Step 3: cube blocks at the same depth (with matching successor depths).
+  if (hasSameDepth(target, source, graph)) {
+    LDBG("Blocks " << target->blockId << " and " << source->blockId
+                   << " can merge: cube blocks have same depth\n");
+    return true;
+  }
+
+  LDBG("Blocks " << target->blockId << " and " << source->blockId
+                 << " cannot merge: unsupport scenario\n");
+  return false;
+}
+
+bool MergeCubeBlockPass::hasSameDepth(BlockNode *node1, BlockNode *node2,
+                                      BlockDependencyGraph &graph) {
+
+  if (!node1 || !node2) {
+    return false;
+  }
+
+  if (node1->depth != node2->depth) {
+    return false;
+  }
+
+  // Check that the max depth among successors of both blocks is the same
+  auto getMaxSuccDepth = [&](BlockNode *node) {
+    int maxDepth = -1;
+    for (BlockNode *succNode : graph.getSuccessors(node)) {
+      if (succNode && succNode->isCube != node->isCube &&
+          succNode->depth > maxDepth) {
+        maxDepth = succNode->depth;
+      }
+    }
+    return maxDepth;
+  };
+
+  int maxSuccDepth1 = getMaxSuccDepth(node1);
+  int maxSuccDepth2 = getMaxSuccDepth(node2);
+
+  // If either block has no successors, still mergeable
+  if (maxSuccDepth1 == -1 || maxSuccDepth2 == -1) {
+    return true;
+  }
+
+  return maxSuccDepth1 == maxSuccDepth2;
+}
+
+llvm::DenseSet<BlockNode *> MergeCubeBlockPass::getBlocksOfDifferentType(
+    BlockNode *currentNode, llvm::ArrayRef<BlockNode *> blocks) {
+
+  llvm::DenseSet<BlockNode *> result;
+  if (!currentNode)
+    return result;
+
+  // Filter blocks: only keep blocks with a different type than currentNode.
+  for (BlockNode *blockNode : blocks) {
+    if (blockNode && blockNode->isCube != currentNode->isCube)
+      result.insert(blockNode);
+  }
+  return result;
+}
+
+bool MergeCubeBlockPass::checkNoCycle(BlockNode *node1, BlockNode *node2,
+                                      BlockDependencyGraph &graph,
+                                      const MemoryDependenceGraph &memGraph,
+                                      ComputeBlockIdManager &bm) {
+
+  // Get all operations from node2 to be merged into node1
+  auto opsToUnify = bm.getOpsByBlockId(node2->blockId);
+
+  // Use willCreateCycle to check if merging would create a cycle
+  return !willCreateCycle(opsToUnify, memGraph, node1->blockId, bm);
+}
+
+bool MergeCubeBlockPass::hasCommonInputOrOutput(BlockNode *node1,
+                                                BlockNode *node2,
+                                                BlockDependencyGraph &graph) {
+
+  // Get predecessors and successors, then filter to opposite-type blocks.
+  // The filtered sets are already DenseSets, so set intersection is O(N).
+  auto filteredPreds1 =
+      getBlocksOfDifferentType(node1, graph.getPredecessors(node1));
+  auto filteredPreds2 =
+      getBlocksOfDifferentType(node2, graph.getPredecessors(node2));
+  auto filteredSuccs1 =
+      getBlocksOfDifferentType(node1, graph.getSuccessors(node1));
+  auto filteredSuccs2 =
+      getBlocksOfDifferentType(node2, graph.getSuccessors(node2));
+
+  // Check if there are common input nodes (predecessors).
+  bool hasCommonPred = llvm::any_of(
+      filteredPreds2, [&](BlockNode *p) { return filteredPreds1.count(p); });
+
+  // Check if there are common output nodes (successors).
+  bool hasCommonSucc = llvm::any_of(
+      filteredSuccs2, [&](BlockNode *s) { return filteredSuccs1.count(s); });
+
+  // Return true if they have common input OR output nodes.
+  return hasCommonPred || hasCommonSucc;
+}
+
+llvm::LogicalResult MergeCubeBlockPass::mergeBlocks(BlockNode *target,
+                                                    BlockNode *source,
+                                                    ComputeBlockIdManager &bm) {
+
+  // Merge all ops of source into target
+  auto sourceOps = bm.getOpsByBlockId(source->blockId);
+  for (Operation *op : sourceOps) {
+    bm.updateBlockId(op, target->blockId);
+  }
+
+  return llvm::success();
+}
+
+void MergeCubeBlockPass::printGraph(BlockDependencyGraph &graph) {
+
+  LDBG("Total blocks in graph: " << graph.blockNodes.size());
+
+  // Print all block nodes
+  for (auto &entry : graph.blockNodes) {
+    int blockId = entry.first;
+    BlockNode *node = entry.second.get();
+
+    LDBG("Block " << blockId << ":");
+    LDBG("  Type: " << (node->isCube ? "CUBE" : "VECTOR"));
+    LDBG("  Depth: " << node->depth);
+    LDBG("  Num ops: " << node->ops.size());
+
+    // Print predecessors
+    auto preds = graph.getPredecessors(node);
+    if (!preds.empty()) {
+      llvm::SmallVector<std::string> predStrs;
+      for (BlockNode *p : preds) {
+        predStrs.push_back(std::to_string(p->blockId));
+      }
+      LDBG("  Predecessors: [" << llvm::join(predStrs, ", ") << "]");
+    } else {
+      LDBG("  Predecessors: []");
+    }
+
+    // Print successors
+    auto succs = graph.getSuccessors(node);
+    if (!succs.empty()) {
+      llvm::SmallVector<std::string> succStrs;
+      for (BlockNode *s : succs) {
+        succStrs.push_back(std::to_string(s->blockId));
+      }
+      LDBG("  Successors: [" << llvm::join(succStrs, ", ") << "]");
+    } else {
+      LDBG("  Successors: []");
+    }
+  }
+
+  LDBG("=== End of graph ===");
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::triton::createMergeCubeBlockPass() {
+  return std::make_unique<MergeCubeBlockPass>();
+}

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MoveLoadIntoUserPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MoveLoadIntoUserPass.cpp
@@ -302,7 +302,7 @@ void MoveLoadIntoUserPass::runOnOperation() {
 
     // Update block_id for all ops
     for (auto *op : opsToMove) {
-      bm.updateBlockId(op, targetBlockId);
+      bm.updateBlockIdWithInner(op, targetBlockId);
     }
 
     LOG_DEBUG("Successfully moved ops to block " << targetBlockId);

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/UBUsageOptPass.cpp
@@ -550,42 +550,6 @@ DenseMap<int, int> UBUsageOptPass::collectRecordChange(
   return recordChange;
 }
 
-static void processOpsInblock(Operation *parentOp, int targetId,
-                              CVPipeline::ComputeBlockIdManager &bm) {
-  // If the parentOp's blockId is the same as every op's id in each of its
-  // blocks, we need to change the ops inside its blocks to targetId as well.
-  int parentBlockId = bm.getBlockIdByOp(parentOp);
-  if (parentBlockId == -1) {
-    return;
-  }
-  // LinalgDialect should have targetId only in prarent, the inner op shouldn't
-  // have blockId.
-  if (isa<linalg::LinalgDialect>(parentOp->getDialect())) {
-    return;
-  }
-
-  bool allSame = true;
-  parentOp->walk([&](Operation *op) {
-    auto innerBlockId = bm.getBlockIdByOp(op);
-    if (innerBlockId != -1 && innerBlockId != parentBlockId) {
-      allSame = false;
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
-
-  if (allSame) {
-    parentOp->walk([&](Operation *op) {
-      // Never fold a sync into a compute block: it must keep its own unique
-      // block id so the fence between before/after ops survives.
-      if (CVPipeline::isSyncOp(op)) {
-        return;
-      }
-      bm.updateBlockId(op, targetId);
-    });
-  }
-}
-
 bool applyRecordChange(DenseMap<int, int> &recordChange,
                        DenseMap<int, Operation *> &nodeId2op,
                        const CVPipeline::MemoryDependenceGraph &memGraph,
@@ -616,8 +580,7 @@ bool applyRecordChange(DenseMap<int, int> &recordChange,
     }
 
     for (auto op : willaddOps) {
-      processOpsInblock(op, targetBlockId, bm);
-      bm.updateBlockId(op, targetBlockId);
+      bm.updateBlockIdWithInner(op, targetBlockId);
     }
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -25,6 +25,7 @@
 #include "DynamicCVPipeline/PlanComputeBlock/Passes.h"
 #include "DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.h"
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlockPass.h"
 #include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlockPass.h"
 
@@ -79,6 +80,8 @@ void ComputeBlockOptPass::runOnOperation() {
   pm.addPass(createMergeComputeBlockPass());
   pm.addPass(createReorderOpsByBlockIdPass());
 
+  pm.addPass(createMergeCubeBlockPass());
+  pm.addPass(createReorderOpsByBlockIdPass());
   pm.addPass(createRelocateMemrefDeclPass());
 
   if (failed(runPipeline(pm, module))) {
@@ -115,6 +118,7 @@ void registerComputeBlockOptPasses() {
   registerPass(createMergeSmallBlockPass);
   registerPass(createSplitIfByBlockIdPass);
   registerPass(createMergeComputeBlockPass);
+  registerPass(createMergeCubeBlockPass);
   registerPass(createRelocateMemrefDeclPass);
 }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
@@ -32,6 +32,7 @@
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
+#include "mlir/Support/WalkResult.h"
 
 namespace mlir {
 namespace CVPipeline {
@@ -75,6 +76,43 @@ bool ComputeBlockIdManager::isSameBlock(Operation *a, Operation *b) {
 }
 
 int ComputeBlockIdManager::getNextId() { return cntComputeBlockId++; }
+
+void ComputeBlockIdManager::updateBlockIdWithInner(Operation *parentOp,
+                                                   int targetId) {
+  // If the parentOp's blockId is the same as every op's id in each of its
+  // blocks, we need to change the ops inside its blocks to targetId as well.
+  int parentBlockId = getBlockIdByOp(parentOp);
+  if (parentBlockId == -1) {
+    updateBlockId(parentOp, targetId);
+    return;
+  }
+  // LinalgDialect should have targetId only in prarent, the inner op shouldn't
+  // have blockId.
+  if (isa<linalg::LinalgDialect>(parentOp->getDialect())) {
+    updateBlockId(parentOp, targetId);
+    return;
+  }
+
+  auto ret = parentOp->walk([&](Operation *op) {
+    auto innerBlockId = getBlockIdByOp(op);
+    if (innerBlockId != -1 && innerBlockId != parentBlockId) {
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+
+  if (ret != WalkResult::interrupt()) {
+    parentOp->walk([&](Operation *op) {
+      // Never fold a sync into a compute block: it must keep its own unique
+      // block id so the fence between before/after ops survives.
+      if (CVPipeline::isSyncOp(op)) {
+        return;
+      }
+      updateBlockId(op, targetId);
+    });
+  }
+  updateBlockId(parentOp, targetId);
+}
 
 void ComputeBlockIdManager::updateBlockId(Operation *op, int blockId) {
   if (!op) {

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -59,7 +59,7 @@ using namespace mlir;
 static constexpr const char *DEBUG_TYPE = "ReorderOpsByBlockIdPass";
 
 #define DBGS(...) LLVM_DEBUG(llvm::dbgs() << __VA_ARGS__)
-#define LOG_DEBUG(...) DBGS("\n[" << DEBUG_TYPE << "] " << __VA_ARGS__)
+#define LOG_DEBUG(...) DBGS("[" << DEBUG_TYPE << "] " << __VA_ARGS__)
 
 using namespace triton;
 using namespace CVPipeline;

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -670,6 +670,16 @@ InterCoreTransferAndSyncPass::getConsumerWaitPoint(int transferIndex) {
   return consumerWaitPoint;
 }
 
+mlir::Operation *InterCoreTransferAndSyncPass::getFixpipePointAfterProducer(
+    Value srcValue, int producerBlockId) {
+  mlir::Operation *fixpipePoint = srcValue.getDefiningOp();
+  int blockId = CVPipeline::getOpBlockId(fixpipePoint).value_or(-1);
+  if (blockId != producerBlockId) {
+    return nullptr;
+  }
+  return fixpipePoint;
+}
+
 Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
     OpBuilder &builder, Value srcValue, Value normalizedValue,
     Operation *vectorEndOp, Operation *cubeStartOp, Location loc,
@@ -1566,6 +1576,14 @@ LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(
   LOG_DEBUG("[newProdEnd]" << *prodEnd << "\n");
   LOG_DEBUG("[newConsStart]" << *consStart << "\n");
   LOG_DEBUG("[newConsEnd]" << *consEnd << "\n");
+
+  if (!isa<scf::ForOp, scf::WhileOp, scf::IfOp>(srcValue.getDefiningOp())) {
+    auto producerPoint =
+        getFixpipePointAfterProducer(srcValue, dep.iniProducerBlockId);
+    if (producerPoint) {
+      prodEnd = producerPoint;
+    }
+  }
 
   // uses of srcValue. Only applied when the source op belongs to a
   // sub-block.

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_cube_block.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/ComputeBlockOpt/merge_cube_block.mlir
@@ -1,0 +1,245 @@
+// RUN: triton-opt --merge-cube-block %s | FileCheck %s
+
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">} {
+  // ============================================
+  // Test Case 1: @test_merge_cube_blocks_with_vector
+  // ============================================
+  // Scenario: Two cube blocks with same vector predecessors and successors
+  // - Vector block 1 (block_id=1) produces vec_tensor1
+  // - Cube block 1 (block_id=2) uses vec_tensor1, produces cube_tensor1
+  // - Cube block 2 (block_id=3) uses vec_tensor1, produces cube_tensor2
+  // - Vector block 2 (block_id=4) uses cube_tensor1 and cube_tensor2
+  // Expected: The two cube blocks should be merged (block_id=3 -> block_id=2)
+  // Wrapped in two-layer for loop (only innermost should be processed)
+  // ============================================
+  // CHECK-LABEL: func.func @test_merge_cube_blocks_with_vector
+  func.func @test_merge_cube_blocks_with_vector(%arg0: memref<?xbf16>, %arg1: memref<?xbf16>, %arg2: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %cst_f32 = arith.constant 0.000000e+00 : f32
+
+    scf.for %i = %c0 to %c128 step %c1 {
+      scf.for %j = %c0 to %c128 step %c1 {
+        %vec_alloc1 = memref.alloc() {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16>
+        %vec_cond1 = arith.constant 1 : i1
+        scf.if %vec_cond1 {
+          linalg.fill {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : bf16) outs(%vec_alloc1 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 1 : i32}
+        %vec_tensor1 = bufferization.to_tensor %vec_alloc1 restrict writable {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16> to tensor<128x128xbf16>
+
+        // CHECK: %{{.*}} = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_alloc1 = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_cond1 = arith.constant 1 : i1
+        // CHECK: scf.if %{{.*}} {
+        // CHECK:   linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+        scf.if %cube_cond1 {
+          linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc1 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 2 : i32}
+        %cube_tensor1 = bufferization.to_tensor %cube_alloc1 restrict writable {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+        %cube_out1 = tensor.empty() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_matmul1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor1 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out1 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+        // CHECK: %{{.*}} = memref.alloc() {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_alloc2 = memref.alloc() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_cond2 = arith.constant 1 : i1
+        // CHECK: scf.if %{{.*}} {
+        // CHECK:   linalg.fill {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+        scf.if %cube_cond2 {
+          linalg.fill {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc2 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 3 : i32}
+        %cube_tensor2 = bufferization.to_tensor %cube_alloc2 restrict writable {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+        %cube_out2 = tensor.empty() {ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_matmul2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 3 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor2 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+        %vec_alloc2 = memref.alloc() {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32>
+        %vec_cond2 = arith.constant 1 : i1
+        scf.if %vec_cond2 {
+          linalg.fill {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_f32 : f32) outs(%vec_alloc2 : memref<128x128xf32>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 4 : i32}
+        // Uses both cube_matmul1 and cube_matmul2
+        %vec_add = arith.addf %cube_matmul1, %cube_matmul2 {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+        %vec_tensor2 = bufferization.to_tensor %vec_alloc2 restrict writable {ssbuffer.block_id = 4 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32> to tensor<128x128xf32>
+
+        scf.yield
+      }
+    }
+
+    return
+  }
+
+  // ============================================
+  // Test Case 2: @test_no_merge_with_extra_vector_dependency
+  // ============================================
+  // Scenario: Based on scenario 1, add an extra vector node pointing to one cube block
+  // - Vector block 5 (block_id=5) produces vec_tensor1
+  // - Vector block 9 (block_id=9) produces vec_tensor3
+  // - Cube block 6 (block_id=6) uses vec_tensor1, produces cube_matmul1
+  // - Cube block 7 (block_id=7) uses vec_tensor3, produces cube_matmul2
+  // - Vector block 8 (block_id=8) uses cube_matmul1 and cube_matmul2
+  // Expected: The two cube blocks should NOT be merged (different source nodes)
+  // Wrapped in two-layer for loop
+  // ============================================
+  // CHECK-LABEL: func.func @test_no_merge_with_extra_vector_dependency
+  func.func @test_no_merge_with_extra_vector_dependency(%arg0: memref<?xbf16>, %arg1: memref<?xbf16>, %arg2: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %cst_f32 = arith.constant 0.000000e+00 : f32
+
+    // Outer for loop
+    scf.for %i = %c0 to %c128 step %c1 {
+      // Inner for loop (innermost, should be processed)
+      scf.for %j = %c0 to %c128 step %c1 {
+        // Vector block 1 (predecessor for cube block 1)
+        %vec_alloc1 = memref.alloc() {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16>
+        %vec_cond1 = arith.constant 1 : i1
+        scf.if %vec_cond1 {
+          linalg.fill {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : bf16) outs(%vec_alloc1 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 5 : i32}
+        %vec_tensor1 = bufferization.to_tensor %vec_alloc1 restrict writable {ssbuffer.block_id = 5 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16> to tensor<128x128xbf16>
+
+        // Cube block 1 (block_id=2) - uses vec_tensor1
+        // CHECK: memref.alloc() {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_alloc1 = memref.alloc() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_cond1 = arith.constant 1 : i1
+        // CHECK: scf.if %{{.*}} {
+        // CHECK:   linalg.fill {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
+        scf.if %cube_cond1 {
+          linalg.fill {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc1 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 6 : i32}
+        %cube_tensor1 = bufferization.to_tensor %cube_alloc1 restrict writable {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+        %cube_out1 = tensor.empty() {ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_matmul1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 6 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor1 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out1 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+        // Extra vector block (block_id=5) - only used by cube block 2
+        %vec_alloc3 = memref.alloc() {ssbuffer.block_id = 9 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16>
+        %vec_cond3 = arith.constant 1 : i1
+        scf.if %vec_cond3 {
+          linalg.fill {ssbuffer.block_id = 9 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : bf16) outs(%vec_alloc3 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 9 : i32}
+        %vec_tensor3 = bufferization.to_tensor %vec_alloc3 restrict writable {ssbuffer.block_id = 9 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16> to tensor<128x128xbf16>
+
+        // Cube block 2 (block_id=3) - should NOT be merged (different source nodes)
+        // Uses vec_tensor3
+        // CHECK: memref.alloc() {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
+        %cube_alloc2 = memref.alloc() {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+        %cube_cond2 = arith.constant 1 : i1
+        // CHECK: scf.if %{{.*}} {
+        // CHECK:   linalg.fill {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
+        scf.if %cube_cond2 {
+          linalg.fill {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc2 : memref<128x128xbf16>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 7 : i32}
+        %cube_tensor2 = bufferization.to_tensor %cube_alloc2 restrict writable {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+        %cube_out2 = tensor.empty() {ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+        // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"}
+        // Uses vec_tensor3 as one of the inputs
+        %cube_matmul2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 7 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor3, %cube_tensor2 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+        // Vector block 2 (successor for both cube blocks)
+        // Uses both cube_matmul1 and cube_matmul2
+        %vec_alloc2 = memref.alloc() {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32>
+        %vec_cond2 = arith.constant 1 : i1
+        scf.if %vec_cond2 {
+          linalg.fill {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_f32 : f32) outs(%vec_alloc2 : memref<128x128xf32>)
+        } {hivm.unlikely_condition, ssbuffer.block_id = 8 : i32}
+        %vec_add = arith.addf %cube_matmul1, %cube_matmul2 {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+        %vec_tensor2 = bufferization.to_tensor %vec_alloc2 restrict writable {ssbuffer.block_id = 8 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32> to tensor<128x128xf32>
+
+        scf.yield
+      }
+    }
+
+    return
+  }
+
+  // ============================================
+  // Test Case 3: @test_no_merge_single_layer_for
+  // ============================================
+  // Scenario: Same as scenario 1, but only one layer of for loop
+  // - Vector block 1 (block_id=1) produces vec_tensor1
+  // - Cube block 1 (block_id=2) uses vec_tensor1, produces cube_matmul1
+  // - Cube block 2 (block_id=3) uses vec_tensor1, produces cube_matmul2
+  // - Vector block 2 (block_id=4) uses cube_matmul1 and cube_matmul2
+  // Expected: The two cube blocks should NOT be merged (not innermost loop)
+  // Only one layer of for loop
+  // ============================================
+  // CHECK-LABEL: func.func @test_no_merge_single_layer_for
+  func.func @test_no_merge_single_layer_for(%arg0: memref<?xbf16>, %arg1: memref<?xbf16>, %arg2: memref<?xf32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %cst_f32 = arith.constant 0.000000e+00 : f32
+
+    // Single layer for loop (not innermost, should NOT be processed)
+    scf.for %i = %c0 to %c128 step %c1 {
+      // Vector block 1 (predecessor for both cube blocks)
+      %vec_alloc1 = memref.alloc() {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16>
+      %vec_cond1 = arith.constant 1 : i1
+      scf.if %vec_cond1 {
+        linalg.fill {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst : bf16) outs(%vec_alloc1 : memref<128x128xbf16>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 15 : i32}
+      %vec_tensor1 = bufferization.to_tensor %vec_alloc1 restrict writable {ssbuffer.block_id = 15 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xbf16> to tensor<128x128xbf16>
+
+      // Cube block 1 (block_id=2) - should remain unchanged
+      // CHECK: memref.alloc() {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"}
+      %cube_alloc1 = memref.alloc() {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+      %cube_cond1 = arith.constant 1 : i1
+      // CHECK: scf.if %{{.*}} {
+      // CHECK:   linalg.fill {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"}
+      scf.if %cube_cond1 {
+        linalg.fill {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc1 : memref<128x128xbf16>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 16 : i32}
+      %cube_tensor1 = bufferization.to_tensor %cube_alloc1 restrict writable {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+      %cube_out1 = tensor.empty() {ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+      // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"}
+      %cube_matmul1 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 16 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor1 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out1 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+      // Cube block 2 (block_id=3) - should remain unchanged
+      // CHECK: memref.alloc() {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"}
+      %cube_alloc2 = memref.alloc() {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16>
+      %cube_cond2 = arith.constant 1 : i1
+      // CHECK: scf.if %{{.*}} {
+      // CHECK:   linalg.fill {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"}
+      scf.if %cube_cond2 {
+        linalg.fill {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc2 : memref<128x128xbf16>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 17 : i32}
+      %cube_tensor2 = bufferization.to_tensor %cube_alloc2 restrict writable {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xbf16> to tensor<128x128xbf16>
+      %cube_out2 = tensor.empty() {ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+      // CHECK: linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"}
+      %cube_matmul2 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 17 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor1, %cube_tensor2 : tensor<128x128xbf16>, tensor<128x128xbf16>) outs(%cube_out2 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+      // Vector block 2 (successor for both cube blocks)
+      // Uses both cube_matmul1 and cube_matmul2
+      %vec_alloc2 = memref.alloc() {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32>
+      %vec_cond2 = arith.constant 1 : i1
+      scf.if %vec_cond2 {
+        linalg.fill {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} ins(%cst_f32 : f32) outs(%vec_alloc2 : memref<128x128xf32>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 18 : i32}
+      %vec_add = arith.addf %cube_matmul1, %cube_matmul2 {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+      %vec_tensor2 = bufferization.to_tensor %vec_alloc2 restrict writable {ssbuffer.block_id = 18 : i32, ssbuffer.core_type = "VECTOR"} : memref<128x128xf32> to tensor<128x128xf32>
+
+
+      %cube_alloc3 = memref.alloc() {ssbuffer.block_id = 19 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf32>
+      %cube_cond3 = arith.constant 1 : i1
+      scf.if %cube_cond3 {
+        linalg.fill {ssbuffer.block_id = 19 : i32, ssbuffer.core_type = "CUBE"} ins(%cst : bf16) outs(%cube_alloc3 : memref<128x128xf32>)
+      } {hivm.unlikely_condition, ssbuffer.block_id = 19 : i32}
+      %cube_tensor3 = bufferization.to_tensor %cube_alloc3 restrict writable {ssbuffer.block_id = 19 : i32, ssbuffer.core_type = "CUBE"} : memref<128x128xf32> to tensor<128x128xf32>
+      %cube_out3 = tensor.empty() {ssbuffer.block_id = 19 : i32, ssbuffer.core_type = "CUBE"} : tensor<128x128xf32>
+      %cube_matmul3 = linalg.matmul {input_precision = "ieee", ssbuffer.block_id = 19 : i32, ssbuffer.core_type = "CUBE"} ins(%vec_tensor2, %cube_tensor3 : tensor<128x128xf32>, tensor<128x128xf32>) outs(%cube_out3 : tensor<128x128xf32>) -> tensor<128x128xf32>
+
+
+      %vec_add3 = arith.addf %cube_matmul2, %cube_matmul3 {ssbuffer.block_id = 20 : i32, ssbuffer.core_type = "VECTOR"} : tensor<128x128xf32>
+      scf.yield
+    }
+
+    return
+  }
+}


### PR DESCRIPTION
Add merge-cube-block pass in compute-block-opt of ssbuffer
if there are two cube blocks with restrict same vector predecessors and successors,
they are supposed to be merge into one block.

       V1                  V1     
     /     \                |
    ▼    ▼                  ▼
    C1   C2     ->          C
     \      /               |
      ▼ ▼                   ▼
        V2                  V2

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
