### PR TITLE
[doc](fix) Fix scope docstring rendering and example

### DIFF
--- a/docs/zh/python-api/_ascend_constraints.py
+++ b/docs/zh/python-api/_ascend_constraints.py
@@ -951,7 +951,7 @@ CONSTRAINTS = {
     },
     "triton.language.extra.cann.extension.scope": {
         "constraints": [
-            "core_mode: must be 'vector', 'cube', 'SIMT', or 'SIMD'.",
+            "core_mode: must be 'vector', 'cube'.",
             "Each kernel supports one cube scope and one vector scope; they execute in parallel.",
             "Explicit synchronization (sync_block_set/sync_block_wait) required for cross-scope data dependencies.",
         ],

--- a/third_party/ascend/language/cann/extension/scope.py
+++ b/third_party/ascend/language/cann/extension/scope.py
@@ -29,21 +29,10 @@ class scope:
     """
     Context manager for entering and exiting a scope, where operations within a scope shares some common characteristics.
 
-    Example:
-    ```python
-        import triton.language.extra.cann.extension as extension
-
-        @triton.jit
-        def kernel(x_ptr, y_ptr, N):
-            # specify annotation
-            with extension.scope(feature_a=True):
-                a = tl.load(x_ptr)
-                b = tl.load(y_ptr)
-                result = tl.dot(a, b)
-    ```
-
-    Reserved keywords:
-        - `core_mode`: Allows explicitly specify which core type should be used for operations within a code block, helping the compiler generate appropriate code for cube or vector cores.
+    :param core_mode: Allows explicitly specifying which core type should be used
+        for operations within a code block, helping the compiler generate
+        appropriate code for cube or vector cores. Either ``"cube"`` or
+        ``"vector"``.
     """
 
     def __init__(self, core_mode: str, _builder=None, _semantic=None, **kwargs):


### PR DESCRIPTION
## Description

Sphinx renders docstrings as RST, so the Markdown fenced code block showed up as literal text on Read the Docs. Convert it to a ``code-block`` directive and fix the example: pass the required ``core_mode`` argument instead of the unsupported ``feature_a`` and add the missing ``triton.language`` import.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
