### PR TITLE
[ssbuffer](fix) Reorder consider multi-region

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -345,6 +345,19 @@ GroupAdjacencyGraph::computeTopologicalOrder() {
   return llvm::failure();
 }
 
+static bool isStoreLikeWithRegion(Operation *op) {
+  if (isa<hivm::StoreOp, bufferization::MaterializeInDestinationOp>(op)) {
+    return true;
+  }
+  auto ret = op->walk([&](Operation *subOp) {
+    if (isa<hivm::StoreOp, bufferization::MaterializeInDestinationOp>(subOp)) {
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return ret == WalkResult::interrupt();
+}
+
 // Stable sort ops based on their group orders
 static llvm::FailureOr<SmallVector<Operation *>>
 buildReorderedOps(const BlockOpGraph &graph,
@@ -361,7 +374,7 @@ buildReorderedOps(const BlockOpGraph &graph,
     SmallVector<Operation *> storeOps;
     for (Operation *op : graph.ops) {
       if (opBlockId.at(op) == blockId) {
-        if (isa<hivm::StoreOp, bufferization::MaterializeInDestinationOp>(op)) {
+        if (isStoreLikeWithRegion(op)) {
           storeOps.push_back(op);
           continue;
         }


### PR DESCRIPTION
# Summary

Fix the reorder logic for multi-region operations.

Previously, only top-level `hivm::StoreOp` and
`bufferization::MaterializeInDestinationOp` were treated as store operations
during reordering. This could miss store-like operations nested inside
operations with regions.

This PR adds recursive detection for store-like operations and ensures that
operations containing `hivm::StoreOp` or
`bufferization::MaterializeInDestinationOp` in their regions are handled as
store operations during reordering.

# Changes

* Add `isStoreLikeWithRegion` to detect store-like operations recursively.
* Handle multi-region operations containing store-like operations during
  `ReorderOpsByBlockId`.
* Preserve the correct ordering of store operations in multi-region scenarios.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
