### PR TITLE
[ssbuffer](feat) keep unrolled page loaders on CUBE

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/CubePageLoaders.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/CubePageLoaders.h
@@ -20,43 +20,31 @@
  * THE SOFTWARE.
  */
 
-#ifndef TRITON_ADAPTER_BLOCK_ID_OPT_PASS_H
-#define TRITON_ADAPTER_BLOCK_ID_OPT_PASS_H
+#ifndef TRITON_ASCEND_DYNAMIC_CV_PIPELINE_CUBE_PAGE_LOADERS_H
+#define TRITON_ASCEND_DYNAMIC_CV_PIPELINE_CUBE_PAGE_LOADERS_H
 
-#include "mlir/Dialect/Linalg/TransformOps/DialectExtension.h"
-#include "mlir/Dialect/Linalg/Transforms/TilingInterfaceImpl.h"
-#include "mlir/Dialect/SCF/TransformOps/SCFTransformOps.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/Pass/Pass.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "llvm/ADT/SmallVector.h"
+#include <optional>
 
-namespace mlir {
-namespace triton {
+namespace mlir::CVPipeline {
 
-class ComputeBlockOptPass
-    : public PassWrapper<ComputeBlockOptPass, OperationPass<ModuleOp>> {
-public:
-  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(ComputeBlockOptPass)
-
-  ComputeBlockOptPass() = default;
-
-  void getDependentDialects(DialectRegistry &registry) const override;
-
-  void runOnOperation() override;
-
-  StringRef getArgument() const override { return "compute-block-opt"; }
-
-  StringRef getDescription() const override {
-    return "Optimize block_id assignment and operation sequencing";
-  }
-
-private:
+struct CubePageLoader {
+  tensor::InsertSliceOp insert;
+  bufferization::ToTensorOp tensor;
+  memref::CopyOp copy;
+  // The private page buffer, its views, and its zero initialization.
+  SmallVector<Operation *> bufferOps;
 };
 
-std::unique_ptr<OperationPass<ModuleOp>> createComputeBlockOptPass();
+// Recognize a complete, ordered row concatenation of private GM page loads.
+// Shared by classification and materialization: a chain must be lowerable to
+// direct GM-to-L1 DMA before it can be assigned to CUBE.
+std::optional<SmallVector<CubePageLoader>>
+getCubePageLoaders(tensor::InsertSliceOp root);
 
-void registerComputeBlockOptPasses();
+} // namespace mlir::CVPipeline
 
-} // namespace triton
-} // namespace mlir
-
-#endif // TRITON_ADAPTER_BLOCK_ID_OPT_PASS_H
+#endif

--- a/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/ComputeBlockOpt/Passes.h
@@ -37,6 +37,7 @@ void registerUnifyAllocBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMergeVectorIfBlockPass();
 void registerMergeVectorIfBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMergeCubeForBlockPass();
+std::unique_ptr<OperationPass<ModuleOp>> createMaterializeCubePageLoadersPass();
 void registerMergeCubeForBlockPass();
 std::unique_ptr<OperationPass<ModuleOp>> createUnifyStoreBlockPass();
 void registerUnifyStoreBlockPass();

--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h
@@ -103,6 +103,7 @@ private:
 
   // Upstream pattern matching helpers
   void matchToTensorPattern(Operation *def);
+  void matchInsertSlicePattern(Operation *def);
   void matchTransposePattern(Operation *def);
   void matchFillPattern(Operation *def);
   void matchEmptyPattern(Operation *def);

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MaterializeCubePageLoadersPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MaterializeCubePageLoadersPass.cpp
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "DynamicCVPipeline/Common/Utils.h"
+#include "DynamicCVPipeline/ComputeBlockOpt/CubePageLoaders.h"
+#include "DynamicCVPipeline/ComputeBlockOpt/Passes.h"
+#include "bishengir/Dialect/Annotation/IR/Annotation.h"
+#include "bishengir/Dialect/HIVM/IR/HIVM.h"
+#include "bishengir/Dialect/HIVM/Utils/Utils.h"
+#include "bishengir/Dialect/Utils/Util.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
+#include "llvm/ADT/SetVector.h"
+#include <algorithm>
+
+using namespace mlir;
+
+namespace {
+
+bool isZero(Value value) { return matchPattern(value, m_PosZeroFloat()); }
+
+bool isGMSource(Value value) {
+  while (true) {
+    auto space = hivm::getOptionalHIVMAddressSpace(value.getType());
+    if (space && *space != hivm::AddressSpace::GM)
+      return false;
+    auto view = value.getDefiningOp<ViewLikeOpInterface>();
+    if (!view)
+      break;
+    value = view.getViewSource();
+  }
+  if (auto arg = dyn_cast<BlockArgument>(value))
+    return isa<func::FuncOp>(arg.getOwner()->getParentOp());
+  auto space = hivm::getOptionalHIVMAddressSpace(value.getType());
+  return space && *space == hivm::AddressSpace::GM;
+}
+
+std::optional<CVPipeline::CubePageLoader>
+getPageLoader(tensor::InsertSliceOp insert) {
+  auto tensor = insert.getSource().getDefiningOp<bufferization::ToTensorOp>();
+  if (!tensor || !tensor->hasOneUse() ||
+      utils::getAnnotateOpWithAttr(tensor.getResult(),
+                                   hivm::kMayImplicitTransposeWithLastAxis))
+    return std::nullopt;
+  auto alloc = tensor.getBuffer().getDefiningOp<memref::AllocOp>();
+  if (!alloc ||
+      alloc.getType().getShape() != insert.getSourceType().getShape() ||
+      alloc->getBlock() != insert->getBlock() ||
+      tensor->getBlock() != insert->getBlock())
+    return std::nullopt;
+
+  CVPipeline::CubePageLoader page{insert, tensor, {}, {}};
+  SmallVector<Value> worklist{alloc.getResult()};
+  llvm::SetVector<Operation *> bufferOps;
+  bufferOps.insert(alloc);
+  bool padded = false;
+  while (!worklist.empty()) {
+    Value buffer = worklist.pop_back_val();
+    for (Operation *user : buffer.getUsers()) {
+      if (user == tensor)
+        continue;
+      if (auto view = dyn_cast<memref::SubViewOp>(user)) {
+        // Only the leading rectangular mask used by a contiguous page load.
+        if (view.getSource() != alloc ||
+            llvm::any_of(view.getStaticOffsets(),
+                         [](int64_t x) { return x != 0; }) ||
+            llvm::any_of(view.getStaticStrides(),
+                         [](int64_t x) { return x != 1; }) ||
+            view.getStaticSizes()[1] <= 0 ||
+            view.getStaticSizes()[1] > alloc.getType().getDimSize(1))
+          return std::nullopt;
+        if (bufferOps.insert(view))
+          worklist.push_back(view.getResult());
+        continue;
+      }
+      if (auto copy = dyn_cast<memref::CopyOp>(user)) {
+        if (copy.getTarget() != buffer || page.copy ||
+            copy->getBlock() != insert->getBlock() ||
+            !isGMSource(copy.getSource()))
+          return std::nullopt;
+        page.copy = copy;
+        continue;
+      }
+      if (auto fill = dyn_cast<linalg::FillOp>(user)) {
+        if (fill.getOutputs()[0] != alloc || !isZero(fill.getInputs()[0]))
+          return std::nullopt;
+        padded = true;
+        bufferOps.insert(fill);
+        continue;
+      }
+      if (isa<annotation::MarkOp>(user) &&
+          !user->hasAttr(hivm::kMayImplicitTransposeWithLastAxis)) {
+        bufferOps.insert(user);
+        continue;
+      }
+      return std::nullopt;
+    }
+  }
+  if (!page.copy || !page.copy->isBeforeInBlock(tensor))
+    return std::nullopt;
+  // Moving initialization past a writer would change the loaded values.
+  for (Operation *op : bufferOps) {
+    if (!isa<linalg::FillOp>(op))
+      continue;
+    while (op && op->getBlock() != insert->getBlock())
+      op = op->getParentOp();
+    if (!op || !op->isBeforeInBlock(page.copy))
+      return std::nullopt;
+  }
+  auto srcType = dyn_cast<MemRefType>(page.copy.getSource().getType());
+  SmallVector<int64_t> strides;
+  int64_t offset;
+  if (!srcType || srcType.getRank() != 2 ||
+#if defined(__LLVM_MAJOR_VERSION_22_COMPATIBLE__)
+      failed(srcType.getStridesAndOffset(strides, offset)) ||
+#else
+      failed(getStridesAndOffset(srcType, strides, offset)) ||
+#endif
+      strides[1] != 1 || srcType.getDimSize(1) <= 0 ||
+      srcType.getDimSize(1) > alloc.getType().getDimSize(1))
+    return std::nullopt;
+  if (!padded && srcType.getShape() != alloc.getType().getShape())
+    return std::nullopt;
+  page.bufferOps.assign(bufferOps.begin(), bufferOps.end());
+  return page;
+}
+
+} // namespace
+
+std::optional<SmallVector<CVPipeline::CubePageLoader>>
+CVPipeline::getCubePageLoaders(tensor::InsertSliceOp root) {
+  if (!root)
+    return std::nullopt;
+  auto type = root.getType();
+  if (type.getRank() != 2 || !type.hasStaticShape() ||
+      (!type.getElementType().isF16() && !type.getElementType().isBF16()) ||
+      type.getDimSize(0) <= 0 || type.getDimSize(1) <= 0 ||
+      type.getDimSize(0) % 16 || type.getDimSize(1) % 16)
+    return std::nullopt;
+
+  int64_t end = type.getDimSize(0);
+  SmallVector<CubePageLoader> pages;
+  Value current = root.getResult();
+  while (auto insert = current.getDefiningOp<tensor::InsertSliceOp>()) {
+    auto sourceType = insert.getSourceType();
+    if (insert != root && !insert->hasOneUse())
+      return std::nullopt;
+    if (insert->getBlock() != root->getBlock() || sourceType.getRank() != 2 ||
+        !sourceType.hasStaticShape() || insert.getType() != type ||
+        insert.getStaticOffsets()[1] != 0 ||
+        insert.getStaticSizes()[1] != type.getDimSize(1) ||
+        insert.getStaticSizes()[0] != sourceType.getDimSize(0) ||
+        llvm::any_of(insert.getStaticStrides(),
+                     [](int64_t x) { return x != 1; }))
+      return std::nullopt;
+    int64_t row = insert.getStaticOffsets()[0];
+    int64_t rows = sourceType.getDimSize(0);
+    // Each page occupies whole NZ rows, possibly part of one 16-row block.
+    if (row < 0 || rows <= 0 || row + rows != end ||
+        (rows < 16 ? row % 16 + rows > 16 : row % 16 || rows % 16))
+      return std::nullopt;
+    auto page = getPageLoader(insert);
+    if (!page)
+      return std::nullopt;
+    pages.push_back(std::move(*page));
+    end = row;
+    current = insert.getDest();
+  }
+  if (end != 0 || !isa_and_nonnull<tensor::EmptyOp, linalg::FillOp>(
+                      current.getDefiningOp()))
+    return std::nullopt;
+  std::reverse(pages.begin(), pages.end());
+  return pages;
+}
+
+namespace {
+
+void materializePages(ArrayRef<CVPipeline::CubePageLoader> pages) {
+  auto root = pages.back().insert;
+  auto type = root.getType();
+  int64_t rows = type.getDimSize(0), cols = type.getDimSize(1);
+  OpBuilder builder(root.getContext());
+  auto cbuf = builder.getAttr<hivm::AddressSpaceAttr>(hivm::AddressSpace::L1);
+  auto nzType = MemRefType::get({cols / 16, rows / 16, 16, 16},
+                                type.getElementType(), nullptr, cbuf);
+  // The whole aggregate belongs to the matmul's compute block. Keeping the
+  // buffer inside the same iteration also prevents writes racing with MMAD.
+  auto tag = [&](Operation *op) {
+    op->setAttr(CVPipeline::kCoreType, builder.getStringAttr("CUBE"));
+    if (auto id = root->getAttr(CVPipeline::kBlockId))
+      op->setAttr(CVPipeline::kBlockId, id);
+  };
+  auto indexAttrs = [&](ArrayRef<int64_t> values) {
+    return llvm::map_to_vector(values, [&](int64_t value) -> OpFoldResult {
+      return builder.getIndexAttr(value);
+    });
+  };
+  Location loc = root.getLoc();
+  Operation *firstCopy = pages.front().copy;
+  for (const auto &page : pages)
+    if (page.copy->isBeforeInBlock(firstCopy))
+      firstCopy = page.copy;
+  builder.setInsertionPoint(firstCopy);
+  auto aggregate = builder.create<memref::AllocOp>(loc, nzType);
+  tag(aggregate);
+  auto zero = builder.create<arith::ConstantOp>(
+      loc, builder.getZeroAttr(type.getElementType()));
+  tag(zero);
+  auto fill = builder.create<linalg::FillOp>(loc, ValueRange{zero},
+                                             ValueRange{aggregate});
+  tag(fill);
+
+  for (auto page : pages) {
+    builder.setInsertionPoint(page.copy);
+    int64_t row = page.insert.getStaticOffsets()[0];
+    int64_t pageRows = page.insert.getSourceType().getDimSize(0);
+    SmallVector<OpFoldResult> offsets = indexAttrs({0, row / 16, row % 16, 0});
+    SmallVector<OpFoldResult> sizes = indexAttrs(
+        {cols / 16, (pageRows + 15) / 16, std::min(pageRows, int64_t{16}), 16});
+    SmallVector<OpFoldResult> strides = indexAttrs({1, 1, 1, 1});
+    auto view = builder.create<memref::SubViewOp>(loc, aggregate, offsets,
+                                                  sizes, strides);
+    tag(view);
+    Value source = page.copy.getSource();
+    auto count = builder.create<memref::DimOp>(loc, source, 0);
+    tag(count);
+    auto c0 = builder.create<arith::ConstantIndexOp>(loc, 0);
+    tag(c0);
+    auto live = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::sgt,
+                                              count, c0);
+    tag(live);
+    auto guard = builder.create<scf::IfOp>(loc, live, false);
+    tag(guard);
+    builder.setInsertionPointToStart(&guard.getThenRegion().front());
+    // ND2NZ uses the full aggregate's N-stride, so a short page writes only
+    // its own rows. The initial zero fill covers masked and sentinel pages.
+    auto load = builder.create<hivm::ND2NZOp>(loc, TypeRange{}, source, view,
+                                              builder.getUnitAttr());
+    tag(load);
+    tag(guard.thenYield());
+  }
+
+  builder.setInsertionPoint(root);
+  auto ndType =
+      MemRefType::get(type.getShape(), type.getElementType(), nullptr, cbuf);
+  auto layout = builder.create<hivm::ConvertLayoutOp>(
+      loc, ndType, aggregate,
+      builder.getAttr<hivm::DataLayoutAttr>(hivm::DataLayout::nZ),
+      builder.getAttr<hivm::DataLayoutAttr>(hivm::DataLayout::ND));
+  tag(layout);
+  auto cast = builder.create<memref::MemorySpaceCastOp>(
+      loc, MemRefType::get(type.getShape(), type.getElementType()),
+      layout.getResult());
+  tag(cast);
+  auto tensor =
+      builder.create<bufferization::ToTensorOp>(loc, type, cast, true, true);
+  tag(tensor);
+  root.replaceAllUsesWith(tensor.getResult());
+
+  llvm::SetVector<Operation *> cleanup;
+  for (const auto &page : llvm::reverse(pages)) {
+    for (Operation *op : page.bufferOps)
+      cleanup.insert(op->getParentOp());
+    page.insert->erase();
+    page.tensor->erase();
+    page.copy->erase();
+    for (Operation *op : llvm::reverse(page.bufferOps))
+      op->erase();
+  }
+  for (Operation *op : cleanup)
+    if (isa<scf::IfOp>(op) && isOpTriviallyDead(op))
+      op->erase();
+}
+
+class MaterializeCubePageLoadersPass
+    : public PassWrapper<MaterializeCubePageLoadersPass,
+                         OperationPass<ModuleOp>> {
+public:
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(MaterializeCubePageLoadersPass)
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<hivm::HIVMDialect, arith::ArithDialect,
+                    memref::MemRefDialect, bufferization::BufferizationDialect,
+                    linalg::LinalgDialect, scf::SCFDialect>();
+  }
+  StringRef getArgument() const override {
+    return "materialize-cube-page-loaders";
+  }
+  StringRef getDescription() const override {
+    return "Load unrolled matmul pages directly into one CUBE L1 buffer";
+  }
+  void runOnOperation() override {
+    if (CVPipeline::hasFallbackAttr(getOperation()))
+      return;
+    SmallVector<SmallVector<CVPipeline::CubePageLoader>> chains;
+    getOperation().walk([&](tensor::InsertSliceOp root) {
+      if (CVPipeline::getOpCoreType(root) != CVPipeline::CoreType::CUBE_ONLY)
+        return;
+      if (llvm::any_of(root->getUsers(), [](Operation *user) {
+            return isa<tensor::InsertSliceOp>(user);
+          }))
+        return;
+      auto pages = CVPipeline::getCubePageLoaders(root);
+      if (!pages || llvm::any_of(*pages, [&](const auto &page) {
+            return page.copy->getAttr(CVPipeline::kBlockId) !=
+                       root->getAttr(CVPipeline::kBlockId) ||
+                   page.insert->getAttr(CVPipeline::kBlockId) !=
+                       root->getAttr(CVPipeline::kBlockId);
+          })) {
+        CVPipeline::setFallbackAttr(getOperation(), CVPipeline::ERRCODE_FAILED);
+        return;
+      }
+      chains.push_back(std::move(*pages));
+    });
+    if (CVPipeline::hasFallbackAttr(getOperation()))
+      return;
+    for (const auto &pages : chains)
+      materializePages(pages);
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::triton::createMaterializeCubePageLoadersPass() {
+  return std::make_unique<MaterializeCubePageLoadersPass>();
+}

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOptPass.cpp
@@ -33,6 +33,14 @@
 using namespace mlir;
 using namespace triton;
 
+void ComputeBlockOptPass::getDependentDialects(
+    DialectRegistry &registry) const {
+  linalg::registerTransformDialectExtension(registry);
+  linalg::registerTilingInterfaceExternalModels(registry);
+  scf::registerTransformDialectExtension(registry);
+  createMaterializeCubePageLoadersPass()->getDependentDialects(registry);
+}
+
 void ComputeBlockOptPass::runOnOperation() {
   ModuleOp module = getOperation();
 
@@ -81,6 +89,9 @@ void ComputeBlockOptPass::runOnOperation() {
 
   pm.addPass(createRelocateMemrefDeclPass());
 
+  pm.addPass(createMaterializeCubePageLoadersPass());
+  pm.addPass(createReorderOpsByBlockIdPass());
+
   if (failed(runPipeline(pm, module))) {
     if (!CVPipeline::hasFallbackAttr(module)) {
       CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
@@ -105,6 +116,7 @@ void registerComputeBlockOptPasses() {
   registerPass(createUnifyAllocBlockPass);
   registerPass(createMergeVectorIfBlockPass);
   registerPass(createMergeCubeForBlockPass);
+  registerPass(createMaterializeCubePageLoadersPass);
   registerPass(createFixpipeOptPass);
   registerPass(createUnifyStoreBlockPass);
   registerPass(createExpSubfPatternPass);

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/OpClassifier.cpp
@@ -44,6 +44,7 @@
 #include "mlir/Support/LLVM.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/Utils.h"
+#include "ascend/include/DynamicCVPipeline/ComputeBlockOpt/CubePageLoaders.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h"
 #include "ascend/include/DynamicCVPipeline/PlanComputeBlock/OpClassifier.h"
 #include "ascend/include/DynamicCVPipeline/SplitDataflow/Utils.h"
@@ -240,6 +241,28 @@ void OpClassifierPass::matchToTensorPattern(Operation *def) {
   }
 }
 
+// static_range page loaders are unrolled into insert_slice chains before core
+// classification. Recognize the entire aggregation, including its initial
+// fill, so that both the copies and their scalar address calculations can be
+// assigned to CUBE. Reject chains containing actual tensor computation.
+void OpClassifierPass::matchInsertSlicePattern(Operation *def) {
+  auto pages =
+      CVPipeline::getCubePageLoaders(dyn_cast<tensor::InsertSliceOp>(def));
+  if (!pages) {
+    return;
+  }
+  for (const auto &page : *pages) {
+    if (isExtractedLoadStoreRelated(page.tensor)) {
+      return;
+    }
+  }
+  for (const auto &page : *pages) {
+    markCube(page.insert);
+    cubeSeeds.push_back(page.insert);
+    matchToTensorPattern(page.tensor);
+  }
+}
+
 // ============================================================================
 // Pattern: transpose → matmul (Upstream)
 // ============================================================================
@@ -290,6 +313,9 @@ void OpClassifierPass::matchTransposePattern(Operation *def) {
   auto operands = transposeOp->getOperands();
   for (const auto &op : operands) {
     auto defOp = op.getDefiningOp();
+    if (defOp) {
+      matchInsertSlicePattern(defOp);
+    }
     if (!shouldMarkCubeSeed(defOp) ||
         utils::getAnnotateOpWithAttr(op,
                                      hivm::kMayImplicitTransposeWithLastAxis)) {
@@ -556,6 +582,7 @@ int OpClassifierPass::patternMatchCUBE() {
         continue;
 
       matchToTensorPattern(def);
+      matchInsertSlicePattern(def);
       matchTransposePattern(def);
       matchFillPattern(def);
       matchEmptyPattern(def);
@@ -700,6 +727,26 @@ void OpClassifierPass::getUpstreamOpsWithMemoryDeps(
     }
     if (isScalarIterArgOp(operand)) {
       findIterArgUpstreamOps(operand, upstreamOps);
+    }
+  }
+  // Masked scalar metadata loads lower to scf.if. Follow the yielded scalars
+  // when tracing a CUBE address dependency, otherwise the load stays VECTOR
+  // even when all of the address arithmetic and page copies run on CUBE.
+  if (getCoreType(cur) == OP_CUBE_ONLY) {
+    if (auto ifOp = dyn_cast<scf::IfOp>(cur)) {
+      if (llvm::all_of(ifOp.getResults(),
+                       [](Value value) { return isScalarType(value); })) {
+        for (Region &region : ifOp->getRegions()) {
+          if (region.empty()) {
+            continue;
+          }
+          for (Value value : region.front().getTerminator()->getOperands()) {
+            if (Operation *def = value.getDefiningOp()) {
+              upstreamOps.push_back(def);
+            }
+          }
+        }
+      }
     }
   }
   if (!isa<bufferization::ToTensorOp>(cur)) {

--- a/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
+++ b/third_party/ascend/lib/TritonToLinalg/LoadStoreConverter.cpp
@@ -475,26 +475,39 @@ LoadConverter::matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
     auto resTy = op.getResult().getType();
     auto idxZero =
         rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
-    auto loadedValue = rewriter
-                           .create<memref::LoadOp>(loc, resTy, scalarMemref,
-                                                   idxZero.getResult())
-                           .getResult();
-    propagateWasBoolToInt8Attr(op.getOperation(), loadedValue.getDefiningOp(),
-                               rewriter);
-    if (mask && other) {
-      mask = rewriter.create<triton::SplatOp>(
-          loc, RankedTensorType::get({1}, mask.getType()), mask);
-      loadedValue = rewriter.create<triton::SplatOp>(
-          loc, RankedTensorType::get({1}, loadedValue.getType()), loadedValue);
-      other = rewriter.create<triton::SplatOp>(
-          loc, RankedTensorType::get({1}, other.getType()), other);
-      loadedValue =
-          rewriter.create<arith::SelectOp>(loc, mask, loadedValue, other);
-      rewriter.replaceOpWithNewOp<tensor::ExtractOp>(op, loadedValue,
-                                                     ValueRange({idxZero}));
-    } else {
-      rewriter.replaceOp(op, loadedValue);
+    auto createScalarLoad = [&]() -> Value {
+      auto load = rewriter.create<memref::LoadOp>(loc, resTy, scalarMemref,
+                                                  idxZero.getResult());
+      propagateWasBoolToInt8Attr(op.getOperation(), load.getOperation(),
+                                 rewriter);
+      return load.getResult();
+    };
+    if (!mask) {
+      rewriter.replaceOp(op, createScalarLoad());
+      return success();
     }
+
+    // Keep scalar results scalar, and guard the access itself: a select after
+    // an unconditional load would still read a masked-off, possibly invalid
+    // address.
+    auto ifOp = rewriter.create<scf::IfOp>(loc, TypeRange{resTy},
+                                           adaptor.getMask(), true);
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(&ifOp.getThenRegion().front());
+      rewriter.create<scf::YieldOp>(loc, createScalarLoad());
+
+      rewriter.setInsertionPointToStart(&ifOp.getElseRegion().front());
+      Value inactiveValue = adaptor.getOther();
+      if (!inactiveValue) {
+        // Without `other`, the inactive value is undefined. Choose zero
+        // without accessing memory or introducing a tensor temporary.
+        inactiveValue = rewriter.create<arith::ConstantOp>(
+            loc, resTy, rewriter.getZeroAttr(resTy));
+      }
+      rewriter.create<scf::YieldOp>(loc, inactiveValue);
+    }
+    rewriter.replaceOp(op, ifOp.getResults());
     return success();
   }
 

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/cube_page_aggregation.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/cube_page_aggregation.mlir
@@ -1,0 +1,186 @@
+// RUN: triton-opt --split-input-file --op-classifier --verify-each %s | FileCheck %s --check-prefixes=CLASSIFY,COMMON
+// RUN: triton-opt --split-input-file --plan-compute-block --compute-block-opt --verify-each %s | FileCheck %s --check-prefixes=MATERIAL,COMMON
+
+// static_range unrolls page loads into insert_slice chains. Both a direct
+// matmul operand (V) and an operand behind transpose (K) must be recognized.
+// The masked scalar metadata load must follow its address users onto CUBE.
+// Classification and materialization both run without an opt-in flag.
+// COMMON-LABEL: func.func @unrolled_pages
+// CLASSIFY-DAG: memref.load {{.*}}ssbuffer.core_type = "CUBE"
+// CLASSIFY-DAG: arith.andi {{.*}}ssbuffer.core_type = "CUBE"
+// CLASSIFY-DAG: arith.shrsi {{.*}}ssbuffer.core_type = "CUBE"
+// CLASSIFY-DAG: memref.copy {{.*}}ssbuffer.core_type = "CUBE"
+// CLASSIFY-DAG: memref.copy {{.*}}ssbuffer.core_type = "CUBE"
+// CLASSIFY-DAG: tensor.insert_slice {{.*}}ssbuffer.core_type = "CUBE"
+// CLASSIFY-DAG: tensor.insert_slice {{.*}}ssbuffer.core_type = "CUBE"
+// MATERIAL-DAG: memref.load {{.*}}ssbuffer.core_type = "CUBE"
+// MATERIAL: %[[BUFFER:.*]] = memref.alloc() {{.*}}memref<1x1x16x16xf16, #hivm.address_space<cbuf>>
+// MATERIAL: %[[ZERO:.*]] = arith.constant {{.*}} 0.000000e+00 : f16
+// MATERIAL: linalg.fill {{.*}}ins(%[[ZERO]] : f16) outs(%[[BUFFER]]
+// MATERIAL: memref.subview %[[BUFFER]][0, 0, 0, 0] [1, 1, 8, 16]
+// MATERIAL: arith.cmpi sgt
+// MATERIAL: scf.if
+// MATERIAL: hivm.hir.nd2nz {{.*}}dst_continuous{{.*}}ssbuffer.core_type = "CUBE"{{.*}}memref<?x8xf16
+// MATERIAL: memref.subview %[[BUFFER]][0, 0, 8, 0] [1, 1, 8, 16]
+// MATERIAL: arith.cmpi sgt
+// MATERIAL: scf.if
+// MATERIAL: hivm.hir.nd2nz {{.*}}dst_continuous{{.*}}ssbuffer.core_type = "CUBE"
+// MATERIAL: hivm.hir.convert_layout
+// MATERIAL-NOT: tensor.insert_slice
+// MATERIAL: linalg.matmul {{.*}}ssbuffer.core_type = "CUBE"
+// COMMON: return
+func.func @unrolled_pages(%metadata: memref<?xi32>, %cache: memref<?xf16>, %active: i1, %q: tensor<16x16xf16>) -> (tensor<16x16xf32>, tensor<16x16xf32>) {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %mask = arith.constant 16777215 : i32
+  %shift = arith.constant 24 : i32
+  %padding = arith.constant -1 : i32
+  %zero = arith.constant 0.0 : f16
+  %zero_f32 = arith.constant 0.0 : f32
+  %meta = scf.if %active -> (i32) {
+    %loaded = memref.load %metadata[%c0] : memref<?xi32>
+    scf.yield %loaded : i32
+  } else {
+    scf.yield %padding : i32
+  }
+  %physical = arith.andi %meta, %mask : i32
+  %valid = arith.shrsi %meta, %shift : i32
+  %valid_idx = arith.index_cast %valid : i32 to index
+  %nonnegative = arith.maxsi %valid_idx, %c0 : index
+  %size = arith.minsi %nonnegative, %c8 : index
+  %physical_idx = arith.index_cast %physical : i32 to index
+  %offset = arith.muli %physical_idx, %c128 : index
+  %src0 = memref.reinterpret_cast %cache to offset: [%offset], sizes: [8, 16], strides: [16, 1] : memref<?xf16> to memref<8x16xf16, strided<[16, 1], offset: ?>>
+  %page0 = memref.alloc() : memref<8x16xf16>
+  linalg.fill ins(%zero : f16) outs(%page0 : memref<8x16xf16>)
+  %src_view0 = memref.subview %src0[0, 0] [%size, 8] [1, 1] : memref<8x16xf16, strided<[16, 1], offset: ?>> to memref<?x8xf16, strided<[16, 1], offset: ?>>
+  %dst_view0 = memref.subview %page0[0, 0] [%size, 8] [1, 1] : memref<8x16xf16> to memref<?x8xf16, strided<[16, 1]>>
+  memref.copy %src_view0, %dst_view0 : memref<?x8xf16, strided<[16, 1], offset: ?>> to memref<?x8xf16, strided<[16, 1]>>
+  %tensor0 = bufferization.to_tensor %page0 restrict writable : memref<8x16xf16> to tensor<8x16xf16>
+  %next = arith.addi %offset, %c128 : index
+  %src1 = memref.reinterpret_cast %cache to offset: [%next], sizes: [8, 16], strides: [16, 1] : memref<?xf16> to memref<8x16xf16, strided<[16, 1], offset: ?>>
+  %page1 = memref.alloc() : memref<8x16xf16>
+  memref.copy %src1, %page1 : memref<8x16xf16, strided<[16, 1], offset: ?>> to memref<8x16xf16>
+  %tensor1 = bufferization.to_tensor %page1 restrict writable : memref<8x16xf16> to tensor<8x16xf16>
+  %empty = tensor.empty() : tensor<16x16xf16>
+  %initial = linalg.fill ins(%zero : f16) outs(%empty : tensor<16x16xf16>) -> tensor<16x16xf16>
+  %insert0 = tensor.insert_slice %tensor0 into %initial[0, 0] [8, 16] [1, 1] : tensor<8x16xf16> into tensor<16x16xf16>
+  %insert1 = tensor.insert_slice %tensor1 into %insert0[8, 0] [8, 16] [1, 1] : tensor<8x16xf16> into tensor<16x16xf16>
+  %transposed = linalg.transpose ins(%insert1 : tensor<16x16xf16>) outs(%empty : tensor<16x16xf16>) permutation = [1, 0]
+  %out = tensor.empty() : tensor<16x16xf32>
+  %init = linalg.fill ins(%zero_f32 : f32) outs(%out : tensor<16x16xf32>) -> tensor<16x16xf32>
+  %qk = linalg.matmul ins(%q, %transposed : tensor<16x16xf16>, tensor<16x16xf16>) outs(%init : tensor<16x16xf32>) -> tensor<16x16xf32>
+  %pv = linalg.matmul ins(%q, %insert1 : tensor<16x16xf16>, tensor<16x16xf16>) outs(%init : tensor<16x16xf32>) -> tensor<16x16xf32>
+  return %qk, %pv : tensor<16x16xf32>, tensor<16x16xf32>
+}
+
+// -----
+
+// A computed page is not a pure loader, even if its aggregation feeds matmul.
+// COMMON-LABEL: func.func @computed_page
+// COMMON: arith.mulf {{.*}}ssbuffer.core_type = "VECTOR"
+// COMMON: tensor.insert_slice {{.*}}ssbuffer.core_type = "VECTOR"
+// COMMON: linalg.matmul {{.*}}ssbuffer.core_type = "CUBE"
+func.func @computed_page(%page: tensor<8x16xf16>, %q: tensor<16x16xf16>) -> tensor<16x16xf32> {
+  %empty = tensor.empty() : tensor<16x16xf16>
+  %zero = arith.constant 0.0 : f16
+  %initial = linalg.fill ins(%zero : f16) outs(%empty : tensor<16x16xf16>) -> tensor<16x16xf16>
+  %computed = arith.mulf %page, %page : tensor<8x16xf16>
+  %insert = tensor.insert_slice %computed into %initial[0, 0] [8, 16] [1, 1] : tensor<8x16xf16> into tensor<16x16xf16>
+  %out = tensor.empty() : tensor<16x16xf32>
+  %mm = linalg.matmul ins(%q, %insert : tensor<16x16xf16>, tensor<16x16xf16>) outs(%out : tensor<16x16xf32>) -> tensor<16x16xf32>
+  return %mm : tensor<16x16xf32>
+}
+
+// -----
+
+// The initial aggregate must also have a known loader provenance.
+// COMMON-LABEL: func.func @unknown_aggregate
+// COMMON: bufferization.to_tensor {{.*}}ssbuffer.core_type = "VECTOR"
+// COMMON: tensor.insert_slice {{.*}}ssbuffer.core_type = "VECTOR"
+// COMMON: linalg.matmul {{.*}}ssbuffer.core_type = "CUBE"
+func.func @unknown_aggregate(%page: memref<8x16xf16>, %initial: tensor<16x16xf16>, %q: tensor<16x16xf16>) -> tensor<16x16xf32> {
+  %tensor = bufferization.to_tensor %page restrict writable : memref<8x16xf16> to tensor<8x16xf16>
+  %insert = tensor.insert_slice %tensor into %initial[0, 0] [8, 16] [1, 1] : tensor<8x16xf16> into tensor<16x16xf16>
+  %out = tensor.empty() : tensor<16x16xf32>
+  %mm = linalg.matmul ins(%q, %insert : tensor<16x16xf16>, tensor<16x16xf16>) outs(%out : tensor<16x16xf32>) -> tensor<16x16xf32>
+  return %mm : tensor<16x16xf32>
+}
+
+// -----
+
+// Nonzero masked padding cannot be replaced by L1 zero initialization.
+// COMMON-LABEL: func.func @nonzero_padding
+// COMMON: tensor.insert_slice {{.*}}ssbuffer.core_type = "VECTOR"
+// COMMON: linalg.matmul {{.*}}ssbuffer.core_type = "CUBE"
+func.func @nonzero_padding(%cache: memref<8x16xf16>, %q: tensor<16x16xf16>) -> tensor<16x16xf32> {
+  %zero = arith.constant 1.0 : f16
+  %empty = tensor.empty() : tensor<16x16xf16>
+  %page0 = memref.alloc() : memref<8x16xf16>
+  linalg.fill ins(%zero : f16) outs(%page0 : memref<8x16xf16>)
+  %src0 = memref.subview %cache[0, 0] [4, 16] [1, 1] : memref<8x16xf16> to memref<4x16xf16, strided<[16, 1]>>
+  %dst0 = memref.subview %page0[0, 0] [4, 16] [1, 1] : memref<8x16xf16> to memref<4x16xf16, strided<[16, 1]>>
+  memref.copy %src0, %dst0 : memref<4x16xf16, strided<[16, 1]>> to memref<4x16xf16, strided<[16, 1]>>
+  %tensor0 = bufferization.to_tensor %page0 restrict writable : memref<8x16xf16> to tensor<8x16xf16>
+  %page1 = memref.alloc() : memref<8x16xf16>
+  linalg.fill ins(%zero : f16) outs(%page1 : memref<8x16xf16>)
+  %src1 = memref.subview %cache[0, 0] [4, 16] [1, 1] : memref<8x16xf16> to memref<4x16xf16, strided<[16, 1]>>
+  %dst1 = memref.subview %page1[0, 0] [4, 16] [1, 1] : memref<8x16xf16> to memref<4x16xf16, strided<[16, 1]>>
+  memref.copy %src1, %dst1 : memref<4x16xf16, strided<[16, 1]>> to memref<4x16xf16, strided<[16, 1]>>
+  %tensor1 = bufferization.to_tensor %page1 restrict writable : memref<8x16xf16> to tensor<8x16xf16>
+  %insert0 = tensor.insert_slice %tensor0 into %empty[0, 0] [8, 16] [1, 1] : tensor<8x16xf16> into tensor<16x16xf16>
+  %insert1 = tensor.insert_slice %tensor1 into %insert0[8, 0] [8, 16] [1, 1] : tensor<8x16xf16> into tensor<16x16xf16>
+  %out = tensor.empty() : tensor<16x16xf32>
+  %mm = linalg.matmul ins(%q, %insert1 : tensor<16x16xf16>, tensor<16x16xf16>) outs(%out : tensor<16x16xf32>) -> tensor<16x16xf32>
+  return %mm : tensor<16x16xf32>
+}
+
+// -----
+
+// A page buffer escaping the loader cannot be removed.
+// COMMON-LABEL: func.func @shared_page_buffer
+// COMMON: tensor.insert_slice {{.*}}ssbuffer.core_type = "VECTOR"
+// COMMON: linalg.matmul {{.*}}ssbuffer.core_type = "CUBE"
+func.func @shared_page_buffer(%cache: memref<8x16xf16>, %q: tensor<16x16xf16>) -> (tensor<16x16xf32>, memref<8x16xf16>) {
+  %zero = arith.constant 0.0 : f16
+  %empty = tensor.empty() : tensor<16x16xf16>
+  %page0 = memref.alloc() : memref<8x16xf16>
+  linalg.fill ins(%zero : f16) outs(%page0 : memref<8x16xf16>)
+  memref.copy %cache, %page0 : memref<8x16xf16> to memref<8x16xf16>
+  %tensor0 = bufferization.to_tensor %page0 restrict writable : memref<8x16xf16> to tensor<8x16xf16>
+  %page1 = memref.alloc() : memref<8x16xf16>
+  linalg.fill ins(%zero : f16) outs(%page1 : memref<8x16xf16>)
+  memref.copy %cache, %page1 : memref<8x16xf16> to memref<8x16xf16>
+  %tensor1 = bufferization.to_tensor %page1 restrict writable : memref<8x16xf16> to tensor<8x16xf16>
+  %insert0 = tensor.insert_slice %tensor0 into %empty[0, 0] [8, 16] [1, 1] : tensor<8x16xf16> into tensor<16x16xf16>
+  %insert1 = tensor.insert_slice %tensor1 into %insert0[8, 0] [8, 16] [1, 1] : tensor<8x16xf16> into tensor<16x16xf16>
+  %out = tensor.empty() : tensor<16x16xf32>
+  %mm = linalg.matmul ins(%q, %insert1 : tensor<16x16xf16>, tensor<16x16xf16>) outs(%out : tensor<16x16xf32>) -> tensor<16x16xf32>
+  return %mm, %page0 : tensor<16x16xf32>, memref<8x16xf16>
+}
+
+// -----
+
+// A later fill overwrites loaded values and must not be moved before the copy.
+// COMMON-LABEL: func.func @fill_after_copy
+// COMMON: tensor.insert_slice {{.*}}ssbuffer.core_type = "VECTOR"
+// COMMON: linalg.matmul {{.*}}ssbuffer.core_type = "CUBE"
+func.func @fill_after_copy(%cache: memref<8x16xf16>, %q: tensor<16x16xf16>) -> tensor<16x16xf32> {
+  %zero = arith.constant 0.0 : f16
+  %empty = tensor.empty() : tensor<16x16xf16>
+  %page0 = memref.alloc() : memref<8x16xf16>
+  memref.copy %cache, %page0 : memref<8x16xf16> to memref<8x16xf16>
+  linalg.fill ins(%zero : f16) outs(%page0 : memref<8x16xf16>)
+  %tensor0 = bufferization.to_tensor %page0 restrict writable : memref<8x16xf16> to tensor<8x16xf16>
+  %page1 = memref.alloc() : memref<8x16xf16>
+  memref.copy %cache, %page1 : memref<8x16xf16> to memref<8x16xf16>
+  linalg.fill ins(%zero : f16) outs(%page1 : memref<8x16xf16>)
+  %tensor1 = bufferization.to_tensor %page1 restrict writable : memref<8x16xf16> to tensor<8x16xf16>
+  %insert0 = tensor.insert_slice %tensor0 into %empty[0, 0] [8, 16] [1, 1] : tensor<8x16xf16> into tensor<16x16xf16>
+  %insert1 = tensor.insert_slice %tensor1 into %insert0[8, 0] [8, 16] [1, 1] : tensor<8x16xf16> into tensor<16x16xf16>
+  %out = tensor.empty() : tensor<16x16xf32>
+  %mm = linalg.matmul ins(%q, %insert1 : tensor<16x16xf16>, tensor<16x16xf16>) outs(%out : tensor<16x16xf32>) -> tensor<16x16xf32>
+  return %mm : tensor<16x16xf32>
+}

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/scalar_masked_load.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/scalar_masked_load.mlir
@@ -1,0 +1,102 @@
+// RUN: triton-opt %s --triton-to-linalg -verify-each | FileCheck %s --implicit-check-not='tensor<' --implicit-check-not='arith.select'
+// RUN: triton-opt %s --triton-to-linalg='named-ops=true' -verify-each | FileCheck %s --implicit-check-not='tensor<' --implicit-check-not='arith.select'
+// RUN: sed 's/Ascend910B2/Ascend950DT_9582/' %s | triton-opt --triton-to-linalg='compile-on-910-95=true' -verify-each | FileCheck %s --implicit-check-not='tensor<' --implicit-check-not='arith.select'
+
+// Scalar masked loads must keep their result scalar and only read memory in
+// the active branch. In particular, selecting the result of an unconditional
+// load does not protect an invalid masked-off address.
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  // CHECK-LABEL: func.func @masked_i32(
+  // CHECK-SAME: %[[MASK:[^:]+]]: i1, %[[OTHER:[^:]+]]: i32
+  // CHECK-NOT: memref.load
+  // CHECK: %[[RESULT:.*]] = scf.if %[[MASK]] -> (i32) {
+  // CHECK-NEXT: %[[VALUE:.*]] = memref.load
+  // CHECK-NEXT: scf.yield %[[VALUE]] : i32
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT: scf.yield %[[OTHER]] : i32
+  // CHECK-NEXT: }
+  // CHECK-NOT: memref.load
+  // CHECK: return %[[RESULT]] : i32
+  tt.func public @masked_i32(%ptr: !tt.ptr<i32>, %mask: i1, %other: i32, %offset: i32) -> i32 {
+    %address = tt.addptr %ptr, %offset : !tt.ptr<i32>, i32
+    %value = tt.load %address, %mask, %other : !tt.ptr<i32>
+    tt.return %value : i32
+  }
+
+  // CHECK-LABEL: func.func @masked_f32(
+  // CHECK-SAME: %[[MASK:[^:]+]]: i1, %[[OTHER:[^:]+]]: f32
+  // CHECK-NOT: memref.load
+  // CHECK: %[[RESULT:.*]] = scf.if %[[MASK]] -> (f32) {
+  // CHECK-NEXT: %[[VALUE:.*]] = memref.load
+  // CHECK-NEXT: scf.yield %[[VALUE]] : f32
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT: scf.yield %[[OTHER]] : f32
+  // CHECK-NEXT: }
+  // CHECK-NOT: memref.load
+  // CHECK: return %[[RESULT]] : f32
+  tt.func public @masked_f32(%ptr: !tt.ptr<f32>, %mask: i1, %other: f32) -> f32 {
+    %value = tt.load %ptr, %mask, %other : !tt.ptr<f32>
+    tt.return %value : f32
+  }
+
+  // No `other` leaves the inactive result unspecified, but the load must
+  // still be conditional. Do not require a particular inactive result value.
+  // CHECK-LABEL: func.func @masked_without_other(
+  // CHECK-SAME: %[[MASK:[^:]+]]: i1
+  // CHECK-NOT: memref.load
+  // CHECK: %[[RESULT:.*]] = scf.if %[[MASK]] -> (i32) {
+  // CHECK-NEXT: %[[VALUE:.*]] = memref.load
+  // CHECK-NEXT: scf.yield %[[VALUE]] : i32
+  // CHECK-NEXT: } else {
+  // CHECK-NOT: memref.load
+  // CHECK: scf.yield %{{.*}} : i32
+  // CHECK-NEXT: }
+  // CHECK-NOT: memref.load
+  // CHECK: return %[[RESULT]] : i32
+  tt.func public @masked_without_other(%ptr: !tt.ptr<i32>, %mask: i1) -> i32 {
+    %value = tt.load %ptr, %mask : !tt.ptr<i32>
+    tt.return %value : i32
+  }
+
+  // CHECK-LABEL: func.func @unmasked(
+  // CHECK-NOT: scf.if
+  // CHECK: %[[VALUE:.*]] = memref.load
+  // CHECK-NOT: scf.if
+  // CHECK: return %[[VALUE]] : i32
+  tt.func public @unmasked(%ptr: !tt.ptr<i32>) -> i32 {
+    %value = tt.load %ptr : !tt.ptr<i32>
+    tt.return %value : i32
+  }
+
+  // CHECK-LABEL: func.func @mask_true(
+  // CHECK-NOT: scf.if
+  // CHECK: %[[VALUE:.*]] = memref.load
+  // CHECK-NOT: scf.if
+  // CHECK: return %[[VALUE]] : i32
+  tt.func public @mask_true(%ptr: !tt.ptr<i32>, %other: i32) -> i32 {
+    %true = arith.constant true
+    %value = tt.load %ptr, %true, %other : !tt.ptr<i32>
+    tt.return %value : i32
+  }
+
+  // CHECK-LABEL: func.func @mask_false(
+  // CHECK-SAME: %[[OTHER:[^:]+]]: i32
+  // CHECK-NOT: memref.load
+  // CHECK-NOT: scf.if
+  // CHECK: return %[[OTHER]] : i32
+  tt.func public @mask_false(%ptr: !tt.ptr<i32>, %other: i32) -> i32 {
+    %false = arith.constant false
+    %value = tt.load %ptr, %false, %other : !tt.ptr<i32>
+    tt.return %value : i32
+  }
+
+  // CHECK-LABEL: func.func @mask_false_without_other(
+  // CHECK-NOT: memref.load
+  // CHECK-NOT: scf.if
+  // CHECK: return %{{.*}} : f32
+  tt.func public @mask_false_without_other(%ptr: !tt.ptr<f32>) -> f32 {
+    %false = arith.constant false
+    %value = tt.load %ptr, %false : !tt.ptr<f32>
+    tt.return %value : f32
+  }
+}

--- a/third_party/ascend/unittest/pytest_ut/test_scalar_masked_load.py
+++ b/third_party/ascend/unittest/pytest_ut/test_scalar_masked_load.py
@@ -1,0 +1,51 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+import triton
+import triton.language as tl
+
+
+@triton.jit(do_not_specialize=["active_count"])
+def scalar_masked_load_kernel(src, dst, active_count, WITH_OTHER: tl.constexpr):
+    pid = tl.program_id(0)
+    active = pid < active_count
+    if WITH_OTHER:
+        value = tl.load(src + pid, mask=active, other=0)
+        tl.store(dst + pid, value)
+    else:
+        value = tl.load(src + pid, mask=active)
+        # The inactive load result is unspecified; leave the destination alone.
+        tl.store(dst + pid, value, mask=active)
+
+
+@pytest.mark.parametrize("dtype", [torch.int8, torch.int32, torch.float32, torch.bool])
+@pytest.mark.parametrize("active_count", [0, 5, 32])
+@pytest.mark.parametrize("with_other", [False, True])
+def test_scalar_masked_load(dtype, active_count, with_other):
+    source = (torch.arange(32) % 7 - 3).to(dtype)
+    src = source.npu()
+    dst = torch.full((32, ), 1, dtype=dtype, device="npu")
+    scalar_masked_load_kernel[(32, )](src, dst, active_count, with_other)
+    expected = torch.full((32, ), 0 if with_other else 1, dtype=dtype)
+    expected[:active_count] = source[:active_count]
+    torch.testing.assert_close(dst.cpu(), expected, rtol=0, atol=0)


### PR DESCRIPTION
Recognize static_range page loads after they become insert_slice chains, including masked scalar metadata dependencies. The existing loader-loop merge only handles surviving scf.for operations.

Materialize supported page aggregates as direct GM-to-L1 ND2NZ transfers at the end of ComputeBlockOpt. This keeps the loads in AIC code when the backend would otherwise lower the insertions to vector concatenation. Preserve masked-page zero initialization and guard empty transfers. Gate classification and materialization on enable_cube_block_merge.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

