### PR TITLE
[Docs](fix) correct LLVM commit and patch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ pip install -e .
 # Check out the specified version of LLVM source code and apply patches
 git clone --no-checkout https://github.com/llvm/llvm-project.git
 cd llvm-project
-git checkout fad3272286528b8a491085183434c5ad4b59ab92
-wget https://raw.gitcode.com/Ascend/triton-ascend/blobs/2b0a06eb21438359d6d0576b622e3bb5e0292d17/fad3272.patch
-git apply fad3272.patch
+git checkout f6ded0be897e2878612dd903f7e8bb85448269e5
+wget https://raw.githubusercontent.com/triton-lang/triton-ascend/main/third_party/ascend/patch/llvm_patch_f6ded0b.patch
+git apply llvm_patch_f6ded0b.patch
 
 export LLVM_INSTALL_PREFIX=/path/to/llvm-install
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -112,9 +112,9 @@ pip install -e .
 # 检出指定版本的LLVM源码并应用补丁
 git clone --no-checkout https://github.com/llvm/llvm-project.git
 cd llvm-project
-git checkout fad3272286528b8a491085183434c5ad4b59ab92
-wget https://raw.gitcode.com/Ascend/triton-ascend/blobs/2b0a06eb21438359d6d0576b622e3bb5e0292d17/fad3272.patch
-git apply fad3272.patch
+git checkout f6ded0be897e2878612dd903f7e8bb85448269e5
+wget https://raw.githubusercontent.com/triton-lang/triton-ascend/main/third_party/ascend/patch/llvm_patch_f6ded0b.patch
+git apply llvm_patch_f6ded0b.patch
 
 export LLVM_INSTALL_PREFIX=/path/to/llvm-install
 

--- a/docs/en/installation_guide.md
+++ b/docs/en/installation_guide.md
@@ -61,7 +61,7 @@ If you need to customize the LLVM build process, follow the steps below to compi
     git clone --no-checkout https://github.com/llvm/llvm-project.git
     cd llvm-project
     git checkout f6ded0be897e2878612dd903f7e8bb85448269e5
-    wget https://raw.githubusercontent.com/triton-lang/triton-ascend/refs/heads/main/third_party/ascend/patch/llvm_patch_f6ded0b.patch
+    wget https://raw.githubusercontent.com/triton-lang/triton-ascend/main/third_party/ascend/patch/llvm_patch_f6ded0b.patch
     git apply llvm_patch_f6ded0b.patch
     ```
 

--- a/docs/zh/installation_guide.md
+++ b/docs/zh/installation_guide.md
@@ -62,7 +62,7 @@ pip install -e .
     git clone --no-checkout https://github.com/llvm/llvm-project.git
     cd llvm-project
     git checkout f6ded0be897e2878612dd903f7e8bb85448269e5
-    wget https://raw.githubusercontent.com/triton-lang/triton-ascend/refs/heads/main/third_party/ascend/patch/llvm_patch_f6ded0b.patch
+    wget https://raw.githubusercontent.com/triton-lang/triton-ascend/main/third_party/ascend/patch/llvm_patch_f6ded0b.patch
     git apply llvm_patch_f6ded0b.patch
     ```
 


### PR DESCRIPTION
## Summary
Update the custom LLVM build instructions in `README.md` / `README_zh.md` to the current pin (`f6ded0b` + `llvm_patch_f6ded0b.patch`), matching `cmake/llvm-hash.txt` and the installation guide. Also switch the raw GitHub patch URL to the usual `/main/...` form (instead of `/refs/heads/main/...`).

## What Is Included
- `README.md` / `README_zh.md`: LLVM checkout `fad3272` → `f6ded0b`; patch URL → `third_party/ascend/patch/llvm_patch_f6ded0b.patch`
- `docs/en|zh/installation_guide.md`: raw URL `/refs/heads/main/` → `/main/` (standard form)

## User Impact
No code behavior change. Documentation only.

## CheckList
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
- Select one of the following.
  - [x] This PR does not need a test because it only updates documentation.
  - [ ] I have added tests.
- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices).
