### PR TITLE
[ssbuffer](feat) fit the change of crossCoreDeps

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition.h
@@ -44,6 +44,20 @@ struct TensorIterArgIfOpRelation {
   llvm::SmallVector<scf::IfOp> consumers;
 };
 
+// One consumer op may appear in multiple groups.
+// Each inner SmallVector is the producers of one group this consumer belongs
+// to.
+using ConsumerProducerMap =
+    llvm::DenseMap<Operation *,
+                   llvm::SmallVector<llvm::SmallVector<Operation *>>>;
+
+inline int countProducerGroups(const ConsumerProducerMap &map) {
+  int numProducerGroups = 0;
+  for (const auto &entry : map)
+    numProducerGroups += static_cast<int>(entry.second.size());
+  return numProducerGroups;
+}
+
 // Variables to control when an ifOp is both producer and consumer of a tensor
 // iter_args
 struct TensorIterArgIfOpVars {
@@ -64,7 +78,7 @@ struct ControlFlowConditionInfo {
   llvm::DenseMap<Operation *, int> blockCounterNums;
   llvm::DenseMap<Operation *, SmallVector<int>> innerDepConds;
 
-  llvm::DenseMap<Operation *, SmallVector<Operation *>> crossCoreDependentMap;
+  ConsumerProducerMap crossCoreDependentMap;
   llvm::DenseMap<Operation *,
                  llvm::DenseMap<Operation *, SmallVector<Operation *>>>
       intraCoreDependentMap;

--- a/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.h
@@ -96,10 +96,10 @@ private:
   //   - maxRequiredBuffers: maximum (m - n + 1) across all dependencies
   //   - maxX: the x value corresponding to maxRequiredBuffers
   //   - returns {-1, -1} on error
-  std::pair<int, int> calculateCrossDepsFactor(
-      scf::ForOp forOp, SmallVector<scf::IfOp> &ifOps,
-      DenseMap<Operation *, int> &ifOpIndex,
-      DenseMap<Operation *, SmallVector<Operation *>> &crossDeps);
+  std::pair<int, int>
+  calculateCrossDepsFactor(scf::ForOp forOp, SmallVector<scf::IfOp> &ifOps,
+                           DenseMap<Operation *, int> &ifOpIndex,
+                           ConsumerProducerMap &crossDeps);
 
   // Calculate factor based on iteration dependencies (tensor iter_args
   // dependencies) For iter deps: consumer and producer are IfOps within the

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/InitDependentMap.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/InitDependentMap.cpp
@@ -29,6 +29,7 @@
 #include "third_party/ascend/include/DynamicCVPipeline/AddControlFlowCondition.h"
 #include "third_party/ascend/include/DynamicCVPipeline/Common/Utils.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 
@@ -72,43 +73,86 @@ static int isConsumerInMainLoop(Operation *consumer, Operation *mainLoop,
 }
 
 // Collect ops with dependency attr `attrName` into depsByGroup (group ->
-// [(op, role)], attr = [group, role], 1=producer/0=consumer). 0 ok, -1 fail.
+// [(op, role)]). Attr is a flat list of pairs: [group, role, group, role, ...].
+// role: 1=producer, 0=consumer. One op may contribute multiple pairs (dual role
+// or several groups). 0 ok, -1 fail.
 static int
 collectDepsByGroup(Operation *rootOp, const char *attrName,
                    llvm::DenseMap<int, SmallVector<std::pair<Operation *, int>>>
                        &depsByGroup) {
-  // Attribute format: {ssbuffer.crossDeps/intraDeps = [group, role]}
   int ret = 0;
+  // One record is [group, role]; the attr concatenates N such records.
   int depSize = 2;
+  int groupOffset = 0;
+  int roleOffset = 1;
 
   rootOp->walk([&](Operation *op) {
     auto depsAttr = op->getAttrOfType<ArrayAttr>(attrName);
     if (!depsAttr)
       return;
 
-    if (depsAttr.size() < depSize) {
-      LDBG("format of dependency attribute error!");
+    if (depsAttr.empty() || depsAttr.size() % depSize != 0) {
+      LDBG("format of dependency attribute error, expect even-length pairs!");
       ret = -1;
       return;
     }
 
-    if (!isa<IntegerAttr>(depsAttr[0]) || !isa<IntegerAttr>(depsAttr[1])) {
-      LDBG("type of dependency attritbute is not Int! error op:" << *op);
-      ret = -1;
-      return;
-    }
+    for (size_t i = 0; i < depsAttr.size(); i += depSize) {
+      Attribute groupAttr = depsAttr[i + groupOffset];
+      Attribute roleAttr = depsAttr[i + roleOffset];
+      if (!isa<IntegerAttr>(groupAttr) || !isa<IntegerAttr>(roleAttr)) {
+        LDBG("type of dependency attritbute is not Int! error op:" << *op);
+        ret = -1;
+        return;
+      }
 
-    int group = cast<IntegerAttr>(depsAttr[0]).getInt();
-    int role = cast<IntegerAttr>(depsAttr[1]).getInt();
-    depsByGroup[group].push_back({op, role});
+      int group = cast<IntegerAttr>(groupAttr).getInt();
+      int role = cast<IntegerAttr>(roleAttr).getInt();
+      depsByGroup[group].push_back({op, role});
+    }
   });
 
   return ret;
 }
 
+// Cross-core: consumer -> one producer list per group it consumes. An op may
+// be both roles and/or in several groups; each group keeps its own list.
+static int buildCrossCoreProducerConsumerMapping(
+    llvm::DenseMap<int, SmallVector<std::pair<Operation *, int>>> &depsByGroup,
+    ConsumerProducerMap &result) {
+  for (auto &groupEntry : depsByGroup) {
+    auto &ops = groupEntry.second;
+
+    SmallVector<Operation *> producers;
+    SmallVector<Operation *> consumers;
+
+    for (auto &opRole : ops) {
+      Operation *op = opRole.first;
+      int role = opRole.second;
+      if (role == CVPipeline::crossCoreProducerId) {
+        if (!llvm::is_contained(producers, op))
+          producers.push_back(op);
+      } else if (role == CVPipeline::crossCoreConsumerId) {
+        if (!llvm::is_contained(consumers, op))
+          consumers.push_back(op);
+      } else {
+        LDBG("Get error role id in dependency attribute: OP: "
+             << *op << ", role: " << role);
+        return -1;
+      }
+    }
+
+    for (Operation *consumer : consumers) {
+      result[consumer].push_back(producers);
+    }
+  }
+
+  return 0;
+}
+
 // Build consumer -> producers mapping from depsByGroup (role 1=producer,
 // 0=consumer); if mainLoop != nullptr only consumers inside it. 0 ok, -1 fail.
-static int buildProducerConsumerMapping(
+static int buildIntraCoreProducerConsumerMapping(
     llvm::DenseMap<int, SmallVector<std::pair<Operation *, int>>> &depsByGroup,
     llvm::DenseMap<Operation *, SmallVector<Operation *>> &result,
     Operation *mainLoop = nullptr) {
@@ -187,11 +231,12 @@ findMainLoopIdContainingOp(Operation *op,
   return -1;
 }
 
-static int filterMemCrossCoreDepsByMainLoop(
-    ModuleOp module,
-    llvm::DenseMap<Operation *, SmallVector<Operation *>> &initialDepsMap,
-    llvm::DenseMap<Operation *, SmallVector<Operation *>> &filteredDepsMap) {
-  LDBG("memCrossCore dependencies before filter: " << initialDepsMap.size());
+static int
+filterMemCrossCoreDepsByMainLoop(ModuleOp module,
+                                 ConsumerProducerMap &initialDepsMap,
+                                 ConsumerProducerMap &filteredDepsMap) {
+  LDBG("memCrossCore dependencies before filter: "
+       << countProducerGroups(initialDepsMap));
 
   // Step 1: Collect all main_loop ops (scf.for or scf.while) and their ids
   llvm::DenseMap<Operation *, int> mainLoopById;
@@ -201,14 +246,10 @@ static int filterMemCrossCoreDepsByMainLoop(
   }
 
   // Step 2: Filter mapping - only keep producer/consumer pairs in the same
-  // main_loop
+  // main_loop. Each inner producer list is one group and is filtered on its
+  // own so a multi-group consumer can keep some groups and drop others.
   for (auto &entry : initialDepsMap) {
     Operation *consumer = entry.first;
-    SmallVector<Operation *> &producers = entry.second;
-    if (producers.empty()) {
-      LDBG("Producers list is empty!");
-      return -1;
-    }
 
     // Find the main_loop id containing the consumer
     int consumerMainLoopId = findMainLoopIdContainingOp(consumer, mainLoopById);
@@ -217,45 +258,54 @@ static int filterMemCrossCoreDepsByMainLoop(
       continue;
     }
 
-    // Find the main_loop id containing the producer
-    int producerMainLoopId =
-        findMainLoopIdContainingOp(producers[0], mainLoopById);
-    if (producerMainLoopId == -1) {
-      LDBG("producer op is not in any main_loop: " << *producers[0]);
-      continue;
-    }
-
-    // Check all producers in the same mainloop
-    for (size_t i = 1; i < producers.size(); i++) {
-      int otherProducerMainLoopId =
-          findMainLoopIdContainingOp(producers[i], mainLoopById);
-      if (otherProducerMainLoopId != producerMainLoopId) {
-        LDBG("Producers are not in the same main_loop. "
-             << "First producer main_loop id: " << producerMainLoopId
-             << ", Producer[" << i
-             << "] main_loop id: " << otherProducerMainLoopId);
+    for (SmallVector<Operation *> &producers : entry.second) {
+      if (producers.empty()) {
+        LDBG("Producers list is empty!");
         return -1;
       }
-    }
 
-    // Check if consumer and producers are in the same main_loop
-    if (consumerMainLoopId != producerMainLoopId) {
-      LDBG("Consumer and producers are in different main_loop, skip. "
-           << "Consumer main_loop id: " << consumerMainLoopId
-           << ", Producer main_loop id: " << producerMainLoopId);
-      continue;
-    }
+      // Find the main_loop id containing the producer
+      int producerMainLoopId =
+          findMainLoopIdContainingOp(producers[0], mainLoopById);
+      if (producerMainLoopId == -1) {
+        LDBG("producer op is not in any main_loop: " << *producers[0]);
+        continue;
+      }
 
-    filteredDepsMap[consumer] = producers;
+      // Check all producers in the same mainloop
+      for (size_t i = 1; i < producers.size(); i++) {
+        int otherProducerMainLoopId =
+            findMainLoopIdContainingOp(producers[i], mainLoopById);
+        if (otherProducerMainLoopId != producerMainLoopId) {
+          LDBG("Producers are not in the same main_loop. "
+               << "First producer main_loop id: " << producerMainLoopId
+               << ", Producer[" << i
+               << "] main_loop id: " << otherProducerMainLoopId);
+          return -1;
+        }
+      }
+
+      // Check if consumer and producers are in the same main_loop
+      if (consumerMainLoopId != producerMainLoopId) {
+        LDBG("Consumer and producers are in different main_loop, skip. "
+             << "Consumer main_loop id: " << consumerMainLoopId
+             << ", Producer main_loop id: " << producerMainLoopId);
+        continue;
+      }
+
+      filteredDepsMap[consumer].push_back(producers);
+    }
   }
 
-  LDBG("memCrossCore dependencies after filter: " << filteredDepsMap.size());
+  LDBG("memCrossCore dependencies after filter: "
+       << countProducerGroups(filteredDepsMap));
 
   return 0;
 }
 
-// Init crossCoreDependentMap from ssbuffer.crossDeps ([group, role]; 1=producer
-// 0=consumer): consumer -> same-group producers, same main_loop. 0 ok, -1 fail.
+// Init crossCoreDependentMap from ssbuffer.crossCoreDeps pairs
+// [group, role, ...]; 1=producer 0=consumer. Consumer -> one producer list per
+// group, same main_loop. 0 ok, -1 fail.
 int initCrossCoreDependentMap(ModuleOp module, ControlFlowConditionInfo *info) {
   // Step 1: Collect all crossDeps by group (including memCrossDeps)
   llvm::DenseMap<int, SmallVector<std::pair<Operation *, int>>>
@@ -267,15 +317,15 @@ int initCrossCoreDependentMap(ModuleOp module, ControlFlowConditionInfo *info) {
   }
 
   // Step 2: Build initial mapping (all producers for each consumer)
-  llvm::DenseMap<Operation *, SmallVector<Operation *>> initialCrossDepsMap;
-  if (buildProducerConsumerMapping(crossDepsByGroup, initialCrossDepsMap) !=
-      0) {
-    LDBG("buildProducerConsumerMapping on crossDeps Failed!");
+  ConsumerProducerMap initialCrossDepsMap;
+  if (buildCrossCoreProducerConsumerMapping(crossDepsByGroup,
+                                            initialCrossDepsMap) != 0) {
+    LDBG("buildCrossCoreProducerConsumerMapping on crossDeps Failed!");
     return -1;
   }
 
   // Step 3: Filter by main_loop constraint
-  llvm::DenseMap<Operation *, SmallVector<Operation *>> filteredCrossDepsMap;
+  ConsumerProducerMap filteredCrossDepsMap;
   if (filterMemCrossCoreDepsByMainLoop(module, initialCrossDepsMap,
                                        filteredCrossDepsMap) != 0) {
     LDBG("filterCrossCoreDepsByMainLoop Failed!");
@@ -312,8 +362,9 @@ int initIntraCoreDependentMap(ModuleOp module, ControlFlowConditionInfo *info) {
     }
 
     llvm::DenseMap<Operation *, SmallVector<Operation *>> depMap;
-    if (buildProducerConsumerMapping(allIntraDepsByGroup, depMap, op) != 0) {
-      LDBG("buildProducerConsumerMapping on intraDeps Failed!");
+    if (buildIntraCoreProducerConsumerMapping(allIntraDepsByGroup, depMap,
+                                              op) != 0) {
+      LDBG("buildIntraCoreProducerConsumerMapping on intraDeps Failed!");
       ret = -1;
       return;
     }
@@ -329,15 +380,18 @@ int initIntraCoreDependentMap(ModuleOp module, ControlFlowConditionInfo *info) {
 // Print all dependent maps for verification
 static void printDependentMaps(ControlFlowConditionInfo *info) {
   // Print crossCoreDependentMap
-  LDBG("crossCoreDependentMap size: " << info->crossCoreDependentMap.size());
+  LDBG("crossCoreDependentMap size: "
+       << countProducerGroups(info->crossCoreDependentMap));
   LDBG("crossCoreDependentMap contents:");
   for (auto &entry : info->crossCoreDependentMap) {
     Operation *consumer = entry.first;
-    SmallVector<Operation *> &producers = entry.second;
-    LDBG("    Consumer: " << *consumer
-                          << " (producers count: " << producers.size() << ")");
-    for (Operation *producer : producers) {
-      LDBG("      Producer: " << *producer);
+    LDBG("    Consumer: " << *consumer << " (groups: " << entry.second.size()
+                          << ")");
+    for (SmallVector<Operation *> &producers : entry.second) {
+      LDBG("      group producers count: " << producers.size());
+      for (Operation *producer : producers) {
+        LDBG("        Producer: " << *producer);
+      }
     }
   }
 
@@ -398,8 +452,10 @@ static void computeProducerBufferCount(ControlFlowConditionInfo *info,
   // Get cross-core buffer count (max size in the map)
   info->crossCoreBufferCount = 0;
   for (auto &entry : info->crossCoreDependentMap) {
-    info->crossCoreBufferCount =
-        std::max(info->crossCoreBufferCount, (int)entry.second.size());
+    for (SmallVector<Operation *> &producers : entry.second) {
+      info->crossCoreBufferCount =
+          std::max(info->crossCoreBufferCount, (int)producers.size());
+    }
   }
   LDBG("Cross-core buffer count (max): " << info->crossCoreBufferCount);
 
@@ -441,21 +497,24 @@ static int buildIfBlockCrossCoreDAG(ModuleOp module,
       return -1;
     }
 
-    // Step 2: Find producer IfOps
-    for (Operation *producerOp : entry.second) {
-      scf::IfOp producerIf = findIfOpContainingOp(producerOp);
-      if (!producerIf) {
-        LDBG("Producer op not in any ssbuffer.if block: " << *producerOp);
-        return -1;
-      }
+    // Step 2: Find producer IfOps (each inner list is one dependency group)
+    for (SmallVector<Operation *> &producers : entry.second) {
+      for (Operation *producerOp : producers) {
+        scf::IfOp producerIf = findIfOpContainingOp(producerOp);
+        if (!producerIf) {
+          LDBG("Producer op not in any ssbuffer.if block: " << *producerOp);
+          return -1;
+        }
 
-      if (producerIf == consumerIf) {
-        LDBG("Producer and consumer are in the same if block, this is invalid: "
-             << *producerIf);
-        return -1;
-      }
+        if (producerIf == consumerIf) {
+          LDBG("Producer and consumer are in the same if block, this is "
+               "invalid: "
+               << *producerIf);
+          return -1;
+        }
 
-      info->ifBlockCrossCoreDAG[producerIf].push_back(consumerIf);
+        info->ifBlockCrossCoreDAG[producerIf].push_back(consumerIf);
+      }
     }
   }
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateConditionInfo.cpp
@@ -252,7 +252,7 @@ UpdateConditionInfoPass::allocSSBuffer(ModuleOp module) {
   SmallVector<SmallVector<Value>> ssbufferMemrefs;
   SmallVector<Value> ssbufferVec0Memrefs;
   SmallVector<Value> ssbufferVec1Memrefs;
-  int numBuffers = info->crossCoreDependentMap.size();
+  int numBuffers = countProducerGroups(info->crossCoreDependentMap);
   if (numBuffers == 0) {
     LDBG("crossCoreDependentMap is empty!" << "\n");
     return ssbufferMemrefs;
@@ -301,8 +301,10 @@ void UpdateConditionInfoPass::collectDependencyBuffers(
     // Collect crossCoreBuffers for this op
     auto it = info->crossCoreDependentMap.find(op);
     if (it != info->crossCoreDependentMap.end()) {
-      crossCoreBuffers[crossCoreIdx][op] = it->second;
-      crossCoreIdx++;
+      for (SmallVector<Operation *> &producers : it->second) {
+        crossCoreBuffers[crossCoreIdx][op] = producers;
+        crossCoreIdx++;
+      }
     }
 
     return WalkResult::advance();
@@ -394,15 +396,16 @@ int UpdateConditionInfoPass::buildIdxToVarMap(
 
 // Helper function to build buffer dependency mappings (fully Operation* based)
 // Outputs two reverse lookup tables for O(1) lookup during IR walk:
-//   - consumerToGroup: consumer Op -> groupIdx
+//   - consumerToGroups: consumer Op -> [groupIdx] (one op may consume several
+//     groups)
 //   - producerToGroups: producer Op -> [groupIdx]
 static int buildBufferDependencyMappings(
     DenseMap<int, DenseMap<Operation *, SmallVector<Operation *>>> &buffers,
-    DenseMap<Operation *, int> &consumerToGroup,
+    DenseMap<Operation *, SmallVector<int>> &consumerToGroups,
     DenseMap<Operation *, SmallVector<int>> &outputToGroups) {
   for (auto &[groupIdx, deps] : buffers) {
     for (auto &[consumer, producers] : deps) {
-      consumerToGroup[consumer] = groupIdx;
+      consumerToGroups[consumer].push_back(groupIdx);
 
       for (Operation *producer : producers) {
         outputToGroups[producer].push_back(groupIdx);
@@ -455,18 +458,18 @@ int UpdateConditionInfoPass::getInputOutputValues(
   DenseMap<Operation *, SmallVector<int>> intraCoreOutputToGroups;
 
   // Add consumer mappings for input dependency identification
-  DenseMap<Operation *, int> crossCoreConsumerToGroup;
-  DenseMap<Operation *, int> intraCoreConsumerToGroup;
+  DenseMap<Operation *, SmallVector<int>> crossCoreConsumerToGroups;
+  DenseMap<Operation *, SmallVector<int>> intraCoreConsumerToGroups;
 
   // Build cross-core mappings
-  if (buildBufferDependencyMappings(crossCoreBuffers, crossCoreConsumerToGroup,
+  if (buildBufferDependencyMappings(crossCoreBuffers, crossCoreConsumerToGroups,
                                     crossCoreOutputToGroups) ==
       UPDATE_CONDITION_INFO_FAILED) {
     return UPDATE_CONDITION_INFO_FAILED;
   }
 
   // Build intra-core mappings
-  if (buildBufferDependencyMappings(intraCoreBuffers, intraCoreConsumerToGroup,
+  if (buildBufferDependencyMappings(intraCoreBuffers, intraCoreConsumerToGroups,
                                     intraCoreOutputToGroups) ==
       UPDATE_CONDITION_INFO_FAILED) {
     return UPDATE_CONDITION_INFO_FAILED;
@@ -478,11 +481,13 @@ int UpdateConditionInfoPass::getInputOutputValues(
       return WalkResult::advance();
 
     // Check if this op is a consumer (for input dependency)
-    if (crossCoreConsumerToGroup.count(op)) {
-      crossCoreInputSet.insert(crossCoreConsumerToGroup[op]);
+    if (crossCoreConsumerToGroups.count(op)) {
+      for (int idx : crossCoreConsumerToGroups[op])
+        crossCoreInputSet.insert(idx);
     }
-    if (intraCoreConsumerToGroup.count(op)) {
-      intraCoreInputSet.insert(intraCoreConsumerToGroup[op]);
+    if (intraCoreConsumerToGroups.count(op)) {
+      for (int idx : intraCoreConsumerToGroups[op])
+        intraCoreInputSet.insert(idx);
     }
 
     // Check if this op is a producer (for output dependency)

--- a/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AddControlFlowCondition/UpdateLoopIterTimes.cpp
@@ -57,11 +57,9 @@ static int findIfOpIndexInList(Operation *op, SmallVector<scf::IfOp> &ifOps,
 }
 
 // Filter out entries where consumer op is not inside the specified forOp
-static llvm::DenseMap<Operation *, SmallVector<Operation *>>
-filterCrossCoreMapByForOp(
-    scf::ForOp forOp,
-    llvm::DenseMap<Operation *, SmallVector<Operation *>> &crossCoreMap) {
-  llvm::DenseMap<Operation *, SmallVector<Operation *>> filteredMap;
+static ConsumerProducerMap
+filterCrossCoreMapByForOp(scf::ForOp forOp, ConsumerProducerMap &crossCoreMap) {
+  ConsumerProducerMap filteredMap;
   for (auto &entry : crossCoreMap) {
     Operation *consumerOp = entry.first;
     if (!forOp->isAncestor(consumerOp)) {
@@ -144,9 +142,8 @@ static scf::ForOp getOtherScopeMainloop(ModuleOp module, bool currentIsCube,
 // has any consumer defOp Returns true if the current compute block runs first
 // (no consumer in first ifOp) Returns false if the current compute block runs
 // later (has consumer in first ifOp)
-static bool
-isRunFirst(SmallVector<scf::IfOp> &ifOps,
-           llvm::DenseMap<Operation *, SmallVector<Operation *>> &crossDeps) {
+static bool isRunFirst(SmallVector<scf::IfOp> &ifOps,
+                       ConsumerProducerMap &crossDeps) {
   if (ifOps.empty()) {
     return true;
   }
@@ -321,7 +318,7 @@ std::pair<int, int> UpdateLoopIterTimesPass::calculateFactor(scf::ForOp forOp) {
   // Calculate cross-core factor and merge with intra-core factor
   if (hasCrossDeps) {
     // Filter out entries where consumer op is not inside current forOp
-    llvm::DenseMap<Operation *, SmallVector<Operation *>> filteredCrossCoreMap =
+    ConsumerProducerMap filteredCrossCoreMap =
         filterCrossCoreMapByForOp(forOp, info->crossCoreDependentMap);
 
     // for caculating the crossdeps, need to filter ifblocks without
@@ -475,8 +472,7 @@ std::pair<int, int> UpdateLoopIterTimesPass::calculateIntraDepsFactor(
 // scope
 std::pair<int, int> UpdateLoopIterTimesPass::calculateCrossDepsFactor(
     scf::ForOp forOp, SmallVector<scf::IfOp> &ifOps,
-    DenseMap<Operation *, int> &ifOpIndex,
-    llvm::DenseMap<Operation *, SmallVector<Operation *>> &crossDeps) {
+    DenseMap<Operation *, int> &ifOpIndex, ConsumerProducerMap &crossDeps) {
   int maxRequiredBuffers = 1;
   int maxX = 1;
 
@@ -514,56 +510,57 @@ std::pair<int, int> UpdateLoopIterTimesPass::calculateCrossDepsFactor(
 
   // Iterate all cross-core dependencies
   for (auto &entry : crossDeps) {
-    Operation *consumerOp = entry.first;                 // Consumer operation
-    SmallVector<Operation *> producerOps = entry.second; // Producer op list
-    int x = producerOps.size(); // Producer op count (one buffer has
-                                // two ops in different scope)
-    // some special buffer is not Symmetrical
-    if (producerOps.size() == 1) {
-      x = 1;
-    }
+    Operation *consumerOp = entry.first; // Consumer operation
+    for (SmallVector<Operation *> &producerOps : entry.second) {
+      int x = producerOps.size(); // Producer op count (one buffer has
+                                  // two ops in different scope)
+      // some special buffer is not Symmetrical
+      if (producerOps.size() == 1) {
+        x = 1;
+      }
 
-    // Find the IfOp index that consumer belongs to (comsumerIdx)
-    int comsumerIdx = getConsumerIfOpIndex(consumerOp, ifOps, ifOpIndex);
-    if (comsumerIdx == -1) {
-      return {-1, -1};
-    }
+      // Find the IfOp index that consumer belongs to (comsumerIdx)
+      int comsumerIdx = getConsumerIfOpIndex(consumerOp, ifOps, ifOpIndex);
+      if (comsumerIdx == -1) {
+        return {-1, -1};
+      }
 
-    // Find producer's position in the other side's ifOps (producerIdx)
-    int producerIdx = getProducerIfOpIndex(producerOps, otherSideIfOps,
-                                           otherSideIfOpIndexMap);
-    if (producerIdx == -1) {
-      return {-1, -1};
-    }
+      // Find producer's position in the other side's ifOps (producerIdx)
+      int producerIdx = getProducerIfOpIndex(producerOps, otherSideIfOps,
+                                             otherSideIfOpIndexMap);
+      if (producerIdx == -1) {
+        return {-1, -1};
+      }
 
-    // If consumer is after producer (comsumerIdx >= producerIdx), calculate
-    // required buffer count comsumerIdx - producerIdx + 1 represents the buffer
-    // count needed to cover this distance If the current compute block executes
-    // first (firstIfOp has no consumer), subtract 1
-    if (comsumerIdx < producerIdx) {
-      // case : C1 -> V1V2V3 -> C2
-      // in this case comsumerIdx < producerIdx, crossDeps hard to process, do
-      // not change the loop iteration times
-      LDBG("there is complex case!");
-      return {1, 1};
-    }
-    int requiredBuffers = comsumerIdx - producerIdx + 1;
-    if (runFirst) {
-      requiredBuffers = requiredBuffers - 1;
-    }
-    LDBG("consumer : " << *consumerOp);
-    LDBG("consumer comsumerIdx: " << comsumerIdx
-                                  << ", producerIdx: " << producerIdx);
-    LDBG("requiredBuffers: " << requiredBuffers);
-    LDBG("buffer: " << x);
-    LDBG("runFirst: " << runFirst);
+      // If consumer is after producer (comsumerIdx >= producerIdx), calculate
+      // required buffer count comsumerIdx - producerIdx + 1 represents the
+      // buffer count needed to cover this distance If the current compute
+      // block executes first (firstIfOp has no consumer), subtract 1
+      if (comsumerIdx < producerIdx) {
+        // case : C1 -> V1V2V3 -> C2
+        // in this case comsumerIdx < producerIdx, crossDeps hard to process, do
+        // not change the loop iteration times
+        LDBG("there is complex case!");
+        return {1, 1};
+      }
+      int requiredBuffers = comsumerIdx - producerIdx + 1;
+      if (runFirst) {
+        requiredBuffers = requiredBuffers - 1;
+      }
+      LDBG("consumer : " << *consumerOp);
+      LDBG("consumer comsumerIdx: " << comsumerIdx
+                                    << ", producerIdx: " << producerIdx);
+      LDBG("requiredBuffers: " << requiredBuffers);
+      LDBG("buffer: " << x);
+      LDBG("runFirst: " << runFirst);
 
-    // Update max value using fraction comparison to avoid precision issues
-    // Comparing requiredBuffers/maxX vs maxRequiredBuffers/x is equivalent to
-    // comparing requiredBuffers * maxX vs maxRequiredBuffers * x
-    if (requiredBuffers * maxX > maxRequiredBuffers * x) {
-      maxRequiredBuffers = requiredBuffers;
-      maxX = x;
+      // Update max value using fraction comparison to avoid precision issues
+      // Comparing requiredBuffers/maxX vs maxRequiredBuffers/x is equivalent to
+      // comparing requiredBuffers * maxX vs maxRequiredBuffers * x
+      if (requiredBuffers * maxX > maxRequiredBuffers * x) {
+        maxRequiredBuffers = requiredBuffers;
+        maxX = x;
+      }
     }
   }
 


### PR DESCRIPTION
fit the change of crossCoreDeps  
Previously, in the "crossCoreDeps" tag of an op, there would only be one pair.like:     
%memspacecast = memref.memory_space_cast %alloc_18 {ssbuffer.block_id = 25 : i32, ssbuffer.crossCoreDeps = [1 : i32, 0 : i32]
but the crossCoreDeps tag now allows multiple pairs to express dependencies.like:
%memspacecast = memref.memory_space_cast %alloc_18 {ssbuffer.block_id = 25 : i32, ssbuffer.crossCoreDeps = [1 : i32, 0 : i32, 2 : i32, 0 : i32 , 3 : i32, 1 : i32]
Therefore, the data structure needs to be changed.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
