### PR TITLE
[costmodel](feat) Support no-anchor materialization, loop stage division

### DIFF
--- a/third_party/ascend/costmodel/include/AscendModel/Analysis/SimtAnchorAnalysis.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Analysis/SimtAnchorAnalysis.h
@@ -31,6 +31,9 @@ enum class SimtAnchorKind {
   PlainOneDimensionalCumsum,
   TensorAtomic,
   TriangularSolveLoop,
+  /// Synthesized descriptor: no primitive anchor exists, so one whole
+  /// LogicalStage's contiguous root range becomes the local SIMT scope.
+  StageOwnedScope,
 };
 
 llvm::StringRef stringifySimtAnchorKind(SimtAnchorKind kind);
@@ -106,9 +109,24 @@ LogicalResult materializeSimtAnchorPlan(ModuleOp module,
                                         int64_t superblockFactor = 1);
 
 /// True when a load/store pointer has an SSA backward slice that reaches a
-/// loaded/gathered index.  This is a real data-dependence test and must not be
-/// confused with the legacy rank-based laneDependentPointerOps proxy.
+/// loaded/gathered index.  This is a real data-dependence test and must not
+/// be confused with the legacy rank-based laneDependentPointerOps proxy.
 bool isLoadedIndexDependentMemoryOp(Operation *op);
+
+/// Structural check: can `roots` be wrapped by one scope.scope region?  All
+/// roots must live in one block and form a lexically contiguous range there
+/// (no foreign operation between the first and last root), because the
+/// materializer moves exactly this set into the scope.
+bool isStageScopeWrappable(llvm::ArrayRef<Operation *> roots);
+
+/// Synthesize a StageOwnedScope descriptor for an anchor-free Stage.  The
+/// Stage's own root range becomes the local SIMT scope, so mixed remains
+/// selectable for kernels with no primitive anchor.  Returns nullopt when
+/// the range is not wrappable, would return pointer-like tensor state, or
+/// when the target cannot materialize local scopes at all.
+std::optional<SimtAnchorDescriptor>
+buildStageOwnedScopeDescriptor(llvm::ArrayRef<Operation *> roots,
+                               bool compileOn91095);
 
 /// Build the non-overlapping shared plan in pre-order.
 SimtAnchorPlan buildMixedSimtAnchorPlan(ModuleOp module, bool compileOn91095);

--- a/third_party/ascend/costmodel/include/AscendModel/Analysis/SimtAnchorAnalysis.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Analysis/SimtAnchorAnalysis.h
@@ -44,6 +44,26 @@ struct CandidateLowerability {
   bool mixed = true;
 };
 
+/// Backend lowering capabilities consumed by anchor analysis.  Keeping these
+/// facts explicit avoids encoding target names in individual pattern matchers
+/// and makes capability changes independently testable.
+struct SimtLoweringCapabilities {
+  bool supportsLocalSimtScopes = false;
+  bool supportsPlainCumsumSIMD = true;
+  /// Plain cumsum is legal when the whole kernel is compiled in simt_only
+  /// mode.  This is deliberately distinct from support inside a local SIMT
+  /// scope: the two routes use different downstream lowering pipelines.
+  bool supportsPlainCumsumSIMTOnly = false;
+  /// Whether tt.scan can be materialized inside a mixed-mode local SIMT
+  /// scope.  Keep this false until the local-scope pipeline lowers vcumsum;
+  /// the surrounding mixed kernel can still execute cumsum on the SIMD side.
+  bool supportsPlainCumsumInLocalSIMTScope = false;
+};
+
+SimtLoweringCapabilities
+querySimtLoweringCapabilities(llvm::StringRef actualTarget,
+                              bool compileOn91095);
+
 /// Structural facts for a blockwise triangular recurrence such as solve_tril.
 /// These are extracted from TTIR and deliberately avoid workload/function
 /// names.  The dense dot tail is outside the SIMT anchor and must remain on the
@@ -130,6 +150,11 @@ buildStageOwnedScopeDescriptor(llvm::ArrayRef<Operation *> roots,
 
 /// Build the non-overlapping shared plan in pre-order.
 SimtAnchorPlan buildMixedSimtAnchorPlan(ModuleOp module, bool compileOn91095);
+
+/// Capability-driven entry point used by the production selector.
+SimtAnchorPlan
+buildMixedSimtAnchorPlan(ModuleOp module,
+                         const SimtLoweringCapabilities &capabilities);
 
 } // namespace ascend
 } // namespace mlir

--- a/third_party/ascend/costmodel/include/AscendModel/Analysis/StagePartitioner.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Analysis/StagePartitioner.h
@@ -18,6 +18,9 @@ struct StagePartitionerOptions {
   int64_t tinyDotFlopsMax = 16384;
   int64_t maximumSuperblockFactor = 1;
   bool scopeSuperblockMaterializable = false;
+  /// Anchor-free Stages may become StageOwnedScope local SIMT scopes only on
+  /// targets whose backend can materialize local scope.scope regions.
+  bool compileOn91095 = true;
 };
 
 /// Ordered post-transform TTIR semantic roots.  AutoBlockify V1's outer loop
@@ -36,12 +39,15 @@ public:
 
 /// Splits ordered semantic roots directly into single-kind Stages.  It does
 /// not evaluate cycles or choose SIMD/SIMT.  The anchor plan is used only as
-/// exact ownership evidence for materializable local SIMT Stages.
+/// exact ownership evidence for materializable local SIMT Stages; anchor-free
+/// Stages may additionally become StageOwnedScope units when the target can
+/// materialize local scopes.
 class StageBoundaryAnalysis {
 public:
   llvm::Expected<StagePartition>
   analyze(const ProgramStructure &structure,
-          const SimtAnchorPlan &anchorPlan) const;
+          const SimtAnchorPlan &anchorPlan,
+          bool compileOn91095 = true) const;
 };
 
 /// Derives structural facts for every already-owned Stage.  It never chooses

--- a/third_party/ascend/costmodel/include/AscendModel/Analysis/StagePartitioner.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Analysis/StagePartitioner.h
@@ -21,6 +21,13 @@ struct StagePartitionerOptions {
   /// Anchor-free Stages may become StageOwnedScope local SIMT scopes only on
   /// targets whose backend can materialize local scope.scope regions.
   bool compileOn91095 = true;
+  /// Expose the direct body operations of independent structured loops
+  /// (no true loop-carried data dependency) as semantic roots, so the loop
+  /// shell is charged only its backedge overhead while the body is partitioned
+  /// with the normal Stage rules.  Loops carrying a real recurrence stay
+  /// atomic.  Always on: independent loop bodies are semantic roots by
+  /// default.
+  bool splitIndependentLoopBody = true;
 };
 
 /// Ordered post-transform TTIR semantic roots.  AutoBlockify V1's outer loop
@@ -29,12 +36,16 @@ struct StagePartitionerOptions {
 /// ownership is derived separately from the immutable SimtAnchorPlan.
 struct ProgramStructure {
   std::vector<Operation *> rootOperations;
+  /// Mirrors StagePartitionerOptions::splitIndependentLoopBody so every
+  /// later analysis resolves roots with the same loop-body exposure rule.
+  bool splitIndependentLoopBody = true;
 };
 
 class ProgramStructureAnalysis {
 public:
   llvm::Expected<ProgramStructure>
-  analyze(ModuleOp module, const SimtAnchorPlan &anchorPlan) const;
+  analyze(ModuleOp module, const SimtAnchorPlan &anchorPlan,
+          bool splitIndependentLoopBody = true) const;
 };
 
 /// Splits ordered semantic roots directly into single-kind Stages.  It does

--- a/third_party/ascend/costmodel/include/AscendModel/Analysis/StagePartitioner.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Analysis/StagePartitioner.h
@@ -55,10 +55,9 @@ public:
 /// materialize local scopes.
 class StageBoundaryAnalysis {
 public:
-  llvm::Expected<StagePartition>
-  analyze(const ProgramStructure &structure,
-          const SimtAnchorPlan &anchorPlan,
-          bool compileOn91095 = true) const;
+  llvm::Expected<StagePartition> analyze(const ProgramStructure &structure,
+                                         const SimtAnchorPlan &anchorPlan,
+                                         bool compileOn91095 = true) const;
 };
 
 /// Derives structural facts for every already-owned Stage.  It never chooses

--- a/third_party/ascend/costmodel/include/AscendModel/RouteModel/SimdSimtCostModel.h
+++ b/third_party/ascend/costmodel/include/AscendModel/RouteModel/SimdSimtCostModel.h
@@ -9,6 +9,7 @@
 #define ASCENDMODEL_ROUTEMODEL_SIMDSIMTCOSTMODEL_H
 
 #include "AscendModel/Analysis/SimtAnchorAnalysis.h"
+#include "AscendModel/RouteModel/StageCostModels.h"
 #include "AscendModel/RouteModel/StageRouteCostModel.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/Support/Error.h"
@@ -139,6 +140,15 @@ llvm::Expected<SimdSimtCostReport>
 analyzeSimdSimtCandidates(mlir::ModuleOp module,
                           const SimtAnchorPlan &anchorPlan,
                           const SimdSimtCostModelOptions &options = {});
+
+/// Partition `module` with exactly the options the candidate model uses for
+/// scoring.  The selector calls this so a Mixed decision synthesized from
+/// StageOwnedScope units (anchor-free Stages) wraps the same root ranges
+/// that produced the scored route.
+llvm::Expected<StagePartition>
+partitionForSimdSimtSelection(mlir::ModuleOp module,
+                              const SimtAnchorPlan &anchorPlan,
+                              const SimdSimtCostModelOptions &options = {});
 
 } // namespace ascend
 } // namespace mlir

--- a/third_party/ascend/costmodel/include/AscendModel/RouteModel/SimdSimtCostModel.h
+++ b/third_party/ascend/costmodel/include/AscendModel/RouteModel/SimdSimtCostModel.h
@@ -87,6 +87,11 @@ struct SimdSimtCostModelOptions {
   /// logical-program group.
   int64_t logicalProgramCountHint = 0;
   int64_t physicalVectorCoreCountHint = 0;
+  /// Expose the bodies of independent structured loops as their own semantic
+  /// roots, so a loop is charged only its backedge overhead while its body is
+  /// partitioned into normal Stages.  Both the scoring analysis and the
+  /// selector's materialization partition must use the same value.
+  bool splitIndependentLoopBody = true;
 };
 
 struct SimdSimtCostReport {

--- a/third_party/ascend/costmodel/include/AscendModel/RouteModel/StageCostModels.h
+++ b/third_party/ascend/costmodel/include/AscendModel/RouteModel/StageCostModels.h
@@ -85,6 +85,15 @@ struct LogicalStage {
   /// materialize only anchors owned by Stages that the solver selected as
   /// SIMT; consuming every materializable anchor would violate the route.
   std::vector<unsigned> simtAnchorIndices;
+  /// Conjunction of all owned anchors' pure-SIMD lowering capabilities.
+  bool allAnchorsSimdLowerable = true;
+  /// Exact operations materialized inside the local SIMT scope.  This may be
+  /// much smaller than `operations` for a hybrid Stage (for example one
+  /// tt.scan inside a loop-carried Stage that also owns several tt.dot ops).
+  std::vector<Operation *> localSimtOperations;
+  /// Per-Stage-iteration workload of localSimtOperations.  Local mixed costing
+  /// uses this for SIMT and charges the residual workload with the SIMD model.
+  StageWorkload localSimtWorkload;
   bool simdLegal = false;
   bool simtLegal = false;
   /// True when this Stage has exact operation ownership/live-in/live-out and

--- a/third_party/ascend/costmodel/include/AscendModel/RouteModel/StageCostModels.h
+++ b/third_party/ascend/costmodel/include/AscendModel/RouteModel/StageCostModels.h
@@ -102,6 +102,10 @@ struct StagePartition {
   bool operationOwnershipComplete = false;
   int64_t modeledOperationCount = 0;
   std::vector<LogicalStage> stages;
+  /// Mirrors StagePartitionerOptions::splitIndependentLoopBody so ownership,
+  /// workload, and feature analyses resolve roots with the same loop-body
+  /// exposure rule that built this partition.
+  bool splitIndependentLoopBody = true;
 };
 
 struct StageOperationRate {

--- a/third_party/ascend/costmodel/include/AscendModel/RouteModel/StageRouteCostModel.h
+++ b/third_party/ascend/costmodel/include/AscendModel/RouteModel/StageRouteCostModel.h
@@ -1,8 +1,9 @@
 //===- StageRouteCostModel.h - Logical-stage route model -------*- C++ -*-===//
 //
-// A kernel is represented as serial algorithm stages.  Every Stage is
-// implemented entirely by SIMD or entirely by SIMT.  A mixed kernel is a
-// route containing both modes; there is deliberately no mixed Stage.
+// A kernel is represented as serial algorithm stages.  Whole-kernel
+// implementations use one mode per Stage.  A local-scope implementation may
+// execute an exact anchored subrange in SIMT while retaining the residual Stage
+// workload in SIMD; this mirrors scope materialization for hybrid IR.
 //
 //===----------------------------------------------------------------------===//
 
@@ -139,6 +140,9 @@ struct LogicalStageCost {
   int64_t iterationCount = 1;
   StageModelFeatures features;
   StageWorkload workload;
+  /// Work executed by an anchored local SIMT scope.  The residual
+  /// (workload-localSimtWorkload) remains SIMD in a mixed implementation.
+  StageWorkload localSimtWorkload;
   int64_t ownedOperationCount = 0;
   /// Unique source locations of the TTIR operations owned by this Stage.
   /// These are calibration provenance only: they let a debug-line-enabled

--- a/third_party/ascend/costmodel/include/AscendModel/Support/CostModelError.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Support/CostModelError.h
@@ -1,0 +1,37 @@
+//===- CostModelError.h - Typed cost-model failures ------------*- C++ -*-===//
+
+#ifndef ASCENDMODEL_SUPPORT_COSTMODELERROR_H
+#define ASCENDMODEL_SUPPORT_COSTMODELERROR_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
+#include <system_error>
+
+namespace mlir::ascend {
+
+/// An input kernel that is valid TTIR but is outside the model/materializer
+/// contract.  The selector may recover from this by using backend_default.
+class UnsupportedCostModelIR final
+    : public llvm::ErrorInfo<UnsupportedCostModelIR> {
+public:
+  static inline char ID = 0;
+
+  explicit UnsupportedCostModelIR(std::string message)
+      : message(std::move(message)) {}
+
+  void log(llvm::raw_ostream &os) const override { os << message; }
+  std::error_code convertToErrorCode() const override {
+    return std::make_error_code(std::errc::not_supported);
+  }
+  llvm::StringRef getMessage() const { return message; }
+
+private:
+  std::string message;
+};
+
+} // namespace mlir::ascend
+
+#endif // ASCENDMODEL_SUPPORT_COSTMODELERROR_H

--- a/third_party/ascend/costmodel/include/AscendModel/Support/CostModelLogger.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Support/CostModelLogger.h
@@ -1,0 +1,117 @@
+//===- CostModelLogger.h - Costmodel execution tracing ----------*- C++ -*-===//
+//
+// Lightweight tracing for the Ascend SIMD/SIMT cost model.  Every log call
+// site goes through costModelSink(), so the current llvm::errs() backend can
+// be swapped for another stream (file, diagnostic engine, callback) by
+// editing that single function.
+//
+// Log levels, resolved once from the COSTMODEL_LOG_LEVEL environment
+// variable:
+//   0 / off      - silent (also the unset default)
+//   1 / default  - full detail: interface call chain, key inputs/outputs,
+//                  IR snapshots, stage partition detail, and per-stage cost
+//                  formulas
+//   2 / verbose  - alias of 1 (kept for compatibility)
+//
+// Usage:
+//   void someInterface(ModuleOp module) {
+//     COSTMODEL_TRACE("someInterface");            // >>> / <<< call chain
+//     costModelLog() << "anchors=" << n << "\n";   // level >= 1
+//     costModelLogIR("tag", module);               // level >= 1 IR snapshot
+//     COSTMODEL_TRACE_DEBUG("helper");             // level >= 2
+//   }
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ASCENDMODEL_SUPPORT_COSTMODELLOGGER_H
+#define ASCENDMODEL_SUPPORT_COSTMODELLOGGER_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
+
+namespace mlir {
+class Operation;
+}
+
+namespace mlir::ascend::costmodel {
+
+/// Resolved log level: 0 = off, 1 = default, 2 = verbose.  Read once from
+/// COSTMODEL_LOG_LEVEL; unset or unrecognized values mean 0 (silent) so
+/// production compilation output stays clean.
+int logLevel();
+bool logEnabled();   // level >= 1
+bool debugEnabled(); // level >= 2
+
+/// Single owner of the output stream.  Currently llvm::errs(); replace this
+/// implementation to redirect logging without touching any call site.
+llvm::raw_ostream &costModelSink();
+
+/// Default-level stream (level >= 1).  Writes the "[COSTMODEL]" prefix plus
+/// current trace indentation, then returns the sink; returns llvm::nulls()
+/// when disabled so call sites need no guard.
+llvm::raw_ostream &costModelLog();
+
+/// Verbose-level stream (level >= 2), same prefixing rules as costModelLog().
+llvm::raw_ostream &costModelDebug();
+
+/// One-line helper: prefix + text + newline at default level.
+void costModelLogLine(llvm::StringRef text);
+/// One-line helper at verbose level.
+void costModelDebugLine(llvm::StringRef text);
+
+/// Print an IR snapshot between banner separators at default level:
+///   ===== IR dump: <tag> =====
+///   <op IR>
+///   ===== IR dump end =====
+void costModelLogIR(llvm::StringRef tag, Operation *op);
+
+/// RAII trace scope.  Prints ">>> name" on entry and "<<< name" on exit,
+/// maintaining indentation so the printed log mirrors the call tree.  No-op
+/// when inactive.
+class CostModelTraceScope {
+public:
+  CostModelTraceScope(llvm::StringRef name, bool active);
+  ~CostModelTraceScope();
+  CostModelTraceScope(const CostModelTraceScope &) = delete;
+  CostModelTraceScope &operator=(const CostModelTraceScope &) = delete;
+
+private:
+  std::string name;
+  bool active;
+};
+
+} // namespace mlir::ascend::costmodel
+
+// Hoist the logging helpers into mlir::ascend so call sites living in (or
+// using) that namespace can invoke them unqualified.
+namespace mlir::ascend {
+using costmodel::costModelDebug;
+using costmodel::costModelDebugLine;
+using costmodel::costModelLog;
+using costmodel::costModelLogIR;
+using costmodel::costModelLogLine;
+using costmodel::costModelSink;
+using costmodel::debugEnabled;
+using costmodel::logEnabled;
+using costmodel::logLevel;
+} // namespace mlir::ascend
+
+#define COSTMODEL_TRACE_PRIVATE_CONCAT2(a, b) a##b
+#define COSTMODEL_TRACE_PRIVATE_CONCAT(a, b)                                    \
+  COSTMODEL_TRACE_PRIVATE_CONCAT2(a, b)
+#define COSTMODEL_TRACE_PRIVATE_VAR(line)                                       \
+  COSTMODEL_TRACE_PRIVATE_CONCAT(costModelTraceScope, line)
+
+/// Interface-level trace, active at log level >= 1.
+#define COSTMODEL_TRACE(name)                                                   \
+  ::mlir::ascend::costmodel::CostModelTraceScope COSTMODEL_TRACE_PRIVATE_VAR(   \
+      __LINE__)(name, ::mlir::ascend::costmodel::logEnabled())
+
+/// Internal helper trace, active at log level >= 2 only.
+#define COSTMODEL_TRACE_DEBUG(name)                                             \
+  ::mlir::ascend::costmodel::CostModelTraceScope COSTMODEL_TRACE_PRIVATE_VAR(   \
+      __LINE__)(name, ::mlir::ascend::costmodel::debugEnabled())
+
+#endif // ASCENDMODEL_SUPPORT_COSTMODELLOGGER_H

--- a/third_party/ascend/costmodel/include/AscendModel/Support/CostModelLogger.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Support/CostModelLogger.h
@@ -99,19 +99,19 @@ using costmodel::logLevel;
 } // namespace mlir::ascend
 
 #define COSTMODEL_TRACE_PRIVATE_CONCAT2(a, b) a##b
-#define COSTMODEL_TRACE_PRIVATE_CONCAT(a, b)                                    \
+#define COSTMODEL_TRACE_PRIVATE_CONCAT(a, b)                                   \
   COSTMODEL_TRACE_PRIVATE_CONCAT2(a, b)
-#define COSTMODEL_TRACE_PRIVATE_VAR(line)                                       \
+#define COSTMODEL_TRACE_PRIVATE_VAR(line)                                      \
   COSTMODEL_TRACE_PRIVATE_CONCAT(costModelTraceScope, line)
 
 /// Interface-level trace, active at log level >= 1.
-#define COSTMODEL_TRACE(name)                                                   \
-  ::mlir::ascend::costmodel::CostModelTraceScope COSTMODEL_TRACE_PRIVATE_VAR(   \
+#define COSTMODEL_TRACE(name)                                                  \
+  ::mlir::ascend::costmodel::CostModelTraceScope COSTMODEL_TRACE_PRIVATE_VAR(  \
       __LINE__)(name, ::mlir::ascend::costmodel::logEnabled())
 
 /// Internal helper trace, active at log level >= 2 only.
-#define COSTMODEL_TRACE_DEBUG(name)                                             \
-  ::mlir::ascend::costmodel::CostModelTraceScope COSTMODEL_TRACE_PRIVATE_VAR(   \
+#define COSTMODEL_TRACE_DEBUG(name)                                            \
+  ::mlir::ascend::costmodel::CostModelTraceScope COSTMODEL_TRACE_PRIVATE_VAR(  \
       __LINE__)(name, ::mlir::ascend::costmodel::debugEnabled())
 
 #endif // ASCENDMODEL_SUPPORT_COSTMODELLOGGER_H

--- a/third_party/ascend/costmodel/include/AscendModel/Support/CostModelLogger.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Support/CostModelLogger.h
@@ -11,7 +11,7 @@
 //   1 / default  - full detail: interface call chain, key inputs/outputs,
 //                  IR snapshots, stage partition detail, and per-stage cost
 //                  formulas
-//   2 / verbose  - alias of 1 (kept for compatibility)
+//   2 / verbose  - level 1 plus internal helper traces
 //
 // Usage:
 //   void someInterface(ModuleOp module) {

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/SimtAnchorAnalysis.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/SimtAnchorAnalysis.cpp
@@ -43,6 +43,17 @@ static std::string getScalarTypeName(Type type) {
   return "unknown";
 }
 
+/// True for scalar or tensor-of-pointer state.  A scope.scope region may
+/// capture such values but must not return them: TritonToUnstructure cannot
+/// reconstruct the offset information for a returned pointer.
+static bool isPointerLikeType(Type type) {
+  std::string text;
+  llvm::raw_string_ostream stream(text);
+  stream << type;
+  stream.flush();
+  return llvm::StringRef(text).contains("!tt.ptr");
+}
+
 struct PlainCumsumLegality {
   int64_t axisExtent;
   std::string elementType;
@@ -557,6 +568,8 @@ llvm::StringRef mlir::ascend::stringifySimtAnchorKind(SimtAnchorKind kind) {
     return "tensor_atomic";
   case SimtAnchorKind::TriangularSolveLoop:
     return "triangular_solve_loop";
+  case SimtAnchorKind::StageOwnedScope:
+    return "stage_owned_scope";
   }
   llvm_unreachable("unknown SIMT anchor kind");
 }
@@ -646,6 +659,86 @@ bool mlir::ascend::isLoadedIndexDependentMemoryOp(Operation *op) {
          hasTensorPointerOperand(op) && pointerDependsOnLoadedIndex(op);
 }
 
+bool mlir::ascend::isStageScopeWrappable(llvm::ArrayRef<Operation *> roots) {
+  if (roots.empty())
+    return false;
+  Block *block = nullptr;
+  llvm::DenseSet<Operation *> planned;
+  for (Operation *root : roots) {
+    if (!root || !root->getBlock())
+      return false;
+    if (block && root->getBlock() != block)
+      return false;
+    block = root->getBlock();
+    if (!planned.insert(root).second)
+      return false;
+    const llvm::StringRef name = root->getName().getStringRef();
+    if (root->hasTrait<OpTrait::IsTerminator>() ||
+        root->hasTrait<OpTrait::IsIsolatedFromAbove>() ||
+        name == "scope.scope" || name == "scope.return")
+      return false;
+  }
+  if (!block)
+    return false;
+
+  // The materializer moves exactly `roots` into one scope.  A foreign
+  // operation lexically inside the [first, last] range would be reordered
+  // behind the new scope and could break SSA dominance for moved consumers,
+  // so require the range to contain only planned operations.
+  Operation *first = nullptr;
+  Operation *last = nullptr;
+  for (Operation &nested : *block) {
+    if (!planned.contains(&nested))
+      continue;
+    if (!first)
+      first = &nested;
+    last = &nested;
+  }
+  for (Operation *cursor = first; cursor && cursor != last;
+       cursor = cursor->getNextNode())
+    if (!planned.contains(cursor))
+      return false;
+  return true;
+}
+
+std::optional<SimtAnchorDescriptor>
+mlir::ascend::buildStageOwnedScopeDescriptor(llvm::ArrayRef<Operation *> roots,
+                                             bool compileOn91095) {
+  if (!compileOn91095 || !isStageScopeWrappable(roots))
+    return std::nullopt;
+
+  // Mirror wrapAnchorRange: the scope returns exactly the values with an
+  // outside user.  Returned pointer-like state cannot be reconstructed by
+  // TritonToUnstructure, so reject that implementation before it is scored.
+  llvm::DenseSet<Operation *> inside;
+  for (Operation *root : roots) {
+    inside.insert(root);
+    root->walk([&](Operation *nested) { inside.insert(nested); });
+  }
+  auto isInside = [&](Operation *user) {
+    for (Operation *owner = user; owner; owner = owner->getParentOp())
+      if (inside.contains(owner))
+        return true;
+    return false;
+  };
+  for (Operation *root : roots)
+    for (Value result : root->getResults())
+      if (isPointerLikeType(result.getType()) &&
+          llvm::any_of(result.getUses(), [&](OpOperand &use) {
+            return !isInside(use.getOwner());
+          }))
+        return std::nullopt;
+
+  SimtAnchorDescriptor descriptor;
+  descriptor.kind = SimtAnchorKind::StageOwnedScope;
+  descriptor.operation = roots.front();
+  llvm::append_range(descriptor.scopeOperations, roots);
+  descriptor.scopeInsertionPoint = roots.front();
+  descriptor.lowerability = CandidateLowerability{};
+  descriptor.materializable = true;
+  return descriptor;
+}
+
 SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(ModuleOp module,
                                                       bool compileOn91095) {
   COSTMODEL_TRACE("buildMixedSimtAnchorPlan");
@@ -690,12 +783,20 @@ SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(ModuleOp module,
     anyMixed |= anchor.lowerability.mixed;
     mixedBlocked |= !anchor.lowerability.mixed && !anchor.lowerability.allSimd;
   }
-  plan.kernelLowerability.mixed = anyMixed && !mixedBlocked;
+  // A kernel with no primitive anchor can still run mixed: every anchor-free
+  // Stage whose roots form a contiguous same-block range is materializable
+  // as a StageOwnedScope, so absence of anchors alone must not disable the
+  // mixed candidate.
+  plan.kernelLowerability.mixed =
+      (anyMixed || plan.anchors.empty()) && !mixedBlocked;
   costModelLog() << "output: anchors=" << plan.anchors.size()
                  << " (kernel lowerability: all_simd="
                  << plan.kernelLowerability.allSimd
                  << " all_simt_only="
                  << plan.kernelLowerability.allSimtOnly
-                 << " mixed=" << plan.kernelLowerability.mixed << ")\n";
+                 << " mixed=" << plan.kernelLowerability.mixed
+                 << (plan.anchors.empty() ? " [stage_owned_scope fallback]"
+                                          : "")
+                 << ")\n";
   return plan;
 }

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/SimtAnchorAnalysis.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/SimtAnchorAnalysis.cpp
@@ -1,6 +1,7 @@
 //===- SimtAnchorAnalysis.cpp - Materializable SIMT anchors --------------===//
 
 #include "AscendModel/Analysis/SimtAnchorAnalysis.h"
+#include "AscendModel/Support/CostModelLogger.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -647,6 +648,7 @@ bool mlir::ascend::isLoadedIndexDependentMemoryOp(Operation *op) {
 
 SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(ModuleOp module,
                                                       bool compileOn91095) {
+  COSTMODEL_TRACE("buildMixedSimtAnchorPlan");
   SimtAnchorPlan plan;
   llvm::DenseSet<Operation *> operationsInPlannedScope;
   module.walk<WalkOrder::PreOrder>([&](Operation *op) {
@@ -670,6 +672,12 @@ SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(ModuleOp module,
     }
     for (Operation *scopeOperation : descriptor->scopeOperations)
       operationsInPlannedScope.insert(scopeOperation);
+    costModelDebug()
+        << "anchor: op=" << descriptor->operation->getName().getStringRef()
+        << " kind="
+        << stringifySimtAnchorKind(descriptor->kind).str()
+        << " materializable=" << descriptor->materializable
+        << " scopeOperations=" << descriptor->scopeOperations.size() << "\n";
     plan.anchors.push_back(std::move(*descriptor));
     return WalkResult::skip();
   });
@@ -683,5 +691,11 @@ SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(ModuleOp module,
     mixedBlocked |= !anchor.lowerability.mixed && !anchor.lowerability.allSimd;
   }
   plan.kernelLowerability.mixed = anyMixed && !mixedBlocked;
+  costModelLog() << "output: anchors=" << plan.anchors.size()
+                 << " (kernel lowerability: all_simd="
+                 << plan.kernelLowerability.allSimd
+                 << " all_simt_only="
+                 << plan.kernelLowerability.allSimtOnly
+                 << " mixed=" << plan.kernelLowerability.mixed << ")\n";
   return plan;
 }

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/SimtAnchorAnalysis.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/SimtAnchorAnalysis.cpp
@@ -473,8 +473,7 @@ collectTriangularSolveScopeOperations(Operation *anchor,
 }
 
 static std::optional<SimtAnchorDescriptor>
-analyzeAnchor(Operation *op,
-              const SimtLoweringCapabilities &capabilities) {
+analyzeAnchor(Operation *op, const SimtLoweringCapabilities &capabilities) {
   if (!op)
     return std::nullopt;
   SimtAnchorDescriptor descriptor;
@@ -561,8 +560,8 @@ analyzeAnchor(Operation *op,
     return std::nullopt;
   }
 
-  descriptor.materializable = capabilities.supportsLocalSimtScopes &&
-                              descriptor.lowerability.mixed;
+  descriptor.materializable =
+      capabilities.supportsLocalSimtScopes && descriptor.lowerability.mixed;
   if (descriptor.kind == SimtAnchorKind::PlainOneDimensionalCumsum)
     descriptor.materializable &=
         capabilities.supportsPlainCumsumInLocalSIMTScope;
@@ -743,10 +742,11 @@ mlir::ascend::buildStageOwnedScopeDescriptor(llvm::ArrayRef<Operation *> roots,
   };
   for (Operation *root : roots)
     for (Value result : root->getResults())
-      if (llvm::any_of(result.getUses(), [&](OpOperand &use) {
-            return !isInside(use.getOwner());
-          }) && (isPointerLikeType(result.getType()) ||
-                 !isa<RankedTensorType>(result.getType())))
+      if (llvm::any_of(
+              result.getUses(),
+              [&](OpOperand &use) { return !isInside(use.getOwner()); }) &&
+          (isPointerLikeType(result.getType()) ||
+           !isa<RankedTensorType>(result.getType())))
         return std::nullopt;
 
   SimtAnchorDescriptor descriptor;
@@ -759,8 +759,9 @@ mlir::ascend::buildStageOwnedScopeDescriptor(llvm::ArrayRef<Operation *> roots,
   return descriptor;
 }
 
-SimtLoweringCapabilities mlir::ascend::querySimtLoweringCapabilities(
-    llvm::StringRef actualTarget, bool compileOn91095) {
+SimtLoweringCapabilities
+mlir::ascend::querySimtLoweringCapabilities(llvm::StringRef actualTarget,
+                                            bool compileOn91095) {
   SimtLoweringCapabilities capabilities;
   // The integration layer is the authority for local-scope support.  Target
   // spelling is retained for diagnostics/future capability-table expansion;
@@ -777,8 +778,7 @@ SimtLoweringCapabilities mlir::ascend::querySimtLoweringCapabilities(
   costModelDebug() << "lowering capabilities: target=" << actualTarget
                    << " local_simt_scope="
                    << capabilities.supportsLocalSimtScopes
-                   << " cumsum_simd="
-                   << capabilities.supportsPlainCumsumSIMD
+                   << " cumsum_simd=" << capabilities.supportsPlainCumsumSIMD
                    << " cumsum_simt_only="
                    << capabilities.supportsPlainCumsumSIMTOnly
                    << " cumsum_local_simt_scope="
@@ -812,12 +812,13 @@ SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(
     }
     for (Operation *scopeOperation : descriptor->scopeOperations)
       operationsInPlannedScope.insert(scopeOperation);
-    costModelDebug()
-        << "anchor: op=" << descriptor->operation->getName().getStringRef()
-        << " kind="
-        << stringifySimtAnchorKind(descriptor->kind).str()
-        << " materializable=" << descriptor->materializable
-        << " scopeOperations=" << descriptor->scopeOperations.size() << "\n";
+    costModelDebug() << "anchor: op="
+                     << descriptor->operation->getName().getStringRef()
+                     << " kind="
+                     << stringifySimtAnchorKind(descriptor->kind).str()
+                     << " materializable=" << descriptor->materializable
+                     << " scopeOperations="
+                     << descriptor->scopeOperations.size() << "\n";
     plan.anchors.push_back(std::move(*descriptor));
     return WalkResult::skip();
   });
@@ -839,8 +840,7 @@ SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(
   costModelLog() << "output: anchors=" << plan.anchors.size()
                  << " (kernel lowerability: all_simd="
                  << plan.kernelLowerability.allSimd
-                 << " all_simt_only="
-                 << plan.kernelLowerability.allSimtOnly
+                 << " all_simt_only=" << plan.kernelLowerability.allSimtOnly
                  << " mixed=" << plan.kernelLowerability.mixed
                  << (plan.anchors.empty() ? " [stage_owned_scope fallback]"
                                           : "")

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/SimtAnchorAnalysis.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/SimtAnchorAnalysis.cpp
@@ -710,6 +710,9 @@ mlir::ascend::buildStageOwnedScopeDescriptor(llvm::ArrayRef<Operation *> roots,
   // Mirror wrapAnchorRange: the scope returns exactly the values with an
   // outside user.  Returned pointer-like state cannot be reconstructed by
   // TritonToUnstructure, so reject that implementation before it is scored.
+  // The SIMT VF scope ABI additionally requires every scope.return value to
+  // be a ranked tensor (LegalizeBoolForSimtVF asserts on non-tensor state),
+  // so a scalar escaping the root range must also reject the scope.
   llvm::DenseSet<Operation *> inside;
   for (Operation *root : roots) {
     inside.insert(root);
@@ -723,10 +726,10 @@ mlir::ascend::buildStageOwnedScopeDescriptor(llvm::ArrayRef<Operation *> roots,
   };
   for (Operation *root : roots)
     for (Value result : root->getResults())
-      if (isPointerLikeType(result.getType()) &&
-          llvm::any_of(result.getUses(), [&](OpOperand &use) {
+      if (llvm::any_of(result.getUses(), [&](OpOperand &use) {
             return !isInside(use.getOwner());
-          }))
+          }) && (isPointerLikeType(result.getType()) ||
+                 !isa<RankedTensorType>(result.getType())))
         return std::nullopt;
 
   SimtAnchorDescriptor descriptor;

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/SimtAnchorAnalysis.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/SimtAnchorAnalysis.cpp
@@ -472,8 +472,9 @@ collectTriangularSolveScopeOperations(Operation *anchor,
   return result;
 }
 
-static std::optional<SimtAnchorDescriptor> analyzeAnchor(Operation *op,
-                                                         bool compileOn91095) {
+static std::optional<SimtAnchorDescriptor>
+analyzeAnchor(Operation *op,
+              const SimtLoweringCapabilities &capabilities) {
   if (!op)
     return std::nullopt;
   SimtAnchorDescriptor descriptor;
@@ -513,8 +514,20 @@ static std::optional<SimtAnchorDescriptor> analyzeAnchor(Operation *op,
     if (!facts)
       return std::nullopt;
     descriptor.kind = SimtAnchorKind::PlainOneDimensionalCumsum;
-    if (facts->axisExtent <= 0 || !isSupportedCumsumType(facts->elementType))
-      descriptor.lowerability.mixed = false;
+    descriptor.lowerability.allSimd = capabilities.supportsPlainCumsumSIMD;
+    descriptor.lowerability.allSimtOnly =
+        capabilities.supportsPlainCumsumSIMTOnly;
+    const bool supportedShapeAndType =
+        facts->axisExtent > 0 && isSupportedCumsumType(facts->elementType);
+    descriptor.lowerability.allSimd &= supportedShapeAndType;
+    descriptor.lowerability.allSimtOnly &= supportedShapeAndType;
+    // A mixed route does not require every recognized anchor to become a
+    // local SIMT scope.  Cumsum can remain in the residual SIMD portion while
+    // independent, genuinely materializable anchors use local SIMT scopes.
+    descriptor.lowerability.mixed =
+        supportedShapeAndType &&
+        (capabilities.supportsPlainCumsumSIMD ||
+         capabilities.supportsPlainCumsumInLocalSIMTScope);
   } else if (name == "tt.atomic_rmw" || name == "tt.atomic_cas") {
     descriptor.kind = SimtAnchorKind::TensorAtomic;
     auto result = op->getNumResults() > 0
@@ -548,7 +561,11 @@ static std::optional<SimtAnchorDescriptor> analyzeAnchor(Operation *op,
     return std::nullopt;
   }
 
-  descriptor.materializable = compileOn91095 && descriptor.lowerability.mixed;
+  descriptor.materializable = capabilities.supportsLocalSimtScopes &&
+                              descriptor.lowerability.mixed;
+  if (descriptor.kind == SimtAnchorKind::PlainOneDimensionalCumsum)
+    descriptor.materializable &=
+        capabilities.supportsPlainCumsumInLocalSIMTScope;
   return descriptor;
 }
 
@@ -742,8 +759,35 @@ mlir::ascend::buildStageOwnedScopeDescriptor(llvm::ArrayRef<Operation *> roots,
   return descriptor;
 }
 
-SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(ModuleOp module,
-                                                      bool compileOn91095) {
+SimtLoweringCapabilities mlir::ascend::querySimtLoweringCapabilities(
+    llvm::StringRef actualTarget, bool compileOn91095) {
+  SimtLoweringCapabilities capabilities;
+  // The integration layer is the authority for local-scope support.  Target
+  // spelling is retained for diagnostics/future capability-table expansion;
+  // individual anchor matchers no longer branch on a product-name boolean.
+  capabilities.supportsLocalSimtScopes = compileOn91095;
+  // tt.scan is supported by the normal SIMD pipeline and by the whole-kernel
+  // simt_only pipeline on 91095.  The local-SIMT-scope pipeline is a third,
+  // narrower capability: its current external compiler cannot legalize the
+  // resulting hivm.hir.vcumsum, so cumsum must stay on the SIMD side of a
+  // mixed route instead of being outlined.
+  capabilities.supportsPlainCumsumSIMD = true;
+  capabilities.supportsPlainCumsumSIMTOnly = compileOn91095;
+  capabilities.supportsPlainCumsumInLocalSIMTScope = false;
+  costModelDebug() << "lowering capabilities: target=" << actualTarget
+                   << " local_simt_scope="
+                   << capabilities.supportsLocalSimtScopes
+                   << " cumsum_simd="
+                   << capabilities.supportsPlainCumsumSIMD
+                   << " cumsum_simt_only="
+                   << capabilities.supportsPlainCumsumSIMTOnly
+                   << " cumsum_local_simt_scope="
+                   << capabilities.supportsPlainCumsumInLocalSIMTScope << "\n";
+  return capabilities;
+}
+
+SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(
+    ModuleOp module, const SimtLoweringCapabilities &capabilities) {
   COSTMODEL_TRACE("buildMixedSimtAnchorPlan");
   SimtAnchorPlan plan;
   llvm::DenseSet<Operation *> operationsInPlannedScope;
@@ -751,7 +795,7 @@ SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(ModuleOp module,
     if (operationsInPlannedScope.contains(op))
       return WalkResult::skip();
     std::optional<SimtAnchorDescriptor> descriptor =
-        analyzeAnchor(op, compileOn91095);
+        analyzeAnchor(op, capabilities);
     if (!descriptor)
       return WalkResult::advance();
 
@@ -802,4 +846,10 @@ SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(ModuleOp module,
                                           : "")
                  << ")\n";
   return plan;
+}
+
+SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(ModuleOp module,
+                                                      bool compileOn91095) {
+  return buildMixedSimtAnchorPlan(
+      module, querySimtLoweringCapabilities("", compileOn91095));
 }

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
@@ -407,6 +407,39 @@ static Operation *getTopLevelSemanticRoot(Operation *operation) {
   return nullptr;
 }
 
+/// Anchor-free Stages can still become local SIMT scopes: the whole root
+/// range is the scope unit (StageOwnedScope).  AutoBlockify V1 scheduling
+/// shells are excluded because wrapping them would serialize the SIMT
+/// execution of every logical program, which is a whole-kernel route.
+static void deriveStageOwnedScopes(StagePartition &partition,
+                                   bool compileOn91095) {
+  for (LogicalStage &stage : partition.stages) {
+    if (stage.localSimtMaterializable || !stage.simtAnchorIndices.empty())
+      continue;
+    if (stage.costModelKind == StageCostModelKind::AutoBlockifyDispatch ||
+        stage.costModelKind == StageCostModelKind::AutoBlockifyLoop)
+      continue;
+    const bool wrappable =
+        buildStageOwnedScopeDescriptor(stage.operations, compileOn91095)
+            .has_value();
+    costModelLog() << "stage scope: stage '" << stage.id << "' roots="
+                   << stage.operations.size()
+                   << " stage_owned_scope=" << wrappable << "\n";
+    if (wrappable) {
+      stage.localSimtMaterializable = true;
+      stage.localSimtFactors = {1};
+      // A stage-owned scope obeys the same SuperBlock ABI as primitive
+      // anchors: factor > 1 requires every root to be a direct child of the
+      // AutoBlockify V1 loop body.
+      stage.localSuperblockMaterializable = llvm::all_of(
+          stage.operations, [](Operation *root) {
+            Operation *parent = root ? root->getParentOp() : nullptr;
+            return parent && parent->hasAttr("ta.auto_blockify_v1.loop");
+          });
+    }
+  }
+}
+
 static bool isInsideAutoBlockifyV1Loop(Operation *operation) {
   if (!operation || operation->hasAttr("ta.auto_blockify_v1.loop"))
     return false;
@@ -668,23 +701,33 @@ static void deriveStageLiveValues(StagePartition &partition) {
 /// materializer will create.  Stage live values are intentionally not used:
 /// a Stage can own SIMD operations around a much smaller local scope, and
 /// charging its complete live-out footprint would invent UB traffic.
+/// Anchor-owned scopes use the merged anchor operation set; anchor-free
+/// StageOwnedScope stages use the Stage's complete root range instead.
 static void deriveLocalSimtScopeTraffic(StagePartition &partition,
                                         const SimtAnchorPlan &anchorPlan) {
   for (LogicalStage &stage : partition.stages) {
     stage.localSimtScopeCount = 0;
     stage.scopeInputTensorBytes = 0;
     stage.scopeOutputTensorBytes = 0;
-    auto merged = mergeSimtStageAnchors(anchorPlan, stage.simtAnchorIndices);
-    if (!merged)
-      continue;
-    {
+    llvm::SmallVector<Operation *> roots;
+    bool isRange = false;
+    if (stage.simtAnchorIndices.empty()) {
+      if (!stage.localSimtMaterializable)
+        continue;
+      llvm::append_range(roots, stage.operations);
+      isRange = roots.size() > 1;
+    } else {
+      auto merged = mergeSimtStageAnchors(anchorPlan, stage.simtAnchorIndices);
+      if (!merged)
+        continue;
       const SimtAnchorDescriptor &anchor = *merged;
-      llvm::SmallVector<Operation *> roots;
-      const bool isRange = anchor.scopeOperations.size() > 1;
+      isRange = anchor.scopeOperations.size() > 1;
       if (isRange)
         llvm::append_range(roots, anchor.scopeOperations);
       else
         roots.push_back(anchor.operation);
+    }
+    {
 
       llvm::DenseSet<Operation *> inside;
       for (Operation *root : roots) {
@@ -948,7 +991,8 @@ buildAnchorGroups(const ProgramStructure &structure,
 
 llvm::Expected<StagePartition>
 StageBoundaryAnalysis::analyze(const ProgramStructure &structure,
-                               const SimtAnchorPlan &anchorPlan) const {
+                               const SimtAnchorPlan &anchorPlan,
+                               bool compileOn91095) const {
   COSTMODEL_TRACE("StageBoundaryAnalysis::analyze");
   if (structure.rootOperations.empty())
     return llvm::createStringError(
@@ -1037,6 +1081,7 @@ StageBoundaryAnalysis::analyze(const ProgramStructure &structure,
     partition.stages.front().workload.paysKernelSetup = true;
 
   attachExactAnchorOwnership(partition, anchorPlan);
+  deriveStageOwnedScopes(partition, compileOn91095);
   deriveStageLiveValues(partition);
   deriveLocalSimtScopeTraffic(partition, anchorPlan);
   return partition;
@@ -1275,12 +1320,10 @@ StagePartitionVerifier::verify(const StagePartition &partition) const {
           std::errc::invalid_argument,
           "materializable Stage '%s' has no operation ownership",
           stage.id.c_str());
-    if (stage.localSimtMaterializable && partition.operationOwnershipComplete &&
-        stage.simtAnchorIndices.empty())
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "materializable Stage '%s' has no exact SIMT anchor ownership",
-          stage.id.c_str());
+    // A materializable Stage carries either exact primitive anchor indices
+    // or, since StageOwnedScope synthesis, none at all: an anchor-free
+    // Stage's own contiguous root range is its local SIMT scope.  Both
+    // forms require the non-empty operation ownership checked above.
     if (partition.operationOwnershipComplete)
       for (unsigned index : stage.simtAnchorIndices)
         if (!ownedAnchors.insert(index).second)
@@ -1446,7 +1489,9 @@ StagePartitioner::partition(ModuleOp module, const SimtAnchorPlan &anchorPlan,
   auto structure = ProgramStructureAnalysis().analyze(module, anchorPlan);
   if (!structure)
     return structure.takeError();
-  auto result = StageBoundaryAnalysis().analyze(*structure, anchorPlan);
+  auto result =
+      StageBoundaryAnalysis().analyze(*structure, anchorPlan,
+                                       options.compileOn91095);
   if (!result)
     return result.takeError();
   costModelLog() << "output: roots=" << structure->rootOperations.size()

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
@@ -1,6 +1,7 @@
 //===- StagePartitioner.cpp - Build semantic Stage IR -------------------===//
 
 #include "AscendModel/Analysis/StagePartitioner.h"
+#include "AscendModel/Support/CostModelLogger.h"
 
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/DenseSet.h"
@@ -740,12 +741,19 @@ static void deriveLocalSimtScopeTraffic(StagePartition &partition,
 llvm::Expected<ProgramStructure>
 ProgramStructureAnalysis::analyze(ModuleOp module,
                                   const SimtAnchorPlan &anchorPlan) const {
+  COSTMODEL_TRACE("ProgramStructureAnalysis::analyze");
   if (!module)
     return llvm::createStringError(
         std::errc::invalid_argument,
         "ProgramStructureAnalysis requires ModuleOp");
   ProgramStructure structure;
   structure.rootOperations = collectTopLevelSemanticRoots(module);
+  costModelLog() << "semantic roots: " << structure.rootOperations.size()
+                 << " (StageBoundaryAnalysis will group these into stages)\n";
+  for (auto [index, root] : llvm::enumerate(structure.rootOperations))
+    costModelLog() << "  root[" << index << "]: "
+                   << root->getName().getStringRef() << " " << root->getLoc()
+                   << "\n";
   if (structure.rootOperations.empty())
     return llvm::createStringError(
         std::errc::invalid_argument,
@@ -941,6 +949,7 @@ buildAnchorGroups(const ProgramStructure &structure,
 llvm::Expected<StagePartition>
 StageBoundaryAnalysis::analyze(const ProgramStructure &structure,
                                const SimtAnchorPlan &anchorPlan) const {
+  COSTMODEL_TRACE("StageBoundaryAnalysis::analyze");
   if (structure.rootOperations.empty())
     return llvm::createStringError(
         std::errc::invalid_argument,
@@ -1003,6 +1012,21 @@ StageBoundaryAnalysis::analyze(const ProgramStructure &structure,
     stage.costModelKind = kind;
     stage.scheduleKind = schedule;
     stage.id = makeStageId(partition.stages.size(), kind);
+    {
+      const char *reason = "single root";
+      if (stage.operations.size() > 1)
+        reason = anchorGroup >= 0 ? "compound SIMT anchor group"
+                                  : "merged plain roots (same kind/schedule "
+                                    "or same source statement)";
+      costModelLog() << "boundary: stage '" << stage.id << "' roots="
+                     << (next - index) << " reason=" << reason << "\n";
+      for (size_t rootIndex = index; rootIndex < next; ++rootIndex) {
+        Operation *rootOp = structure.rootOperations[rootIndex];
+        costModelLog() << "  root[" << rootIndex << "]: "
+                       << rootOp->getName().getStringRef() << " "
+                       << rootOp->getLoc() << "\n";
+      }
+    }
     partition.stages.push_back(std::move(stage));
     index = next;
   }
@@ -1108,6 +1132,7 @@ llvm::Error StageFeatureAnalysis::analyze(StagePartition &partition) const {
 
 llvm::Error StageKindClassifier::analyze(StagePartition &partition,
                                          int64_t tinyDotFlopsMax) const {
+  COSTMODEL_TRACE("StageKindClassifier::analyze");
   if (!partition.operationOwnershipComplete)
     return llvm::Error::success();
   auto compatible = [](StageCostModelKind kind,
@@ -1286,6 +1311,7 @@ llvm::Error
 StageModeLegalityAnalysis::analyze(StagePartition &partition,
                                    int64_t maximumSuperblockFactor,
                                    bool scopeSuperblockMaterializable) const {
+  COSTMODEL_TRACE("StageModeLegalityAnalysis::analyze");
   const int64_t maximum = std::clamp<int64_t>(maximumSuperblockFactor, 1, 4);
   // Local and whole-kernel SuperBlock candidates consume the same SIMT warp
   // resources.  Do not regenerate F4 here after evaluateStageModel has
@@ -1329,15 +1355,102 @@ StageModeLegalityAnalysis::analyze(StagePartition &partition,
   return llvm::Error::success();
 }
 
+static llvm::StringRef stringifyScheduleKind(StageScheduleKind kind) {
+  switch (kind) {
+  case StageScheduleKind::StraightLine:
+    return "straight_line";
+  case StageScheduleKind::IndependentPipelined:
+    return "independent_pipelined";
+  case StageScheduleKind::LoopCarriedSerial:
+    return "loop_carried_serial";
+  case StageScheduleKind::PartiallyDependent:
+    return "partially_dependent";
+  }
+  return "unknown";
+}
+
+static std::string joinFactors(const std::vector<int64_t> &factors) {
+  std::string text;
+  llvm::raw_string_ostream stream(text);
+  llvm::interleave(factors, stream, ",");
+  stream.flush();
+  return text;
+}
+
+/// Print one operation and its nested regions as an indented tree.  Every
+/// TTIR operation owned by a Stage appears here, including loop bodies.
+static void logOperationTree(Operation *operation, int depth) {
+  std::string indent(static_cast<size_t>(depth) * 2, ' ');
+  costModelLog() << indent << operation->getName().getStringRef() << " "
+                 << operation->getLoc() << "\n";
+  for (Region &region : operation->getRegions())
+    for (Block &block : region)
+      for (Operation &nested : block)
+        logOperationTree(&nested, depth + 1);
+}
+
+/// Print the final Stage partition: one summary block per logical Stage with
+/// its kind, schedule, ownership, legality, features, and workload.
+static void logStagePartition(const StagePartition &partition) {
+  for (const LogicalStage &stage : partition.stages) {
+    costModelLog()
+        << "stage '" << stage.id << "': model="
+        << stringifyStageCostModel(stage.costModelKind)
+        << " schedule=" << stringifyScheduleKind(stage.scheduleKind)
+        << " iterations=" << stage.iterationCount
+        << " ops=" << stage.operations.size()
+        << " liveIn=" << stage.liveIns.size() << "(" << stage.liveInBytes
+        << "B)"
+        << " liveOut=" << stage.liveOuts.size() << "(" << stage.liveOutBytes
+        << "B)"
+        << " simdLegal=" << stage.simdLegal
+        << " simtLegal=" << stage.simtLegal
+        << " simtFactors=[" << joinFactors(stage.legalSimtFactors) << "]"
+        << " localFactors=[" << joinFactors(stage.localSimtFactors) << "]"
+        << (stage.localSimtMaterializable ? " localSimtMaterializable" : "")
+        << "\n";
+    costModelLog()
+        << "  features: loop=" << stage.features.hasLoop
+        << " loopCarriedDep=" << stage.features.hasLoopCarriedDataDependency
+        << " pointerInduction=" << stage.features.hasPointerInduction
+        << " contiguousMem=" << stage.features.hasContiguousMemory
+        << " indirectMem=" << stage.features.hasIndirectMemory
+        << " reduction=" << stage.features.hasReduction
+        << " prefixScan=" << stage.features.hasPrefixScan
+        << " dot=" << stage.features.hasDot
+        << " conversionPack=" << stage.features.hasConversionPack
+        << " activeLaneRatio=" << stage.features.activeLaneRatio << "\n";
+    costModelLog()
+        << "  workload: scalarOps=" << stage.workload.scalarOperations
+        << " loadBytes=" << stage.workload.loadBytes
+        << " storeBytes=" << stage.workload.storeBytes
+        << " loadWarps=" << stage.workload.loadWarpInstructions
+        << " storeWarps=" << stage.workload.storeWarpInstructions
+        << " predElems=" << stage.workload.predicateElements
+        << " shuffleSteps=" << stage.workload.shuffleLaneSteps
+        << " dotFlops=" << stage.workload.dotFlops
+        << " issueElems=" << stage.workload.issueElements
+        << " spillTxns=" << stage.workload.estimatedSpillTransactions
+        << " paysKernelSetup=" << stage.workload.paysKernelSetup << "\n";
+    costModelLog() << "  operation tree (" << stage.operations.size()
+                   << " roots):\n";
+    for (Operation *root : stage.operations)
+      logOperationTree(root, 2);
+  }
+}
+
 llvm::Expected<StagePartition>
 StagePartitioner::partition(ModuleOp module, const SimtAnchorPlan &anchorPlan,
                             const StagePartitionerOptions &options) const {
+  COSTMODEL_TRACE("StagePartitioner::partition");
   auto structure = ProgramStructureAnalysis().analyze(module, anchorPlan);
   if (!structure)
     return structure.takeError();
   auto result = StageBoundaryAnalysis().analyze(*structure, anchorPlan);
   if (!result)
     return result.takeError();
+  costModelLog() << "output: roots=" << structure->rootOperations.size()
+                 << " stages=" << result->stages.size() << "\n";
   StageWorkloadAnalysis workloadAnalysis;
   if (llvm::Error error = workloadAnalysis.analyze(*result))
     return std::move(error);
@@ -1354,5 +1467,6 @@ StagePartitioner::partition(ModuleOp module, const SimtAnchorPlan &anchorPlan,
     return std::move(error);
   if (llvm::Error error = StagePartitionVerifier().verify(*result))
     return std::move(error);
+  logStagePartition(*result);
   return std::move(*result);
 }

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
@@ -426,6 +426,8 @@ static void attachExactAnchorOwnership(StagePartition &partition,
     if (!stage.localSimtMaterializable)
       continue;
     stage.simtAnchorIndices.clear();
+    stage.localSimtOperations.clear();
+    stage.allAnchorsSimdLowerable = true;
     stage.localSuperblockMaterializable = false;
     bool allAnchorsDirectlyOwnedByV1Loop = true;
     for (auto indexedAnchor : llvm::enumerate(anchorPlan.anchors)) {
@@ -434,6 +436,7 @@ static void attachExactAnchorOwnership(StagePartition &partition,
           stageOwnsAnchor(stage, anchor, splitLoopBody)) {
         stage.simtAnchorIndices.push_back(
             static_cast<unsigned>(indexedAnchor.index()));
+        stage.allAnchorsSimdLowerable &= anchor.lowerability.allSimd;
         Operation *insertionPoint = anchor.scopeOperations.size() > 1
                                         ? anchor.scopeInsertionPoint
                                         : anchor.operation;
@@ -665,17 +668,21 @@ static bool isIndependentStructuredLoop(Operation *operation) {
 }
 
 /// Trip count of the independent structured loops enclosing `root` when
-/// loop-body splitting is active.  Nested split loops take the maximum
-/// enclosing trip count, mirroring semanticRootIterationCount's max-based
-/// nesting approximation; the common single-loop case is exact.
+/// loop-body splitting is active.  Nested loop bodies execute by the product
+/// of their enclosing trip counts, not the maximum.
 static int64_t enclosingSplitLoopTripCount(Operation *root) {
   int64_t trips = 1;
   if (!root)
     return trips;
   for (Operation *parent = root->getParentOp(); parent;
-       parent = parent->getParentOp())
-    if (isIndependentStructuredLoop(parent))
-      trips = std::max(trips, getLoopTripCount(parent, 1));
+       parent = parent->getParentOp()) {
+    if (!isIndependentStructuredLoop(parent))
+      continue;
+    const int64_t factor = std::max<int64_t>(1, getLoopTripCount(parent, 1));
+    if (trips > std::numeric_limits<int64_t>::max() / factor)
+      return std::numeric_limits<int64_t>::max();
+    trips *= factor;
+  }
   return trips;
 }
 
@@ -881,6 +888,7 @@ static void deriveLocalSimtScopeTraffic(StagePartition &partition,
     stage.localSimtScopeCount = 0;
     stage.scopeInputTensorBytes = 0;
     stage.scopeOutputTensorBytes = 0;
+    stage.localSimtOperations.clear();
     llvm::SmallVector<Operation *> roots;
     bool isRange = false;
     if (stage.simtAnchorIndices.empty()) {
@@ -900,6 +908,7 @@ static void deriveLocalSimtScopeTraffic(StagePartition &partition,
         roots.push_back(anchor.operation);
     }
     {
+      stage.localSimtOperations.assign(roots.begin(), roots.end());
 
       llvm::DenseSet<Operation *> inside;
       for (Operation *root : roots) {
@@ -1401,12 +1410,24 @@ llvm::Error StageKindClassifier::analyze(StagePartition &partition,
     if (stage.costModelKind == StageCostModelKind::AutoBlockifyDispatch ||
         stage.costModelKind == StageCostModelKind::AutoBlockifyLoop)
       continue;
+    // A Stage mixing tt.dot with another dominant structure (reduction,
+    // indirect memory, loop-carried recurrence) cannot always be split: the
+    // dot may sit inside the serial chain itself (e.g. a chunked-scan state
+    // update whose per-iteration body contains dots), so the partitioner has
+    // no boundary at which to separate it.  Model such hybrid Stages with
+    // the dominant structure's kind instead of failing: the workload
+    // accounting already charges the dot on the same critical path
+    // (StageCostModels mapWorkload/estimateStage), and the SIMT profile's
+    // scalar-FMA dot rate keeps a hybrid Stage honestly expensive in SIMT.
     if (facts.hasDot && (facts.hasReduction || facts.hasIndirectMemory ||
                          facts.hasLoopCarriedDataDependency))
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "requires_split: Stage '%s' owns incompatible dominant structures",
-          stage.id.c_str());
+      costModelLog()
+          << "hybrid dominant structures accepted: Stage '" << stage.id
+          << "' combines tt.dot with "
+          << (facts.hasLoopCarriedDataDependency
+                  ? "loop-carried recurrence"
+                  : facts.hasReduction ? "reduction" : "indirect memory")
+          << "; modeling as the dominant structure\n";
 
     auto derive = [&]() {
       if (facts.hasLoopCarriedDataDependency)
@@ -1480,6 +1501,44 @@ llvm::Error StageWorkloadAnalysis::analyze(StagePartition &partition) const {
     recomputeIssueElements(work);
     stage.workload = std::move(work);
     makePerIteration(stage);
+
+    stage.localSimtWorkload = StageWorkload{};
+    if (!stage.localSimtOperations.empty()) {
+      llvm::DenseSet<Operation *> selected;
+      for (Operation *localRoot : stage.localSimtOperations) {
+        selected.insert(localRoot);
+        localRoot->walk(
+            [&](Operation *nested) { selected.insert(nested); });
+      }
+      auto accumulateSelected = [&](auto &&self, Operation *operation,
+                                    double multiplicity) -> void {
+        if (!operation)
+          return;
+        if (selected.contains(operation)) {
+          StageWorkload local;
+          accumulateOneOperation(operation, local);
+          scaleWorkload(local, multiplicity);
+          mergeWorkload(stage.localSimtWorkload, std::move(local));
+        }
+        if (operation->hasAttr("ta.auto_blockify_v1.loop"))
+          return;
+        const double childMultiplicity =
+            multiplicity * static_cast<double>(
+                               getLoopTripCount(operation,
+                                                fallbackLoopTripCount));
+        for (Region &region : operation->getRegions())
+          for (Block &block : region)
+            for (Operation &nested : block.getOperations())
+              self(self, &nested, childMultiplicity);
+      };
+      for (Operation *root : stage.operations)
+        accumulateSelected(accumulateSelected, root,
+                           semanticRootEntryMultiplicity(root, splitLoopBody));
+      scaleWorkload(stage.localSimtWorkload,
+                    1.0 / static_cast<double>(
+                              std::max<int64_t>(1, stage.iterationCount)));
+      recomputeIssueElements(stage.localSimtWorkload);
+    }
     if (!stage.workload.isFiniteAndNonNegative())
       return llvm::createStringError(
           std::errc::invalid_argument,
@@ -1553,7 +1612,7 @@ StageModeLegalityAnalysis::analyze(StagePartition &partition,
   // a smaller runtime grid).
   const int64_t localMaximum = scopeSuperblockMaterializable ? maximum : 1;
   for (LogicalStage &stage : partition.stages) {
-    stage.simdLegal = true;
+    stage.simdLegal = stage.allAnchorsSimdLowerable;
     stage.simtLegal = true;
     stage.legalSimtFactors = {1};
     // A pure-SIMT SuperBlock factor is a whole-kernel schedule, not a

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
@@ -467,8 +467,15 @@ static Operation *getTopLevelSemanticRoot(Operation *operation) {
     return nullptr;
   Operation *root = operation;
   while (Operation *parent = root->getParentOp()) {
+    const llvm::StringRef parentName = parent->getName().getStringRef();
+    // AutoBlockify V1 may wrap a multi-block original function body in a
+    // newly created scf.execute_region.  That region is only a scheduling
+    // shell, so semantic roots inside it should be exposed directly instead
+    // of being owned by the execute_region.
     if (isFunctionLikeTTIROp(parent) ||
-        parent->hasAttr("ta.auto_blockify_v1.loop"))
+        parent->hasAttr("ta.auto_blockify_v1.loop") ||
+        (parentName == "scf.execute_region" &&
+         parent->hasAttr("ta.auto_blockify_v1.schedule")))
       return root;
     root = parent;
   }
@@ -536,29 +543,44 @@ static bool isInsideAutoBlockifyV1Loop(Operation *operation) {
 
 static std::vector<Operation *> collectTopLevelSemanticRoots(ModuleOp module) {
   std::vector<Operation *> result;
-  auto appendBlock = [&](Block &block) {
+  auto appendOps = [&](auto &&self, Block &block, bool insideV1Loop) -> void {
     for (Operation &nested : block.getOperations()) {
       if (nested.hasTrait<OpTrait::IsTerminator>())
         continue;
+
+      const llvm::StringRef name = nested.getName().getStringRef();
+      const bool isV1Loop = nested.hasAttr("ta.auto_blockify_v1.loop");
+      // AutoBlockify V1 wraps a multi-block original function body in a new
+      // scf.execute_region.  That region is only a scheduling shell; expose
+      // its inner operations as semantic roots so the real algorithm is not
+      // hidden behind an auto_blockify_dispatch stage.
+      const bool isV1ExecuteRegion =
+          insideV1Loop && name == "scf.execute_region" &&
+          nested.hasAttr("ta.auto_blockify_v1.schedule");
+      if (isV1ExecuteRegion) {
+        for (Region &region : nested.getRegions())
+          for (Block &body : region)
+            self(self, body, insideV1Loop);
+        continue;
+      }
+
       result.push_back(&nested);
       // AutoBlockify V1's scf.for is a scheduling shell.  Own the shell as
       // loop control, then expose its direct body operations as semantic
       // roots.  Other structured operations remain atomic roots so their
       // nested recurrence/reduction work is not double-owned.
-      if (!nested.hasAttr("ta.auto_blockify_v1.loop") ||
-          nested.getNumRegions() == 0)
+      if (!isV1Loop || nested.getNumRegions() == 0)
         continue;
-      for (Block &body : nested.getRegion(0))
-        for (Operation &bodyOperation : body.getOperations())
-          if (!bodyOperation.hasTrait<OpTrait::IsTerminator>())
-            result.push_back(&bodyOperation);
+      for (Region &region : nested.getRegions())
+        for (Block &body : region)
+          self(self, body, /*insideV1Loop=*/true);
     }
   };
   for (Operation &operation : module.getBody()->getOperations()) {
     if (!isFunctionLikeTTIROp(&operation) || operation.getNumRegions() == 0)
       continue;
     for (Block &block : operation.getRegion(0))
-      appendBlock(block);
+      appendOps(appendOps, block, /*insideV1Loop=*/false);
   }
   return result;
 }

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
@@ -513,8 +513,8 @@ static void deriveStageOwnedScopes(StagePartition &partition,
     const bool wrappable =
         buildStageOwnedScopeDescriptor(stage.operations, compileOn91095)
             .has_value();
-    costModelLog() << "stage scope: stage '" << stage.id << "' roots="
-                   << stage.operations.size()
+    costModelLog() << "stage scope: stage '" << stage.id
+                   << "' roots=" << stage.operations.size()
                    << " stage_owned_scope=" << wrappable << "\n";
     if (wrappable) {
       stage.localSimtMaterializable = true;
@@ -522,8 +522,8 @@ static void deriveStageOwnedScopes(StagePartition &partition,
       // A stage-owned scope obeys the same SuperBlock ABI as primitive
       // anchors: factor > 1 requires every root to be a direct child of the
       // AutoBlockify V1 loop body.
-      stage.localSuperblockMaterializable = llvm::all_of(
-          stage.operations, [](Operation *root) {
+      stage.localSuperblockMaterializable =
+          llvm::all_of(stage.operations, [](Operation *root) {
             Operation *parent = root ? root->getParentOp() : nullptr;
             return parent && parent->hasAttr("ta.auto_blockify_v1.loop");
           });
@@ -585,8 +585,8 @@ static std::vector<Operation *> collectTopLevelSemanticRoots(ModuleOp module) {
   return result;
 }
 
-static void appendIndependentLoopBodyRoots(
-    Operation *operation, std::vector<Operation *> &roots) {
+static void appendIndependentLoopBodyRoots(Operation *operation,
+                                           std::vector<Operation *> &roots) {
   if (!isIndependentStructuredLoop(operation) ||
       operation->hasAttr("ta.auto_blockify_v1.loop"))
     return;
@@ -1003,9 +1003,9 @@ ProgramStructureAnalysis::analyze(ModuleOp module,
   costModelLog() << "semantic roots: " << structure.rootOperations.size()
                  << " (StageBoundaryAnalysis will group these into stages)\n";
   for (auto [index, root] : llvm::enumerate(structure.rootOperations))
-    costModelLog() << "  root[" << index << "]: "
-                   << root->getName().getStringRef() << " " << root->getLoc()
-                   << "\n";
+    costModelLog() << "  root[" << index
+                   << "]: " << root->getName().getStringRef() << " "
+                   << root->getLoc() << "\n";
   if (structure.rootOperations.empty())
     return llvm::createStringError(
         std::errc::invalid_argument,
@@ -1156,8 +1156,8 @@ buildAnchorGroups(const ProgramStructure &structure,
       continue;
     llvm::SmallVector<size_t, 8> positions;
     auto addPosition = [&](Operation *operation) {
-      Operation *root =
-          getPartitionSemanticRoot(operation, structure.splitIndependentLoopBody);
+      Operation *root = getPartitionSemanticRoot(
+          operation, structure.splitIndependentLoopBody);
       auto iterator = llvm::find(structure.rootOperations, root);
       if (iterator == structure.rootOperations.end())
         return;
@@ -1263,8 +1263,9 @@ StageBoundaryAnalysis::analyze(const ProgramStructure &structure,
             std::errc::invalid_argument,
             "StageBoundaryAnalysis overlaps semantic root ownership");
       stage.operations.push_back(candidate);
-      stage.iterationCount = std::max(
-          stage.iterationCount, semanticRootIterationCount(candidate, splitLoopBody));
+      stage.iterationCount =
+          std::max(stage.iterationCount,
+                   semanticRootIterationCount(candidate, splitLoopBody));
       if (semanticKindPriority(candidateKind) > semanticKindPriority(kind)) {
         kind = candidateKind;
         schedule = candidateSchedule;
@@ -1280,12 +1281,13 @@ StageBoundaryAnalysis::analyze(const ProgramStructure &structure,
         reason = anchorGroup >= 0 ? "compound SIMT anchor group"
                                   : "merged plain roots (same kind/schedule "
                                     "or same source statement)";
-      costModelLog() << "boundary: stage '" << stage.id << "' roots="
-                     << (next - index) << " reason=" << reason << "\n";
+      costModelLog() << "boundary: stage '" << stage.id
+                     << "' roots=" << (next - index) << " reason=" << reason
+                     << "\n";
       for (size_t rootIndex = index; rootIndex < next; ++rootIndex) {
         Operation *rootOp = structure.rootOperations[rootIndex];
-        costModelLog() << "  root[" << rootIndex << "]: "
-                       << rootOp->getName().getStringRef() << " "
+        costModelLog() << "  root[" << rootIndex
+                       << "]: " << rootOp->getName().getStringRef() << " "
                        << rootOp->getLoc() << "\n";
       }
     }
@@ -1443,13 +1445,13 @@ llvm::Error StageKindClassifier::analyze(StagePartition &partition,
     // scalar-FMA dot rate keeps a hybrid Stage honestly expensive in SIMT.
     if (facts.hasDot && (facts.hasReduction || facts.hasIndirectMemory ||
                          facts.hasLoopCarriedDataDependency))
-      costModelLog()
-          << "hybrid dominant structures accepted: Stage '" << stage.id
-          << "' combines tt.dot with "
-          << (facts.hasLoopCarriedDataDependency
-                  ? "loop-carried recurrence"
-                  : facts.hasReduction ? "reduction" : "indirect memory")
-          << "; modeling as the dominant structure\n";
+      costModelLog() << "hybrid dominant structures accepted: Stage '"
+                     << stage.id << "' combines tt.dot with "
+                     << (facts.hasLoopCarriedDataDependency
+                             ? "loop-carried recurrence"
+                         : facts.hasReduction ? "reduction"
+                                              : "indirect memory")
+                     << "; modeling as the dominant structure\n";
 
     auto derive = [&]() {
       if (facts.hasLoopCarriedDataDependency)
@@ -1529,8 +1531,7 @@ llvm::Error StageWorkloadAnalysis::analyze(StagePartition &partition) const {
       llvm::DenseSet<Operation *> selected;
       for (Operation *localRoot : stage.localSimtOperations) {
         selected.insert(localRoot);
-        localRoot->walk(
-            [&](Operation *nested) { selected.insert(nested); });
+        localRoot->walk([&](Operation *nested) { selected.insert(nested); });
       }
       auto accumulateSelected = [&](auto &&self, Operation *operation,
                                     double multiplicity) -> void {
@@ -1545,9 +1546,8 @@ llvm::Error StageWorkloadAnalysis::analyze(StagePartition &partition) const {
         if (operation->hasAttr("ta.auto_blockify_v1.loop"))
           return;
         const double childMultiplicity =
-            multiplicity * static_cast<double>(
-                               getLoopTripCount(operation,
-                                                fallbackLoopTripCount));
+            multiplicity * static_cast<double>(getLoopTripCount(
+                               operation, fallbackLoopTripCount));
         for (Region &region : operation->getRegions())
           for (Block &block : region)
             for (Operation &nested : block.getOperations())
@@ -1709,8 +1709,8 @@ static void logOperationTree(Operation *operation, int depth) {
 static void logStagePartition(const StagePartition &partition) {
   for (const LogicalStage &stage : partition.stages) {
     costModelLog()
-        << "stage '" << stage.id << "': model="
-        << stringifyStageCostModel(stage.costModelKind)
+        << "stage '" << stage.id
+        << "': model=" << stringifyStageCostModel(stage.costModelKind)
         << " schedule=" << stringifyScheduleKind(stage.scheduleKind)
         << " iterations=" << stage.iterationCount
         << " ops=" << stage.operations.size()
@@ -1718,35 +1718,36 @@ static void logStagePartition(const StagePartition &partition) {
         << "B)"
         << " liveOut=" << stage.liveOuts.size() << "(" << stage.liveOutBytes
         << "B)"
-        << " simdLegal=" << stage.simdLegal
-        << " simtLegal=" << stage.simtLegal
+        << " simdLegal=" << stage.simdLegal << " simtLegal=" << stage.simtLegal
         << " simtFactors=[" << joinFactors(stage.legalSimtFactors) << "]"
         << " localFactors=[" << joinFactors(stage.localSimtFactors) << "]"
         << (stage.localSimtMaterializable ? " localSimtMaterializable" : "")
         << "\n";
-    costModelLog()
-        << "  features: loop=" << stage.features.hasLoop
-        << " loopCarriedDep=" << stage.features.hasLoopCarriedDataDependency
-        << " pointerInduction=" << stage.features.hasPointerInduction
-        << " contiguousMem=" << stage.features.hasContiguousMemory
-        << " indirectMem=" << stage.features.hasIndirectMemory
-        << " reduction=" << stage.features.hasReduction
-        << " prefixScan=" << stage.features.hasPrefixScan
-        << " dot=" << stage.features.hasDot
-        << " conversionPack=" << stage.features.hasConversionPack
-        << " activeLaneRatio=" << stage.features.activeLaneRatio << "\n";
-    costModelLog()
-        << "  workload: scalarOps=" << stage.workload.scalarOperations
-        << " loadBytes=" << stage.workload.loadBytes
-        << " storeBytes=" << stage.workload.storeBytes
-        << " loadWarps=" << stage.workload.loadWarpInstructions
-        << " storeWarps=" << stage.workload.storeWarpInstructions
-        << " predElems=" << stage.workload.predicateElements
-        << " shuffleSteps=" << stage.workload.shuffleLaneSteps
-        << " dotFlops=" << stage.workload.dotFlops
-        << " issueElems=" << stage.workload.issueElements
-        << " spillTxns=" << stage.workload.estimatedSpillTransactions
-        << " paysKernelSetup=" << stage.workload.paysKernelSetup << "\n";
+    costModelLog() << "  features: loop=" << stage.features.hasLoop
+                   << " loopCarriedDep="
+                   << stage.features.hasLoopCarriedDataDependency
+                   << " pointerInduction=" << stage.features.hasPointerInduction
+                   << " contiguousMem=" << stage.features.hasContiguousMemory
+                   << " indirectMem=" << stage.features.hasIndirectMemory
+                   << " reduction=" << stage.features.hasReduction
+                   << " prefixScan=" << stage.features.hasPrefixScan
+                   << " dot=" << stage.features.hasDot
+                   << " conversionPack=" << stage.features.hasConversionPack
+                   << " activeLaneRatio=" << stage.features.activeLaneRatio
+                   << "\n";
+    costModelLog() << "  workload: scalarOps="
+                   << stage.workload.scalarOperations
+                   << " loadBytes=" << stage.workload.loadBytes
+                   << " storeBytes=" << stage.workload.storeBytes
+                   << " loadWarps=" << stage.workload.loadWarpInstructions
+                   << " storeWarps=" << stage.workload.storeWarpInstructions
+                   << " predElems=" << stage.workload.predicateElements
+                   << " shuffleSteps=" << stage.workload.shuffleLaneSteps
+                   << " dotFlops=" << stage.workload.dotFlops
+                   << " issueElems=" << stage.workload.issueElements
+                   << " spillTxns=" << stage.workload.estimatedSpillTransactions
+                   << " paysKernelSetup=" << stage.workload.paysKernelSetup
+                   << "\n";
     costModelLog() << "  operation tree (" << stage.operations.size()
                    << " roots):\n";
     for (Operation *root : stage.operations)
@@ -1762,9 +1763,8 @@ StagePartitioner::partition(ModuleOp module, const SimtAnchorPlan &anchorPlan,
       module, anchorPlan, options.splitIndependentLoopBody);
   if (!structure)
     return structure.takeError();
-  auto result =
-      StageBoundaryAnalysis().analyze(*structure, anchorPlan,
-                                       options.compileOn91095);
+  auto result = StageBoundaryAnalysis().analyze(*structure, anchorPlan,
+                                                options.compileOn91095);
   if (!result)
     return result.takeError();
   costModelLog() << "output: roots=" << structure->rootOperations.size()

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
@@ -61,10 +61,57 @@ static bool isPointerLikeType(Type type) {
   return llvm::StringRef(typeToString(type)).contains("!tt.ptr");
 }
 
-/// True when a loop argument only participates in address induction.  Such a
-/// value is an implementation recurrence that later pointer canonicalization
-/// can eliminate; it is not an algorithmic loop-carried dependency and must
-/// not disable the SIMD independent-loop roofline model.
+/// Defined after operationTreeHasTrueLoopCarriedDependency; forward declared
+/// because root collection, ownership, and workload helpers all resolve loop
+/// shells through it.
+static bool isIndependentStructuredLoop(Operation *operation);
+
+/// Operand index of the (optional) mask predicate of a memory operation.
+static std::optional<unsigned> getMemoryMaskOperandIndex(Operation *operation) {
+  const llvm::StringRef name = operation->getName().getStringRef();
+  if (name == "tt.load")
+    return 1u;
+  if (name == "tt.store" || name.starts_with("tt.atomic"))
+    return 2u;
+  return std::nullopt;
+}
+
+/// True when every use of `value` is the mask predicate of a memory
+/// operation, allowing forwarding through shape helpers and predicate
+/// boolean algebra.  A comparison that only guards masked accesses
+/// implements addressing boundary logic; it does not couple loop
+/// iterations algorithmically.
+static bool isMemoryMaskOnlyValue(Value value) {
+  llvm::SmallVector<Value, 8> worklist{value};
+  llvm::DenseSet<Value> visited;
+  while (!worklist.empty()) {
+    Value current = worklist.pop_back_val();
+    if (!visited.insert(current).second)
+      continue;
+    for (OpOperand &use : current.getUses()) {
+      Operation *user = use.getOwner();
+      const std::optional<unsigned> maskOperand =
+          getMemoryMaskOperandIndex(user);
+      if (maskOperand && use.getOperandNumber() == *maskOperand)
+        continue;
+      const llvm::StringRef name = user->getName().getStringRef();
+      const bool maskForwarding =
+          name == "tt.splat" || name == "tt.broadcast" ||
+          name == "tt.expand_dims" || name == "arith.andi" ||
+          name == "arith.ori" || name == "arith.xori";
+      if (!maskForwarding)
+        return false;
+      llvm::append_range(worklist, user->getResults());
+    }
+  }
+  return true;
+}
+
+/// True when a loop argument only participates in address induction or in
+/// masking the accesses that addressing guards.  Such a value is an
+/// implementation recurrence that later pointer canonicalization can
+/// eliminate; it is not an algorithmic loop-carried dependency and must not
+/// disable the SIMD independent-loop roofline model.
 static bool isAddressOnlyLoopValue(Value root) {
   llvm::SmallVector<Value, 8> worklist{root};
   llvm::DenseSet<Value> visited;
@@ -81,6 +128,14 @@ static bool isAddressOnlyLoopValue(Value root) {
       if ((name == "tt.load" || name == "tt.store" ||
            name.starts_with("tt.atomic")) &&
           use.getOperandNumber() == 0) {
+        reachesAddressUse = true;
+        continue;
+      }
+      if (name == "arith.cmpi" || name == "arith.cmpf") {
+        // A comparison feeding only memory masks is addressing boundary
+        // logic (e.g. a per-iteration bound), not a data recurrence.
+        if (!llvm::all_of(user->getResults(), isMemoryMaskOnlyValue))
+          return false;
         reachesAddressUse = true;
         continue;
       }
@@ -281,7 +336,8 @@ static int64_t getLoopTripCount(Operation *operation,
 static void accumulateDynamicOperationTree(Operation *operation,
                                            StageWorkload &work,
                                            double multiplicity,
-                                           int64_t fallbackLoopTripCount) {
+                                           int64_t fallbackLoopTripCount,
+                                           bool splitLoopBody = false) {
   if (!operation)
     return;
   StageWorkload local;
@@ -291,6 +347,10 @@ static void accumulateDynamicOperationTree(Operation *operation,
 
   if (operation->hasAttr("ta.auto_blockify_v1.loop"))
     return;
+  // With loop-body splitting the loop shell Stage owns only control overhead;
+  // its body operations are separate roots and must not be double-counted.
+  if (splitLoopBody && isIndependentStructuredLoop(operation))
+    return;
   const double childMultiplicity =
       multiplicity *
       static_cast<double>(getLoopTripCount(operation, fallbackLoopTripCount));
@@ -298,7 +358,7 @@ static void accumulateDynamicOperationTree(Operation *operation,
     for (Block &block : region)
       for (Operation &nested : block.getOperations())
         accumulateDynamicOperationTree(&nested, work, childMultiplicity,
-                                       fallbackLoopTripCount);
+                                       fallbackLoopTripCount, splitLoopBody);
 }
 
 static int64_t countAlgorithmLoops(const LogicalStage &stage) {
@@ -338,13 +398,16 @@ static void makePerIteration(LogicalStage &stage) {
 }
 
 static Operation *getTopLevelSemanticRoot(Operation *operation);
+static Operation *getPartitionSemanticRoot(Operation *operation,
+                                           bool splitLoopBody);
 
 static bool stageOwnsAnchor(const LogicalStage &stage,
-                            const SimtAnchorDescriptor &anchor) {
+                            const SimtAnchorDescriptor &anchor,
+                            bool splitLoopBody = false) {
   if (!anchor.materializable || !stage.localSimtMaterializable)
     return false;
   auto owns = [&](Operation *operation) {
-    Operation *root = getTopLevelSemanticRoot(operation);
+    Operation *root = getPartitionSemanticRoot(operation, splitLoopBody);
     return root && llvm::is_contained(stage.operations, root);
   };
   if (anchor.scopeOperations.empty())
@@ -358,6 +421,7 @@ static bool stageOwnsAnchor(const LogicalStage &stage,
 /// second source of Stage boundaries.
 static void attachExactAnchorOwnership(StagePartition &partition,
                                        const SimtAnchorPlan &anchorPlan) {
+  const bool splitLoopBody = partition.splitIndependentLoopBody;
   for (LogicalStage &stage : partition.stages) {
     if (!stage.localSimtMaterializable)
       continue;
@@ -366,7 +430,8 @@ static void attachExactAnchorOwnership(StagePartition &partition,
     bool allAnchorsDirectlyOwnedByV1Loop = true;
     for (auto indexedAnchor : llvm::enumerate(anchorPlan.anchors)) {
       const SimtAnchorDescriptor &anchor = indexedAnchor.value();
-      if (anchor.materializable && stageOwnsAnchor(stage, anchor)) {
+      if (anchor.materializable &&
+          stageOwnsAnchor(stage, anchor, splitLoopBody)) {
         stage.simtAnchorIndices.push_back(
             static_cast<unsigned>(indexedAnchor.index()));
         Operation *insertionPoint = anchor.scopeOperations.size() > 1
@@ -405,6 +470,22 @@ static Operation *getTopLevelSemanticRoot(Operation *operation) {
     root = parent;
   }
   return nullptr;
+}
+
+static Operation *getPartitionSemanticRoot(Operation *operation,
+                                           bool splitLoopBody) {
+  Operation *topLevelRoot = getTopLevelSemanticRoot(operation);
+  if (!splitLoopBody || !topLevelRoot)
+    return topLevelRoot;
+
+  Operation *root = operation;
+  while (root != topLevelRoot) {
+    Operation *parent = root->getParentOp();
+    if (isIndependentStructuredLoop(parent))
+      return root;
+    root = parent;
+  }
+  return topLevelRoot;
 }
 
 /// Anchor-free Stages can still become local SIMT scopes: the whole root
@@ -479,6 +560,41 @@ static std::vector<Operation *> collectTopLevelSemanticRoots(ModuleOp module) {
   return result;
 }
 
+static void appendIndependentLoopBodyRoots(
+    Operation *operation, std::vector<Operation *> &roots) {
+  if (!isIndependentStructuredLoop(operation) ||
+      operation->hasAttr("ta.auto_blockify_v1.loop"))
+    return;
+
+  costModelLog() << "loop split: exposing body roots of "
+                 << operation->getName().getStringRef() << " "
+                 << operation->getLoc() << "\n";
+  for (Region &region : operation->getRegions()) {
+    for (Block &block : region) {
+      for (Operation &nested : block.getOperations()) {
+        if (nested.hasTrait<OpTrait::IsTerminator>())
+          continue;
+        roots.push_back(&nested);
+        appendIndependentLoopBodyRoots(&nested, roots);
+      }
+    }
+  }
+}
+
+static std::vector<Operation *>
+collectPartitionSemanticRoots(ModuleOp module, bool splitLoopBody) {
+  std::vector<Operation *> roots = collectTopLevelSemanticRoots(module);
+  if (!splitLoopBody)
+    return roots;
+
+  std::vector<Operation *> expandedRoots;
+  for (Operation *root : roots) {
+    expandedRoots.push_back(root);
+    appendIndependentLoopBodyRoots(root, expandedRoots);
+  }
+  return expandedRoots;
+}
+
 static bool operationTreeContainsName(Operation *root, llvm::StringRef name) {
   bool found = root && root->getName().getStringRef() == name;
   if (!root || found)
@@ -531,6 +647,53 @@ static bool operationTreeHasAnyName(Operation *root,
   return llvm::any_of(names, [&](llvm::StringRef name) {
     return operationTreeContainsName(root, name);
   });
+}
+
+/// A structured loop whose body may be exposed as independent semantic roots:
+/// it is not an AutoBlockify V1 scheduling shell and carries no true
+/// algorithmic loop-carried dependency (address-only induction is an
+/// implementation recurrence and stays legal).  Recurrence loops keep the
+/// atomic whole-loop Stage because their body cannot be re-associated.
+static bool isIndependentStructuredLoop(Operation *operation) {
+  if (!operation || operation->hasAttr("ta.auto_blockify_v1.loop"))
+    return false;
+  const llvm::StringRef name = operation->getName().getStringRef();
+  if ((name != "scf.for" && name != "scf.while") ||
+      operation->getNumRegions() == 0 || operation->getRegion(0).empty())
+    return false;
+  return !operationTreeHasTrueLoopCarriedDependency(operation);
+}
+
+/// Trip count of the independent structured loops enclosing `root` when
+/// loop-body splitting is active.  Nested split loops take the maximum
+/// enclosing trip count, mirroring semanticRootIterationCount's max-based
+/// nesting approximation; the common single-loop case is exact.
+static int64_t enclosingSplitLoopTripCount(Operation *root) {
+  int64_t trips = 1;
+  if (!root)
+    return trips;
+  for (Operation *parent = root->getParentOp(); parent;
+       parent = parent->getParentOp())
+    if (isIndependentStructuredLoop(parent))
+      trips = std::max(trips, getLoopTripCount(parent, 1));
+  return trips;
+}
+
+/// Entry multiplicity for one semantic root when accumulating a Stage's
+/// dynamic workload.  A split loop's shell Stage and body-root Stages each
+/// see one textual appearance of their roots per loop iteration, while
+/// StageWorkloadAnalysis charges them through iterationCount (inherited
+/// from the enclosing split loop).  The accumulation must therefore
+/// pre-multiply by that trip count so makePerIteration's division restores
+/// the true per-iteration workload; otherwise N_iter * C_body undercounts
+/// the Stage's dynamic work by the trip count.
+static double semanticRootEntryMultiplicity(Operation *root,
+                                            bool splitLoopBody) {
+  if (!splitLoopBody || !root)
+    return 1.0;
+  if (isIndependentStructuredLoop(root))
+    return static_cast<double>(getLoopTripCount(root, 1));
+  return static_cast<double>(enclosingSplitLoopTripCount(root));
 }
 
 /// Classify one transitive semantic ownership unit.  This function consumes
@@ -587,7 +750,8 @@ static StageScheduleKind scheduleForSemanticRoot(Operation *root,
   return StageScheduleKind::StraightLine;
 }
 
-static int64_t semanticRootIterationCount(Operation *root) {
+static int64_t semanticRootIterationCount(Operation *root,
+                                          bool splitLoopBody = false) {
   int64_t iterations = 1;
   if (!root || root->hasAttr("ta.auto_blockify_v1.loop"))
     return iterations;
@@ -595,6 +759,10 @@ static int64_t semanticRootIterationCount(Operation *root) {
     if (!operation->hasAttr("ta.auto_blockify_v1.loop"))
       iterations = std::max(iterations, getLoopTripCount(operation, 1));
   });
+  // Loop-body body roots execute once per enclosing iteration: inherit the
+  // enclosing independent loop's trip count so per-Stage cost stays exact.
+  if (splitLoopBody)
+    iterations = std::max(iterations, enclosingSplitLoopTripCount(root));
   return iterations;
 }
 
@@ -617,14 +785,17 @@ static std::string makeStageId(size_t ordinal, StageCostModelKind kind) {
 }
 
 static void collectOwnedOperationTree(Operation *root,
-                                      llvm::DenseSet<Operation *> &owned) {
+                                      llvm::DenseSet<Operation *> &owned,
+                                      bool splitLoopBody = false) {
   if (!root)
     return;
   owned.insert(root);
   // The AutoBlockify loop is intentionally split into a scheduling shell and
   // direct semantic body roots.  Treating the shell as the owner of its body
-  // would double-own every algorithm operation.
-  if (root->hasAttr("ta.auto_blockify_v1.loop"))
+  // would double-own every algorithm operation.  Independent algorithmic
+  // loops follow the same rule when loop-body splitting is active.
+  if (root->hasAttr("ta.auto_blockify_v1.loop") ||
+      (splitLoopBody && isIndependentStructuredLoop(root)))
     return;
   root->walk([&](Operation *nested) {
     if (nested != root)
@@ -673,10 +844,11 @@ static int64_t staticTensorBytes(llvm::ArrayRef<Value> values) {
 /// Values defined outside and consumed inside are live-ins; values defined
 /// inside and consumed by any operation outside are live-outs.
 static void deriveStageLiveValues(StagePartition &partition) {
+  const bool splitLoopBody = partition.splitIndependentLoopBody;
   for (LogicalStage &stage : partition.stages) {
     llvm::DenseSet<Operation *> owned;
     for (Operation *root : stage.operations)
-      collectOwnedOperationTree(root, owned);
+      collectOwnedOperationTree(root, owned, splitLoopBody);
 
     llvm::SetVector<Value> liveIns;
     llvm::SetVector<Value> liveOuts;
@@ -783,14 +955,20 @@ static void deriveLocalSimtScopeTraffic(StagePartition &partition,
 
 llvm::Expected<ProgramStructure>
 ProgramStructureAnalysis::analyze(ModuleOp module,
-                                  const SimtAnchorPlan &anchorPlan) const {
+                                  const SimtAnchorPlan &anchorPlan,
+                                  bool splitIndependentLoopBody) const {
   COSTMODEL_TRACE("ProgramStructureAnalysis::analyze");
   if (!module)
     return llvm::createStringError(
         std::errc::invalid_argument,
         "ProgramStructureAnalysis requires ModuleOp");
   ProgramStructure structure;
-  structure.rootOperations = collectTopLevelSemanticRoots(module);
+  structure.splitIndependentLoopBody = splitIndependentLoopBody;
+  structure.rootOperations =
+      collectPartitionSemanticRoots(module, splitIndependentLoopBody);
+  if (splitIndependentLoopBody)
+    costModelLog() << "loop body split: enabled (independent structured "
+                      "loops expose body roots)\n";
   costModelLog() << "semantic roots: " << structure.rootOperations.size()
                  << " (StageBoundaryAnalysis will group these into stages)\n";
   for (auto [index, root] : llvm::enumerate(structure.rootOperations))
@@ -816,13 +994,14 @@ ProgramStructureAnalysis::analyze(ModuleOp module,
 
     llvm::SmallVector<Operation *, 8> scopeRoots;
     for (Operation *operation : anchor.scopeOperations) {
-      Operation *root = getTopLevelSemanticRoot(operation);
+      Operation *root =
+          getPartitionSemanticRoot(operation, splitIndependentLoopBody);
       if (root && llvm::is_contained(structure.rootOperations, root) &&
           !llvm::is_contained(scopeRoots, root))
         scopeRoots.push_back(root);
     }
-    Operation *insertionRoot =
-        getTopLevelSemanticRoot(anchor.scopeInsertionPoint);
+    Operation *insertionRoot = getPartitionSemanticRoot(
+        anchor.scopeInsertionPoint, splitIndependentLoopBody);
     auto insertionIt = llvm::find(structure.rootOperations, insertionRoot);
     if (scopeRoots.empty() || insertionIt == structure.rootOperations.end())
       return llvm::createStringError(
@@ -946,7 +1125,8 @@ buildAnchorGroups(const ProgramStructure &structure,
       continue;
     llvm::SmallVector<size_t, 8> positions;
     auto addPosition = [&](Operation *operation) {
-      Operation *root = getTopLevelSemanticRoot(operation);
+      Operation *root =
+          getPartitionSemanticRoot(operation, structure.splitIndependentLoopBody);
       auto iterator = llvm::find(structure.rootOperations, root);
       if (iterator == structure.rootOperations.end())
         return;
@@ -1003,6 +1183,8 @@ StageBoundaryAnalysis::analyze(const ProgramStructure &structure,
     return anchorGroups.takeError();
 
   StagePartition partition;
+  partition.splitIndependentLoopBody = structure.splitIndependentLoopBody;
+  const bool splitLoopBody = structure.splitIndependentLoopBody;
   llvm::DenseSet<Operation *> owned;
   for (size_t index = 0; index < structure.rootOperations.size();) {
     Operation *root = structure.rootOperations[index];
@@ -1013,10 +1195,15 @@ StageBoundaryAnalysis::analyze(const ProgramStructure &structure,
 
     const int64_t anchorGroup = (*anchorGroups)[index];
     StageCostModelKind kind = classifySemanticRoot(root);
+    // A split loop's shell owns only control overhead; classification must
+    // not reach into the body it no longer owns (e.g. a scan inside the body
+    // must not relabel the backedge Stage as a reduction).
+    if (splitLoopBody && isIndependentStructuredLoop(root))
+      kind = StageCostModelKind::IndependentPipelinedLoop;
     StageScheduleKind schedule = scheduleForSemanticRoot(root, kind);
     LogicalStage stage;
     stage.operations.push_back(root);
-    stage.iterationCount = semanticRootIterationCount(root);
+    stage.iterationCount = semanticRootIterationCount(root, splitLoopBody);
     stage.localSimtMaterializable = anchorGroup >= 0;
     if (stage.localSimtMaterializable)
       stage.localSimtFactors = {1};
@@ -1045,8 +1232,8 @@ StageBoundaryAnalysis::analyze(const ProgramStructure &structure,
             std::errc::invalid_argument,
             "StageBoundaryAnalysis overlaps semantic root ownership");
       stage.operations.push_back(candidate);
-      stage.iterationCount =
-          std::max(stage.iterationCount, semanticRootIterationCount(candidate));
+      stage.iterationCount = std::max(
+          stage.iterationCount, semanticRootIterationCount(candidate, splitLoopBody));
       if (semanticKindPriority(candidateKind) > semanticKindPriority(kind)) {
         kind = candidateKind;
         schedule = candidateSchedule;
@@ -1088,6 +1275,7 @@ StageBoundaryAnalysis::analyze(const ProgramStructure &structure,
 }
 
 llvm::Error StageFeatureAnalysis::analyze(StagePartition &partition) const {
+  const bool splitLoopBody = partition.splitIndependentLoopBody;
   for (LogicalStage &stage : partition.stages) {
     StageModelFeatures &facts = stage.features;
     const double activeLaneRatio = facts.activeLaneRatio;
@@ -1095,7 +1283,7 @@ llvm::Error StageFeatureAnalysis::analyze(StagePartition &partition) const {
     facts.activeLaneRatio = activeLaneRatio;
     llvm::DenseSet<Operation *> owned;
     for (Operation *root : stage.operations)
-      collectOwnedOperationTree(root, owned);
+      collectOwnedOperationTree(root, owned, splitLoopBody);
     bool hasMemory = false;
     int64_t algorithmLoopCount = 0;
     if (stage.costModelKind != StageCostModelKind::AutoBlockifyDispatch &&
@@ -1277,6 +1465,7 @@ llvm::Error StageWorkloadAnalysis::analyze(StagePartition &partition) const {
     return llvm::createStringError(
         std::errc::invalid_argument,
         "StageWorkloadAnalysis requires complete operation ownership");
+  const bool splitLoopBody = partition.splitIndependentLoopBody;
   for (LogicalStage &stage : partition.stages) {
     StageWorkload work;
     work.paysKernelSetup = stage.workload.paysKernelSetup;
@@ -1285,7 +1474,9 @@ llvm::Error StageWorkloadAnalysis::analyze(StagePartition &partition) const {
         loopCount > 0 ? std::max<int64_t>(1, stage.iterationCount / loopCount)
                       : 1;
     for (Operation *root : stage.operations)
-      accumulateDynamicOperationTree(root, work, 1.0, fallbackLoopTripCount);
+      accumulateDynamicOperationTree(
+          root, work, semanticRootEntryMultiplicity(root, splitLoopBody),
+          fallbackLoopTripCount, splitLoopBody);
     recomputeIssueElements(work);
     stage.workload = std::move(work);
     makePerIteration(stage);
@@ -1486,7 +1677,8 @@ llvm::Expected<StagePartition>
 StagePartitioner::partition(ModuleOp module, const SimtAnchorPlan &anchorPlan,
                             const StagePartitionerOptions &options) const {
   COSTMODEL_TRACE("StagePartitioner::partition");
-  auto structure = ProgramStructureAnalysis().analyze(module, anchorPlan);
+  auto structure = ProgramStructureAnalysis().analyze(
+      module, anchorPlan, options.splitIndependentLoopBody);
   if (!structure)
     return structure.takeError();
   auto result =

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/CMakeLists.txt
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/CMakeLists.txt
@@ -5,6 +5,7 @@ add_compile_definitions(
 )
 
 add_mlir_library(AscendModelRouteModel
+  ../Support/CostModelLogger.cpp
   ../Analysis/SimtAnchorAnalysis.cpp
   ../Analysis/StagePartitioner.cpp
   StageCostModels.cpp
@@ -15,6 +16,7 @@ add_mlir_library(AscendModelRouteModel
 
   ADDITIONAL_HEADER_DIRS
   ${TRITON_ASCEND_COSTMODEL_SOURCE_DIR}/include/AscendModel/RouteModel
+  ${TRITON_ASCEND_COSTMODEL_SOURCE_DIR}/include/AscendModel/Support
 
   DEPENDS
   AscendModelOpsIncGen

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
@@ -513,15 +513,18 @@ loadCandidateProfile(llvm::StringRef requestedPath) {
   return profile;
 }
 
-static llvm::Expected<StageCostModelSummary> evaluateStageModel(
+/// Options shared by candidate scoring and the selector's StageOwnedScope
+/// synthesis so both see identical Stage boundaries.  The selector must
+/// partition the materialization module with exactly these options;
+/// otherwise synthesized stage scopes would not match the scored route.
+static StagePartitionerOptions buildStagePartitionerOptions(
     const SimdSimtFeatureSummary &features, const CandidateProfile &profile,
     unsigned numWarps, bool wholeKernelSuperblockMaterializable,
-    bool scopeSuperblockMaterializable, int64_t logicalProgramCountHint,
-    int64_t physicalCoreCountHint, ModuleOp module,
-    const SimtAnchorPlan *anchorPlan) {
-  COSTMODEL_TRACE_DEBUG("evaluateStageModel");
+    bool scopeSuperblockMaterializable, bool compileOn91095,
+    int64_t logicalProgramCountHint) {
   StagePartitionerOptions partitionerOptions;
   partitionerOptions.tinyDotFlopsMax = profile.structural.tinyDotFlopsMax;
+  partitionerOptions.compileOn91095 = compileOn91095;
   partitionerOptions.maximumSuperblockFactor =
       (wholeKernelSuperblockMaterializable || scopeSuperblockMaterializable ||
        features.autoBlockifyV1Applied)
@@ -541,6 +544,20 @@ static llvm::Expected<StageCostModelSummary> evaluateStageModel(
   }
   partitionerOptions.scopeSuperblockMaterializable =
       scopeSuperblockMaterializable;
+  return partitionerOptions;
+}
+
+static llvm::Expected<StageCostModelSummary> evaluateStageModel(
+    const SimdSimtFeatureSummary &features, const CandidateProfile &profile,
+    unsigned numWarps, bool wholeKernelSuperblockMaterializable,
+    bool scopeSuperblockMaterializable, bool compileOn91095,
+    int64_t logicalProgramCountHint, int64_t physicalCoreCountHint,
+    ModuleOp module, const SimtAnchorPlan *anchorPlan) {
+  COSTMODEL_TRACE_DEBUG("evaluateStageModel");
+  StagePartitionerOptions partitionerOptions = buildStagePartitionerOptions(
+      features, profile, numWarps, wholeKernelSuperblockMaterializable,
+      scopeSuperblockMaterializable, compileOn91095,
+      logicalProgramCountHint);
   StagePartitioner partitioner;
   if (!module || !anchorPlan)
     return llvm::createStringError(std::errc::invalid_argument,
@@ -782,9 +799,12 @@ estimateSimdSimtCandidatesImpl(const SimdSimtFeatureSummary &features,
   report.allSimtOnlyCandidateLegal =
       options.compileOn91095 && !features.hasExplicitScope &&
       features.simtAnchors.kernelLowerability.allSimtOnly;
+  // Anchor count is deliberately not required here: an anchor-free kernel
+  // may still select Mixed through StageOwnedScope units synthesized by the
+  // StagePartitioner.  Stage-level materializability is decided by the
+  // stage model's mixed legality below.
   report.mixedCandidateLegal = !features.hasExplicitScope &&
                                options.compileOn91095 &&
-                               features.simtAnchors.count > 0 &&
                                features.simtAnchors.kernelLowerability.mixed;
   report.includeFeaturesInJSON = options.includeFeaturesInJSON;
 
@@ -793,8 +813,9 @@ estimateSimdSimtCandidatesImpl(const SimdSimtFeatureSummary &features,
   auto stageModel = evaluateStageModel(
       features, profile, static_cast<unsigned>(numWarps),
       options.wholeKernelSuperblockMaterializable,
-      options.scopeSuperblockMaterializable, options.logicalProgramCountHint,
-      options.physicalVectorCoreCountHint, module, anchorPlan);
+      options.scopeSuperblockMaterializable, options.compileOn91095,
+      options.logicalProgramCountHint, options.physicalVectorCoreCountHint,
+      module, anchorPlan);
   if (!stageModel)
     return stageModel.takeError();
   report.stageModel = std::move(*stageModel);
@@ -844,4 +865,27 @@ llvm::Expected<SimdSimtCostReport> mlir::ascend::analyzeSimdSimtCandidates(
     return features.takeError();
   return estimateSimdSimtCandidatesImpl(*features, options, module,
                                         &anchorPlan);
+}
+
+llvm::Expected<StagePartition> mlir::ascend::partitionForSimdSimtSelection(
+    ModuleOp module, const SimtAnchorPlan &anchorPlan,
+    const SimdSimtCostModelOptions &options) {
+  COSTMODEL_TRACE("partitionForSimdSimtSelection");
+  if (!module)
+    return llvm::createStringError(std::errc::invalid_argument,
+                                   "cannot partition a null ModuleOp");
+  auto profileOrError = loadCandidateProfile(options.profilePath);
+  if (!profileOrError)
+    return profileOrError.takeError();
+  CandidateProfile profile = std::move(*profileOrError);
+  auto features = analyzeSimdSimtFeatures(module, anchorPlan);
+  if (!features)
+    return features.takeError();
+  StagePartitionerOptions partitionerOptions = buildStagePartitionerOptions(
+      *features, profile, options.numWarps,
+      options.wholeKernelSuperblockMaterializable,
+      options.scopeSuperblockMaterializable, options.compileOn91095,
+      options.logicalProgramCountHint);
+  return StagePartitioner().partition(module, anchorPlan,
+                                      partitionerOptions);
 }

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
@@ -11,6 +11,7 @@
 #include "AscendModel/Analysis/StagePartitioner.h"
 #include "AscendModel/Profile/MicrobenchmarkProfile.h"
 #include "AscendModel/RouteModel/StageCostModels.h"
+#include "AscendModel/Support/CostModelLogger.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -518,6 +519,7 @@ static llvm::Expected<StageCostModelSummary> evaluateStageModel(
     bool scopeSuperblockMaterializable, int64_t logicalProgramCountHint,
     int64_t physicalCoreCountHint, ModuleOp module,
     const SimtAnchorPlan *anchorPlan) {
+  COSTMODEL_TRACE_DEBUG("evaluateStageModel");
   StagePartitionerOptions partitionerOptions;
   partitionerOptions.tinyDotFlopsMax = profile.structural.tinyDotFlopsMax;
   partitionerOptions.maximumSuperblockFactor =
@@ -717,6 +719,7 @@ mlir::ascend::analyzeSimdSimtFeatures(ModuleOp module, bool compileOn91095) {
 llvm::Expected<SimdSimtFeatureSummary>
 mlir::ascend::analyzeSimdSimtFeatures(ModuleOp module,
                                       const SimtAnchorPlan &anchorPlan) {
+  COSTMODEL_TRACE("analyzeSimdSimtFeatures");
   if (!module)
     return llvm::createStringError(std::errc::invalid_argument,
                                    "cannot analyze a null ModuleOp");
@@ -726,6 +729,13 @@ mlir::ascend::analyzeSimdSimtFeatures(ModuleOp module,
       anchorPlan.anchors,
       [](const SimtAnchorDescriptor &anchor) { return anchor.materializable; });
   features.simtAnchors.kernelLowerability = anchorPlan.kernelLowerability;
+  costModelLog() << "features: materializable anchors="
+                 << features.simtAnchors.count
+                 << " (lowerability: all_simd="
+                 << anchorPlan.kernelLowerability.allSimd
+                 << " all_simt_only="
+                 << anchorPlan.kernelLowerability.allSimtOnly
+                 << " mixed=" << anchorPlan.kernelLowerability.mixed << ")\n";
 
   for (const SimtAnchorDescriptor &anchor : anchorPlan.anchors) {
     if (anchor.triangularSolve)
@@ -747,10 +757,13 @@ estimateSimdSimtCandidatesImpl(const SimdSimtFeatureSummary &features,
                                const SimdSimtCostModelOptions &options,
                                ModuleOp module,
                                const SimtAnchorPlan *anchorPlan) {
+  COSTMODEL_TRACE("estimateSimdSimtCandidates");
   auto profileOrError = loadCandidateProfile(options.profilePath);
   if (!profileOrError)
     return profileOrError.takeError();
   CandidateProfile profile = std::move(*profileOrError);
+  costModelLog() << "profile: version=" << profile.hardware.profileVersion
+                 << " target=" << profile.hardware.target << "\n";
 
   SimdSimtCostReport report;
   report.profileVersion = profile.hardware.profileVersion;
@@ -785,6 +798,14 @@ estimateSimdSimtCandidatesImpl(const SimdSimtFeatureSummary &features,
   if (!stageModel)
     return stageModel.takeError();
   report.stageModel = std::move(*stageModel);
+  costModelLog() << "stage model: stages=" << report.stageModel.stages.size()
+                 << " (legal: all_simd=" << report.stageModel.allSimd.legal
+                 << " all_simt_only=" << report.stageModel.allSimt.legal
+                 << " mixed=" << report.stageModel.mixed.legal
+                 << "; totals: all_simd="
+                 << report.stageModel.allSimd.totalCycles
+                 << " all_simt_only=" << report.stageModel.allSimt.totalCycles
+                 << " mixed=" << report.stageModel.mixed.totalCycles << ")\n";
   report.candidateCosts.allSimd = report.stageModel.allSimd.totalCycles;
   report.candidateCosts.allSimtOnly = report.stageModel.allSimt.totalCycles;
   report.candidateCosts.mixedSimdSimt = report.stageModel.mixed.totalCycles;

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AscendModel/RouteModel/SimdSimtCostModel.h"
+#include "AscendModel/Support/CostModelError.h"
 #include "AscendModel/Analysis/SimtAnchorAnalysis.h"
 #include "AscendModel/Analysis/StagePartitioner.h"
 #include "AscendModel/Profile/MicrobenchmarkProfile.h"
@@ -840,8 +841,7 @@ estimateSimdSimtCandidatesImpl(const SimdSimtFeatureSummary &features,
       static_cast<unsigned>(report.allSimtOnlyCandidateLegal) +
       static_cast<unsigned>(report.mixedCandidateLegal);
   if (legalCandidateCount == 0)
-    return llvm::createStringError(
-        std::errc::not_supported,
+    return llvm::make_error<UnsupportedCostModelIR>(
         "Stage Route Model found no materializable candidate");
   report.decision =
       chooseBest(report.candidateCosts, report.allSimdCandidateLegal,
@@ -854,8 +854,9 @@ llvm::Expected<SimdSimtCostReport> mlir::ascend::analyzeSimdSimtCandidates(
   if (!module)
     return llvm::createStringError(std::errc::invalid_argument,
                                    "cannot analyze a null ModuleOp");
-  SimtAnchorPlan anchorPlan =
-      buildMixedSimtAnchorPlan(module, options.compileOn91095);
+  SimtAnchorPlan anchorPlan = buildMixedSimtAnchorPlan(
+      module, querySimtLoweringCapabilities(options.actualTarget,
+                                            options.compileOn91095));
   return analyzeSimdSimtCandidates(module, anchorPlan, options);
 }
 

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
@@ -521,10 +521,11 @@ static StagePartitionerOptions buildStagePartitionerOptions(
     const SimdSimtFeatureSummary &features, const CandidateProfile &profile,
     unsigned numWarps, bool wholeKernelSuperblockMaterializable,
     bool scopeSuperblockMaterializable, bool compileOn91095,
-    int64_t logicalProgramCountHint) {
+    int64_t logicalProgramCountHint, bool splitIndependentLoopBody) {
   StagePartitionerOptions partitionerOptions;
   partitionerOptions.tinyDotFlopsMax = profile.structural.tinyDotFlopsMax;
   partitionerOptions.compileOn91095 = compileOn91095;
+  partitionerOptions.splitIndependentLoopBody = splitIndependentLoopBody;
   partitionerOptions.maximumSuperblockFactor =
       (wholeKernelSuperblockMaterializable || scopeSuperblockMaterializable ||
        features.autoBlockifyV1Applied)
@@ -552,12 +553,13 @@ static llvm::Expected<StageCostModelSummary> evaluateStageModel(
     unsigned numWarps, bool wholeKernelSuperblockMaterializable,
     bool scopeSuperblockMaterializable, bool compileOn91095,
     int64_t logicalProgramCountHint, int64_t physicalCoreCountHint,
-    ModuleOp module, const SimtAnchorPlan *anchorPlan) {
+    bool splitIndependentLoopBody, ModuleOp module,
+    const SimtAnchorPlan *anchorPlan) {
   COSTMODEL_TRACE_DEBUG("evaluateStageModel");
   StagePartitionerOptions partitionerOptions = buildStagePartitionerOptions(
       features, profile, numWarps, wholeKernelSuperblockMaterializable,
       scopeSuperblockMaterializable, compileOn91095,
-      logicalProgramCountHint);
+      logicalProgramCountHint, splitIndependentLoopBody);
   StagePartitioner partitioner;
   if (!module || !anchorPlan)
     return llvm::createStringError(std::errc::invalid_argument,
@@ -815,7 +817,7 @@ estimateSimdSimtCandidatesImpl(const SimdSimtFeatureSummary &features,
       options.wholeKernelSuperblockMaterializable,
       options.scopeSuperblockMaterializable, options.compileOn91095,
       options.logicalProgramCountHint, options.physicalVectorCoreCountHint,
-      module, anchorPlan);
+      options.splitIndependentLoopBody, module, anchorPlan);
   if (!stageModel)
     return stageModel.takeError();
   report.stageModel = std::move(*stageModel);
@@ -885,7 +887,7 @@ llvm::Expected<StagePartition> mlir::ascend::partitionForSimdSimtSelection(
       *features, profile, options.numWarps,
       options.wholeKernelSuperblockMaterializable,
       options.scopeSuperblockMaterializable, options.compileOn91095,
-      options.logicalProgramCountHint);
+      options.logicalProgramCountHint, options.splitIndependentLoopBody);
   return StagePartitioner().partition(module, anchorPlan,
                                       partitionerOptions);
 }

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
@@ -7,11 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "AscendModel/RouteModel/SimdSimtCostModel.h"
-#include "AscendModel/Support/CostModelError.h"
 #include "AscendModel/Analysis/SimtAnchorAnalysis.h"
 #include "AscendModel/Analysis/StagePartitioner.h"
 #include "AscendModel/Profile/MicrobenchmarkProfile.h"
 #include "AscendModel/RouteModel/StageCostModels.h"
+#include "AscendModel/Support/CostModelError.h"
 #include "AscendModel/Support/CostModelLogger.h"
 
 #include "mlir/IR/BuiltinAttributes.h"
@@ -549,18 +549,19 @@ static StagePartitionerOptions buildStagePartitionerOptions(
   return partitionerOptions;
 }
 
-static llvm::Expected<StageCostModelSummary> evaluateStageModel(
-    const SimdSimtFeatureSummary &features, const CandidateProfile &profile,
-    unsigned numWarps, bool wholeKernelSuperblockMaterializable,
-    bool scopeSuperblockMaterializable, bool compileOn91095,
-    int64_t logicalProgramCountHint, int64_t physicalCoreCountHint,
-    bool splitIndependentLoopBody, ModuleOp module,
-    const SimtAnchorPlan *anchorPlan) {
+static llvm::Expected<StageCostModelSummary>
+evaluateStageModel(const SimdSimtFeatureSummary &features,
+                   const CandidateProfile &profile, unsigned numWarps,
+                   bool wholeKernelSuperblockMaterializable,
+                   bool scopeSuperblockMaterializable, bool compileOn91095,
+                   int64_t logicalProgramCountHint,
+                   int64_t physicalCoreCountHint, bool splitIndependentLoopBody,
+                   ModuleOp module, const SimtAnchorPlan *anchorPlan) {
   COSTMODEL_TRACE_DEBUG("evaluateStageModel");
   StagePartitionerOptions partitionerOptions = buildStagePartitionerOptions(
       features, profile, numWarps, wholeKernelSuperblockMaterializable,
-      scopeSuperblockMaterializable, compileOn91095,
-      logicalProgramCountHint, splitIndependentLoopBody);
+      scopeSuperblockMaterializable, compileOn91095, logicalProgramCountHint,
+      splitIndependentLoopBody);
   StagePartitioner partitioner;
   if (!module || !anchorPlan)
     return llvm::createStringError(std::errc::invalid_argument,
@@ -750,10 +751,8 @@ mlir::ascend::analyzeSimdSimtFeatures(ModuleOp module,
       [](const SimtAnchorDescriptor &anchor) { return anchor.materializable; });
   features.simtAnchors.kernelLowerability = anchorPlan.kernelLowerability;
   costModelLog() << "features: materializable anchors="
-                 << features.simtAnchors.count
-                 << " (lowerability: all_simd="
-                 << anchorPlan.kernelLowerability.allSimd
-                 << " all_simt_only="
+                 << features.simtAnchors.count << " (lowerability: all_simd="
+                 << anchorPlan.kernelLowerability.allSimd << " all_simt_only="
                  << anchorPlan.kernelLowerability.allSimtOnly
                  << " mixed=" << anchorPlan.kernelLowerability.mixed << ")\n";
 
@@ -889,6 +888,5 @@ llvm::Expected<StagePartition> mlir::ascend::partitionForSimdSimtSelection(
       options.wholeKernelSuperblockMaterializable,
       options.scopeSuperblockMaterializable, options.compileOn91095,
       options.logicalProgramCountHint, options.splitIndependentLoopBody);
-  return StagePartitioner().partition(module, anchorPlan,
-                                      partitionerOptions);
+  return StagePartitioner().partition(module, anchorPlan, partitionerOptions);
 }

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageCostModels.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageCostModels.cpp
@@ -1,6 +1,7 @@
 //===- StageCostModels.cpp - Per-stage analytical models -----------------===//
 
 #include "AscendModel/RouteModel/StageCostModels.h"
+#include "AscendModel/Support/CostModelLogger.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSet.h"
@@ -145,7 +146,8 @@ static double applySuperBlock(const LogicalStage &stage,
                               const StageResourceCycles &resources,
                               const StageImplementation &implementation,
                               const HardwareProfile &profile,
-                              double stageCycles) {
+                              double stageCycles,
+                              std::string *formula = nullptr) {
   if (implementation.mode != StageMode::SIMT ||
       implementation.superblockFactor == 1)
     return stageCycles;
@@ -190,6 +192,10 @@ static double applySuperBlock(const LogicalStage &stage,
   // both materializers batch complete logical programs around the Stage.
   if (stage.costModelKind == StageCostModelKind::LoopCarriedRecurrence) {
     const double recurrenceBody = std::max(0.0, stageCycles - fixed);
+    if (formula)
+      *formula = "superblock: max(setup + F*N_iter*issue, "
+                 "setup + recurrenceBody + spillPressure) + "
+                 "persistentStatePressure";
     return std::max(issueFloor, fixed + recurrenceBody + pressure) +
            persistentStatePressure;
   }
@@ -198,21 +204,32 @@ static double applySuperBlock(const LogicalStage &stage,
   const double body = std::max(0.0, stageCycles - fixed);
   const double groupedBody = factor * std::max(0.0, body - latencySensitive) +
                              factor * latencySensitive / effectiveFactor;
+  if (formula)
+    *formula = "superblock: max(setup + F*N_iter*issue, setup + F*(body - "
+               "latencySensitive) + F*latencySensitive/F_eff + spillPressure) "
+               "+ persistentStatePressure";
   return std::max(issueFloor, fixed + groupedBody + pressure) +
          persistentStatePressure;
 }
 
 static double estimateStage(const LogicalStage &stage,
                             const HardwareProfile &profile, StageMode mode,
-                            const StageResourceCycles &r) {
+                            const StageResourceCycles &r,
+                            std::string *formula = nullptr) {
   const double count = iterations(stage);
   const double serial = r.setup + count * serialBody(r);
+  if (formula)
+    *formula = "total = setup + N_iter * max(execution, issue), execution = "
+               "scalar + load + store + compute + predicate + shuffle + dot + "
+               "control + spill";
   switch (stage.costModelKind) {
   case StageCostModelKind::AutoBlockifyDispatch:
   case StageCostModelKind::AutoBlockifyLoop: {
     const double dispatchCount =
         stage.costModelKind == StageCostModelKind::AutoBlockifyLoop ? count
                                                                     : 1.0;
+    if (formula)
+      *formula = "total = setup + D * max(scalar + control, issue)";
     return r.setup +
            dispatchCount * std::max(r.scalar + controlBody(r), r.issue);
   }
@@ -220,17 +237,25 @@ static double estimateStage(const LogicalStage &stage,
   case StageCostModelKind::ContinuousTileStore:
   case StageCostModelKind::ContinuousShortLoad:
   case StageCostModelKind::CachePolicyStore:
-    if (mode == StageMode::SIMD && permitsSimdOverlap(stage))
+    if (mode == StageMode::SIMD && permitsSimdOverlap(stage)) {
+      if (formula)
+        *formula = "total = setup + N_iter * (scalar + predicate + control + "
+                   "spill + max(load, store, issue))";
       return r.setup + count * (r.scalar + r.predicate + controlBody(r) +
                                 r.spill + std::max({r.load, r.store, r.issue}));
+    }
     return serial;
   case StageCostModelKind::IndependentPipelinedLoop:
-    if (mode == StageMode::SIMD && permitsSimdOverlap(stage))
+    if (mode == StageMode::SIMD && permitsSimdOverlap(stage)) {
+      if (formula)
+        *formula = "total = setup + N_iter * (max(load, store, compute + dot + "
+                   "shuffle, scalar + predicate + control, issue) + spill)";
       return r.setup +
              count *
                  (std::max({r.load, r.store, r.compute + r.dot + r.shuffle,
                             r.scalar + r.predicate + controlBody(r), r.issue}) +
                   r.spill);
+    }
     return serial;
   case StageCostModelKind::LoopCarriedRecurrence: {
     const double critical = r.criticalPath > 0.0
@@ -248,16 +273,26 @@ static double estimateStage(const LogicalStage &stage,
       const double persistentState =
           static_cast<double>(stage.liveOutBytes) /
           profile.superblockPersistentStateBytesPerCycle;
+      if (formula)
+        *formula = "total = setup + N_iter * max(criticalPath + load + store "
+                   "+ control + spill, issue) + liveOutBytes / "
+                   "persistentStateBytesPerCycle";
       return r.setup + count * critical + persistentState;
     }
     const int64_t groups = std::max<int64_t>(
         1, std::min(stage.features.parallelRecurrenceGroupCount,
                     profile.logicalWarpGroupCount));
+    if (formula)
+      *formula = "total = setup + max(ceil(N_iter / warpGroups) * critical, "
+                 "N_iter * issue)";
     return r.setup +
            std::max(std::ceil(count / static_cast<double>(groups)) * critical,
                     count * r.issue);
   }
   case StageCostModelKind::RowwiseReduction:
+    if (formula)
+      *formula = "total = setup + N_iter * max(scalar + load + store + "
+                 "criticalPath + control + spill, issue)";
     return r.setup +
            count * std::max(r.scalar + r.load + r.store + r.criticalPath +
                                 controlBody(r) + r.spill,
@@ -268,6 +303,10 @@ static double estimateStage(const LogicalStage &stage,
         r.shuffle * (mode == StageMode::SIMD
                          ? profile.simd.prefixScanDependencyFactor
                          : profile.simt.prefixScanDependencyFactor);
+    if (formula)
+      *formula = "total = setup + N_iter * max(scalar + load + store + compute "
+                 "+ predicate + shuffle * scanDependencyFactor + control + "
+                 "spill, issue)";
     return r.setup +
            count * std::max(r.scalar + r.load + r.store + scanCritical +
                                 controlBody(r) + r.spill,
@@ -275,17 +314,25 @@ static double estimateStage(const LogicalStage &stage,
   }
   case StageCostModelKind::CubeRoofline:
   case StageCostModelKind::TinyCubeRoofline:
-    if (mode == StageMode::SIMD && permitsSimdOverlap(stage))
+    if (mode == StageMode::SIMD && permitsSimdOverlap(stage)) {
+      if (formula)
+        *formula = "total = setup + N_iter * (scalar + predicate + control + "
+                   "shuffle + spill + max(load, compute + dot, store, issue))";
       return r.setup +
              count * (r.scalar + r.predicate + controlBody(r) + r.shuffle +
                       r.spill +
                       std::max({r.load, r.compute + r.dot, r.store, r.issue}));
+    }
     return serial;
   case StageCostModelKind::ConversionPack:
-    if (mode == StageMode::SIMD && permitsSimdOverlap(stage))
+    if (mode == StageMode::SIMD && permitsSimdOverlap(stage)) {
+      if (formula)
+        *formula = "total = setup + N_iter * (predicate + control + spill + "
+                   "max(scalar + compute, load, store, issue))";
       return r.setup + count * (r.predicate + controlBody(r) + r.spill +
                                 std::max({r.scalar + r.compute, r.load, r.store,
                                           r.issue}));
+    }
     return serial;
   default:
     return serial;
@@ -306,6 +353,35 @@ static bool isDeclaredLegal(const LogicalStage &stage,
                               implementation.superblockFactor);
   return llvm::is_contained(stage.legalSimtFactors,
                             implementation.superblockFactor);
+}
+
+/// One log block per (Stage, implementation) candidate: mode, factor, the
+/// mapped resource cycles, and the symbolic cost formula that produced the
+/// total.
+static void logImplementationCost(const LogicalStage &stage,
+                                  const StageImplementation &implementation,
+                                  const StageResourceCycles &r,
+                                  double totalCycles,
+                                  const std::string &formula,
+                                  const std::string &superblockFormula) {
+  llvm::raw_ostream &os = costModelLog();
+  os << "cost stage '" << stage.id << "' ["
+     << stringifyStageCostModel(stage.costModelKind) << "] "
+     << (implementation.mode == StageMode::SIMD ? "SIMD" : "SIMT")
+     << " factor=" << implementation.superblockFactor
+     << (implementation.localScope ? " local_scope" : "")
+     << ": total=" << totalCycles << " cycles\n";
+  os << "  resources: setup=" << r.setup << " scalar=" << r.scalar
+     << " load=" << r.load << " store=" << r.store << " compute=" << r.compute
+     << " predicate=" << r.predicate << " shuffle=" << r.shuffle
+     << " dot=" << r.dot << " loopCtl=" << r.loopControl
+     << " branchCtl=" << r.branchControl << " divergence=" << r.divergence
+     << " sync=" << r.synchronization << " spill=" << r.spill
+     << " issue=" << r.issue << " criticalPath=" << r.criticalPath << "\n";
+  os << "  formula: " << formula;
+  if (!superblockFormula.empty())
+    os << " | " << superblockFormula;
+  os << "\n";
 }
 
 } // namespace
@@ -429,6 +505,25 @@ StageCostEvaluator::evaluate(const StagePartition &partition,
   table.modeledOperationCount = partition.modeledOperationCount;
   table.profileVersion = profile.profileVersion;
   llvm::StringSet<> stageIds;
+  const bool trace = logEnabled();
+  if (trace) {
+    const StageModeProfile &simd = profile.simd;
+    const StageModeProfile &simt = profile.simt;
+    costModelLog() << "profile rates: SIMD(vectorWidth=" << simd.vectorWidth
+                   << " issueWidth=" << simd.issueWidth
+                   << " loadBytesPerCycle=" << simd.loadBytesPerCycle
+                   << " storeBytesPerCycle=" << simd.storeBytesPerCycle
+                   << " scalarOpsPerCycle=" << simd.scalarOperationsPerCycle
+                   << " issueOpsPerCycle=" << simd.issueOperationsPerCycle
+                   << ")\n";
+    costModelLog() << "profile rates: SIMT(loadWarpsPerCycle="
+                   << simt.loadWarpInstructionsPerCycle
+                   << " storeWarpsPerCycle="
+                   << simt.storeWarpInstructionsPerCycle
+                   << " scalarOpsPerCycle=" << simt.scalarOperationsPerCycle
+                   << " issueOpsPerCycle=" << simt.issueOperationsPerCycle
+                   << " warpGroups=" << profile.logicalWarpGroupCount << ")\n";
+  }
 
   for (const LogicalStage &stage : partition.stages) {
     if (stage.id.empty() || !stageIds.insert(stage.id).second)
@@ -492,16 +587,24 @@ StageCostEvaluator::evaluate(const StagePartition &partition,
           stage,
           implementation.mode == StageMode::SIMD ? profile.simd : profile.simt,
           implementation.mode);
+      std::string formula;
+      std::string superblockFormula;
+      const double baseCycles =
+          estimateStage(stage, profile, implementation.mode, resources,
+                        trace ? &formula : nullptr);
       StageImplementationCost cost;
       cost.implementation = implementation;
       cost.resources = resources;
-      cost.totalCycles = applySuperBlock(
-          stage, resources, implementation, profile,
-          estimateStage(stage, profile, implementation.mode, resources));
+      cost.totalCycles =
+          applySuperBlock(stage, resources, implementation, profile,
+                          baseCycles, trace ? &superblockFormula : nullptr);
       if (!cost.isValid())
         return llvm::createStringError(std::errc::invalid_argument,
                                        "Stage '%s' produced an invalid cost",
                                        stage.id.c_str());
+      if (trace)
+        logImplementationCost(stage, implementation, resources,
+                              cost.totalCycles, formula, superblockFormula);
       logicalCost.implementations.push_back(std::move(cost));
     }
 

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageCostModels.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageCostModels.cpp
@@ -137,9 +137,62 @@ static StageResourceCycles mapWorkload(const LogicalStage &stage,
                              resources.predicate + resources.shuffle +
                              resources.dot;
   else if (stage.features.hasReduction)
+    // A reduction whose accumulation is a tt.dot (hybrid dot+reduction
+    // Stage) must charge the dot on the accumulation chain; pure
+    // reductions keep dot == 0 and are unaffected.
     resources.criticalPath =
-        resources.compute + resources.predicate + resources.shuffle;
+        resources.compute + resources.predicate + resources.shuffle +
+        resources.dot;
   return materializeControlFlow(stage, mode, resources, profile.controlFlow);
+}
+
+static StageWorkload subtractWorkload(const StageWorkload &total,
+                                      const StageWorkload &local) {
+  StageWorkload residual = total;
+  auto subtract = [](double lhs, double rhs) {
+    return std::max(0.0, lhs - rhs);
+  };
+  residual.scalarOperations =
+      subtract(total.scalarOperations, local.scalarOperations);
+  residual.loadBytes = subtract(total.loadBytes, local.loadBytes);
+  residual.storeBytes = subtract(total.storeBytes, local.storeBytes);
+  residual.loadWarpInstructions =
+      subtract(total.loadWarpInstructions, local.loadWarpInstructions);
+  residual.storeWarpInstructions =
+      subtract(total.storeWarpInstructions, local.storeWarpInstructions);
+  residual.predicateElements =
+      subtract(total.predicateElements, local.predicateElements);
+  residual.shuffleLaneSteps =
+      subtract(total.shuffleLaneSteps, local.shuffleLaneSteps);
+  residual.dotFlops = subtract(total.dotFlops, local.dotFlops);
+  residual.issueElements = subtract(total.issueElements, local.issueElements);
+  residual.estimatedSpillTransactions = subtract(
+      total.estimatedSpillTransactions, local.estimatedSpillTransactions);
+  for (const auto &[name, elements] : local.operationElements) {
+    auto it = residual.operationElements.find(name);
+    if (it != residual.operationElements.end())
+      it->second = subtract(it->second, elements);
+  }
+  return residual;
+}
+
+static void addResources(StageResourceCycles &into,
+                         const StageResourceCycles &from) {
+  into.setup += from.setup;
+  into.scalar += from.scalar;
+  into.load += from.load;
+  into.store += from.store;
+  into.compute += from.compute;
+  into.predicate += from.predicate;
+  into.shuffle += from.shuffle;
+  into.dot += from.dot;
+  into.loopControl += from.loopControl;
+  into.branchControl += from.branchControl;
+  into.divergence += from.divergence;
+  into.synchronization += from.synchronization;
+  into.spill += from.spill;
+  into.issue += from.issue;
+  into.criticalPath += from.criticalPath;
 }
 
 static double applySuperBlock(const LogicalStage &stage,
@@ -551,6 +604,7 @@ StageCostEvaluator::evaluate(const StagePartition &partition,
     logicalCost.iterationCount = stage.iterationCount;
     logicalCost.features = stage.features;
     logicalCost.workload = stage.workload;
+    logicalCost.localSimtWorkload = stage.localSimtWorkload;
     logicalCost.ownedOperationCount =
         static_cast<int64_t>(stage.operations.size());
     logicalCost.sourceLocations = collectSourceLocations(stage);
@@ -583,15 +637,53 @@ StageCostEvaluator::evaluate(const StagePartition &partition,
         return llvm::createStringError(std::errc::invalid_argument,
                                        "Stage '%s' has an illegal candidate",
                                        stage.id.c_str());
-      StageResourceCycles resources = mapWorkload(
-          stage,
-          implementation.mode == StageMode::SIMD ? profile.simd : profile.simt,
-          implementation.mode);
       std::string formula;
       std::string superblockFormula;
-      const double baseCycles =
-          estimateStage(stage, profile, implementation.mode, resources,
-                        trace ? &formula : nullptr);
+      StageResourceCycles resources;
+      double baseCycles = 0.0;
+      if (implementation.localScope &&
+          stage.localSimtWorkload.issueElements > 0.0) {
+        LogicalStage residualStage = stage;
+        residualStage.workload =
+            subtractWorkload(stage.workload, stage.localSimtWorkload);
+        StageResourceCycles residual =
+            mapWorkload(residualStage, profile.simd, StageMode::SIMD);
+        std::string residualFormula;
+        const double residualCycles =
+            estimateStage(residualStage, profile, StageMode::SIMD, residual,
+                          trace ? &residualFormula : nullptr);
+
+        LogicalStage localStage = stage;
+        localStage.costModelKind = stage.features.hasPrefixScan
+                                       ? StageCostModelKind::PrefixScan
+                                       : stage.costModelKind;
+        localStage.scheduleKind = StageScheduleKind::StraightLine;
+        localStage.workload = stage.localSimtWorkload;
+        localStage.workload.paysKernelSetup = false;
+        localStage.features = StageModelFeatures{};
+        localStage.features.hasPrefixScan = stage.features.hasPrefixScan;
+        localStage.features.hasReduction = !stage.features.hasPrefixScan &&
+                                           stage.features.hasReduction;
+        StageResourceCycles local =
+            mapWorkload(localStage, profile.simt, StageMode::SIMT);
+        std::string localFormula;
+        const double localCycles =
+            estimateStage(localStage, profile, StageMode::SIMT, local,
+                          trace ? &localFormula : nullptr);
+        resources = residual;
+        addResources(resources, local);
+        baseCycles = residualCycles + localCycles;
+        if (trace)
+          formula = "hybrid_local_scope = residual SIMD (" + residualFormula +
+                    ") + anchored SIMT (" + localFormula + ")";
+      } else {
+        resources = mapWorkload(
+            stage, implementation.mode == StageMode::SIMD ? profile.simd
+                                                           : profile.simt,
+            implementation.mode);
+        baseCycles = estimateStage(stage, profile, implementation.mode,
+                                   resources, trace ? &formula : nullptr);
+      }
       StageImplementationCost cost;
       cost.implementation = implementation;
       cost.resources = resources;

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageCostModels.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageCostModels.cpp
@@ -140,9 +140,8 @@ static StageResourceCycles mapWorkload(const LogicalStage &stage,
     // A reduction whose accumulation is a tt.dot (hybrid dot+reduction
     // Stage) must charge the dot on the accumulation chain; pure
     // reductions keep dot == 0 and are unaffected.
-    resources.criticalPath =
-        resources.compute + resources.predicate + resources.shuffle +
-        resources.dot;
+    resources.criticalPath = resources.compute + resources.predicate +
+                             resources.shuffle + resources.dot;
   return materializeControlFlow(stage, mode, resources, profile.controlFlow);
 }
 
@@ -662,8 +661,8 @@ StageCostEvaluator::evaluate(const StagePartition &partition,
         localStage.workload.paysKernelSetup = false;
         localStage.features = StageModelFeatures{};
         localStage.features.hasPrefixScan = stage.features.hasPrefixScan;
-        localStage.features.hasReduction = !stage.features.hasPrefixScan &&
-                                           stage.features.hasReduction;
+        localStage.features.hasReduction =
+            !stage.features.hasPrefixScan && stage.features.hasReduction;
         StageResourceCycles local =
             mapWorkload(localStage, profile.simt, StageMode::SIMT);
         std::string localFormula;
@@ -677,10 +676,11 @@ StageCostEvaluator::evaluate(const StagePartition &partition,
           formula = "hybrid_local_scope = residual SIMD (" + residualFormula +
                     ") + anchored SIMT (" + localFormula + ")";
       } else {
-        resources = mapWorkload(
-            stage, implementation.mode == StageMode::SIMD ? profile.simd
-                                                           : profile.simt,
-            implementation.mode);
+        resources =
+            mapWorkload(stage,
+                        implementation.mode == StageMode::SIMD ? profile.simd
+                                                               : profile.simt,
+                        implementation.mode);
         baseCycles = estimateStage(stage, profile, implementation.mode,
                                    resources, trace ? &formula : nullptr);
       }
@@ -688,8 +688,8 @@ StageCostEvaluator::evaluate(const StagePartition &partition,
       cost.implementation = implementation;
       cost.resources = resources;
       cost.totalCycles =
-          applySuperBlock(stage, resources, implementation, profile,
-                          baseCycles, trace ? &superblockFormula : nullptr);
+          applySuperBlock(stage, resources, implementation, profile, baseCycles,
+                          trace ? &superblockFormula : nullptr);
       if (!cost.isValid())
         return llvm::createStringError(std::errc::invalid_argument,
                                        "Stage '%s' produced an invalid cost",

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageRouteCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageRouteCostModel.cpp
@@ -1,6 +1,7 @@
 //===- StageRouteCostModel.cpp - Logical-stage route solver ---------------===//
 
 #include "AscendModel/RouteModel/StageRouteCostModel.h"
+#include "AscendModel/Support/CostModelLogger.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -94,6 +95,29 @@ static void removeAutoBlockifyCostFromAllSIMD(StageRoutePlan &plan,
     plan.entryTransitionCycles[index] = 0.0;
   }
   plan.totalCycles = std::max(0.0, plan.totalCycles);
+}
+
+/// One log block per candidate route: legality, factor, per-Stage mode and
+/// cycles, and the summed total.
+static void logRoutePlan(llvm::StringRef name, const StageRoutePlan &plan,
+                         const StageCostTable &costTable) {
+  costModelLog() << "route " << name << ": legal=" << plan.legal
+                 << " factor=" << plan.routeSuperblockFactor
+                 << " total=" << plan.totalCycles << " cycles";
+  if (plan.runtimePhysicalProgramCount > 0)
+    costModelLog() << " (physicalPrograms=" << plan.runtimePhysicalProgramCount
+                   << " waves=" << plan.runtimeWaveCount << ")";
+  costModelLog() << "\n";
+  for (size_t index = 0; index < plan.implementations.size(); ++index) {
+    const StageImplementation &implementation = plan.implementations[index];
+    costModelLog() << "  stage '" << costTable.stages[index].id << "': "
+                   << stringifyStageMode(implementation.mode)
+                   << " factor=" << implementation.superblockFactor
+                   << (implementation.localScope ? " local_scope" : "")
+                   << " cycles=" << plan.logicalStageCycles[index]
+                   << " transition=" << plan.entryTransitionCycles[index]
+                   << "\n";
+  }
 }
 
 } // namespace
@@ -598,6 +622,12 @@ mlir::ascend::solveStageRoutes(const StageCostTable &costTable,
   result.allSimt = bestFactoredPlan(StageKernelRouteKind::AllSIMT);
   result.mixed = bestFactoredPlan(StageKernelRouteKind::Mixed);
   removeAutoBlockifyCostFromAllSIMD(result.allSimd, costTable);
+
+  if (logEnabled()) {
+    logRoutePlan("all_simd", result.allSimd, costTable);
+    logRoutePlan("all_simt_only", result.allSimt, costTable);
+    logRoutePlan("mixed_simd_simt", result.mixed, costTable);
+  }
 
   return result;
 }

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageRouteCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageRouteCostModel.cpp
@@ -110,8 +110,8 @@ static void logRoutePlan(llvm::StringRef name, const StageRoutePlan &plan,
   costModelLog() << "\n";
   for (size_t index = 0; index < plan.implementations.size(); ++index) {
     const StageImplementation &implementation = plan.implementations[index];
-    costModelLog() << "  stage '" << costTable.stages[index].id << "': "
-                   << stringifyStageMode(implementation.mode)
+    costModelLog() << "  stage '" << costTable.stages[index].id
+                   << "': " << stringifyStageMode(implementation.mode)
                    << " factor=" << implementation.superblockFactor
                    << (implementation.localScope ? " local_scope" : "")
                    << " cycles=" << plan.logicalStageCycles[index]

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageRouteCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageRouteCostModel.cpp
@@ -292,6 +292,7 @@ llvm::json::Object LogicalStageCost::toJSON() const {
   result["iteration_count"] = iterationCount;
   result["features"] = features.toJSON();
   result["workload"] = workload.toJSON();
+  result["local_simt_workload"] = localSimtWorkload.toJSON();
   result["owned_operation_count"] = ownedOperationCount;
   llvm::json::Array locations;
   for (const std::string &location : sourceLocations)

--- a/third_party/ascend/costmodel/lib/AscendModel/Support/CostModelLogger.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Support/CostModelLogger.cpp
@@ -1,0 +1,121 @@
+//===- CostModelLogger.cpp - Costmodel execution tracing --------*- C++ -*-===//
+
+#include "AscendModel/Support/CostModelLogger.h"
+#include "mlir/IR/Operation.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdlib>
+#include <mutex>
+
+using namespace mlir;
+using namespace mlir::ascend::costmodel;
+
+namespace {
+
+// The whole costmodel pipeline runs on one thread per module, but keep the
+// trace bookkeeping under a mutex so concurrent compilations cannot
+// interleave a single trace scope.
+std::mutex &traceMutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+int resolveLogLevelFromEnvironment() {
+  const char *environment = std::getenv("COSTMODEL_LOG_LEVEL");
+  if (!environment || !*environment)
+    return 0; // unset: silent, keeps production stderr clean
+  llvm::StringRef value(environment);
+  if (value == "0" || value.equals_insensitive("off"))
+    return 0;
+  if (value == "2" || value.equals_insensitive("verbose") ||
+      value.equals_insensitive("debug"))
+    return 2;
+  return 1;
+}
+
+int &logLevelRef() {
+  static int level = resolveLogLevelFromEnvironment();
+  return level;
+}
+
+unsigned &traceDepthRef() {
+  static unsigned depth = 0;
+  return depth;
+}
+
+llvm::raw_ostream &writePrefix(llvm::raw_ostream &os) {
+  os << "[COSTMODEL] ";
+  for (unsigned i = 0; i < traceDepthRef(); ++i)
+    os << "  ";
+  return os;
+}
+
+} // namespace
+
+namespace mlir::ascend::costmodel {
+
+int logLevel() { return logLevelRef(); }
+bool logEnabled() { return logLevel() >= 1; }
+bool debugEnabled() { return logLevel() >= 1; }
+
+// The one place that owns the log backend.  Swap llvm::errs() here (e.g. for
+// a raw_fd_ostream or a captured callback stream) to redirect all costmodel
+// logging; no call site needs to change.
+llvm::raw_ostream &costModelSink() { return llvm::errs(); }
+
+llvm::raw_ostream &costModelLog() {
+  if (!logEnabled())
+    return llvm::nulls();
+  return writePrefix(costModelSink());
+}
+
+llvm::raw_ostream &costModelDebug() {
+  if (!debugEnabled())
+    return llvm::nulls();
+  return writePrefix(costModelSink());
+}
+
+void costModelLogLine(llvm::StringRef text) {
+  if (!logEnabled())
+    return;
+  std::lock_guard<std::mutex> lock(traceMutex());
+  writePrefix(costModelSink()) << text << "\n";
+}
+
+void costModelDebugLine(llvm::StringRef text) {
+  if (!debugEnabled())
+    return;
+  std::lock_guard<std::mutex> lock(traceMutex());
+  writePrefix(costModelSink()) << text << "\n";
+}
+
+void costModelLogIR(llvm::StringRef tag, Operation *op) {
+  if (!logEnabled() || !op)
+    return;
+  std::lock_guard<std::mutex> lock(traceMutex());
+  llvm::raw_ostream &os = costModelSink();
+  writePrefix(os) << "===== IR dump: " << tag << " =====\n";
+  op->print(os);
+  os << "\n";
+  writePrefix(os) << "===== IR dump end =====\n";
+}
+
+CostModelTraceScope::CostModelTraceScope(llvm::StringRef name, bool active)
+    : name(name.str()), active(active && logLevel() >= 1) {
+  if (!this->active)
+    return;
+  std::lock_guard<std::mutex> lock(traceMutex());
+  writePrefix(costModelSink()) << ">>> " << this->name << "\n";
+  ++traceDepthRef();
+}
+
+CostModelTraceScope::~CostModelTraceScope() {
+  if (!active)
+    return;
+  std::lock_guard<std::mutex> lock(traceMutex());
+  --traceDepthRef();
+  writePrefix(costModelSink()) << "<<< " << name << "\n";
+}
+
+} // namespace mlir::ascend::costmodel

--- a/third_party/ascend/costmodel/lib/AscendModel/Support/CostModelLogger.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Support/CostModelLogger.cpp
@@ -40,7 +40,7 @@ int &logLevelRef() {
 }
 
 unsigned &traceDepthRef() {
-  static unsigned depth = 0;
+  static thread_local unsigned depth = 0;
   return depth;
 }
 
@@ -57,7 +57,7 @@ namespace mlir::ascend::costmodel {
 
 int logLevel() { return logLevelRef(); }
 bool logEnabled() { return logLevel() >= 1; }
-bool debugEnabled() { return logLevel() >= 1; }
+bool debugEnabled() { return logLevel() >= 2; }
 
 // The one place that owns the log backend.  Swap llvm::errs() here (e.g. for
 // a raw_fd_ostream or a captured callback stream) to redirect all costmodel

--- a/third_party/ascend/costmodel/lib/AscendModel/Transforms/MaterializeSimtScopes.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Transforms/MaterializeSimtScopes.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AscendModel/Analysis/SimtAnchorAnalysis.h"
+#include "AscendModel/Support/CostModelLogger.h"
 #include "AscendModel/Transforms/Passes.h"
 #include "AscendModel/Transforms/SimtSelection.h"
 
@@ -163,6 +164,9 @@ static LogicalResult wrapAnchorRange(ArrayRef<Operation *> ops,
 LogicalResult materializeSimtAnchorPlan(ModuleOp module,
                                         const SimtAnchorPlan &plan,
                                         int64_t superblockFactor) {
+  COSTMODEL_TRACE("materializeSimtAnchorPlan");
+  costModelLog() << "input: module anchors=" << plan.anchors.size()
+                 << " superblock_factor=" << superblockFactor << "\n";
   if (superblockFactor <= 0 || (superblockFactor & (superblockFactor - 1)) != 0)
     return module.emitError(
         "SIMT scope superblock factor must be a positive power of two");
@@ -213,6 +217,7 @@ LogicalResult materializeSimtAnchorPlan(ModuleOp module,
   if (materialized == 0)
     return module.emitError(
         "mixed_simd_simt has no materializable local SIMT scope");
+  costModelLog() << "output: materialized scopes=" << materialized << "\n";
   return success();
 }
 

--- a/third_party/ascend/costmodel/lib/AscendModel/Transforms/SelectSimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Transforms/SelectSimdSimtCostModel.cpp
@@ -79,9 +79,57 @@ static void clearPreviousSelection(ModuleOp module) {
   module->removeAttr(kSuperblockFactorAttr);
 }
 
+/// Scheduling stage names present only in the post-AutoBlockify analysis
+/// view; the route-neutral materialization module never contains them.
+static bool isSchedulingModelName(llvm::StringRef model) {
+  return model == "auto_blockify_dispatch" || model == "auto_blockify_loop";
+}
+
+static bool isSchedulingStageKind(const LogicalStage &stage) {
+  return stage.costModelKind == StageCostModelKind::AutoBlockifyDispatch ||
+         stage.costModelKind == StageCostModelKind::AutoBlockifyLoop;
+}
+
+/// Align the scored (analysis) Stages with the materialization module's
+/// Stages.  Scheduling Stages are skipped on both sides; the remaining
+/// Stages must agree in order and kind.  Aligned entries for scheduling
+/// Stages stay null.  Returns false when the two partitions disagree.
+static bool
+alignModuleStages(const StageCostModelSummary &stageModel,
+                  const StagePartition &modulePartition,
+                  llvm::SmallVectorImpl<const LogicalStage *> &aligned) {
+  aligned.assign(stageModel.stages.size(), nullptr);
+  size_t moduleCursor = 0;
+  auto skipScheduling = [&]() {
+    while (moduleCursor < modulePartition.stages.size() &&
+           isSchedulingStageKind(modulePartition.stages[moduleCursor]))
+      ++moduleCursor;
+  };
+  for (size_t index = 0; index < stageModel.stages.size(); ++index) {
+    if (isSchedulingModelName(stageModel.stages[index].model))
+      continue;
+    skipScheduling();
+    if (moduleCursor >= modulePartition.stages.size())
+      return false;
+    const LogicalStage &moduleStage = modulePartition.stages[moduleCursor++];
+    if (stageModel.stages[index].model !=
+        stringifyStageCostModel(moduleStage.costModelKind))
+      return false;
+    aligned[index] = &moduleStage;
+  }
+  skipScheduling();
+  return moduleCursor == modulePartition.stages.size();
+}
+
+/// Build the exact anchor set a legal mixed route will materialize.
+/// Primitive anchors come from the shared plan; an anchor-free Stage chosen
+/// as SIMT is synthesized as a StageOwnedScope from the module's own Stage
+/// boundaries, so the wrapped root range is the range the route charged.
 static SimtAnchorPlan
 buildSelectedMixedAnchorPlan(const StageCostModelSummary &stageModel,
-                             const SimtAnchorPlan &completePlan) {
+                             const SimtAnchorPlan &completePlan,
+                             llvm::ArrayRef<const LogicalStage *> alignedStages,
+                             bool compileOn91095) {
   SimtAnchorPlan selected;
   selected.kernelLowerability = completePlan.kernelLowerability;
   if (!stageModel.mixed.legal ||
@@ -91,11 +139,11 @@ buildSelectedMixedAnchorPlan(const StageCostModelSummary &stageModel,
   llvm::DenseSet<unsigned> included;
   for (size_t stageIndex = 0; stageIndex < stageModel.stages.size();
        ++stageIndex) {
-    const LogicalStageCost &stage = stageModel.stages[stageIndex];
     const StageImplementation &implementation =
         stageModel.mixed.implementations[stageIndex];
     if (implementation.mode != StageMode::SIMT)
       continue;
+    const LogicalStageCost &stage = stageModel.stages[stageIndex];
 
     llvm::SmallVector<unsigned> stageAnchorIndices;
     for (unsigned index : stage.simtAnchorIndices)
@@ -104,10 +152,63 @@ buildSelectedMixedAnchorPlan(const StageCostModelSummary &stageModel,
     auto merged = mergeSimtStageAnchors(completePlan, stageAnchorIndices);
     if (!stageAnchorIndices.empty() && !merged)
       return SimtAnchorPlan{};
-    if (merged)
+    if (merged) {
       selected.anchors.push_back(std::move(*merged));
+      continue;
+    }
+
+    const LogicalStage *moduleStage = alignedStages[stageIndex];
+    if (!moduleStage || !moduleStage->localSimtMaterializable)
+      return SimtAnchorPlan{};
+    auto descriptor = buildStageOwnedScopeDescriptor(moduleStage->operations,
+                                                     compileOn91095);
+    if (!descriptor)
+      return SimtAnchorPlan{};
+    costModelLog() << "selected stage-owned scope: stage '" << stage.id
+                   << "' roots=" << moduleStage->operations.size() << "\n";
+    selected.anchors.push_back(std::move(*descriptor));
   }
   return selected;
+}
+
+/// Outcome of preparing a mixed route's local scope contract.
+struct MixedAnchorSelection {
+  SimtAnchorPlan plan;
+  llvm::SmallVector<Operation *> roots;
+  bool supported = false;
+  std::string reason;
+};
+
+/// Prepare the mixed route's local scope contract in one step: partition the
+/// materialization module with the scoring options, align its Stages with
+/// the scored route, and select or synthesize the anchors to materialize.
+static MixedAnchorSelection
+selectMixedAnchors(ModuleOp module, const StageCostModelSummary &stageModel,
+                   const SimtAnchorPlan &anchorPlan,
+                   const SimdSimtCostModelOptions &options) {
+  MixedAnchorSelection selection;
+  auto modulePartition =
+      partitionForSimdSimtSelection(module, anchorPlan, options);
+  if (!modulePartition) {
+    module.emitWarning("mixed route module partition failed: ")
+        << llvm::toString(modulePartition.takeError());
+    selection.reason = "module_partition_failed";
+    return selection;
+  }
+  llvm::SmallVector<const LogicalStage *> aligned;
+  if (!alignModuleStages(stageModel, *modulePartition, aligned)) {
+    selection.reason = "module_stage_alignment_failed";
+    return selection;
+  }
+  selection.plan = buildSelectedMixedAnchorPlan(
+      stageModel, anchorPlan, aligned, options.compileOn91095);
+  selection.roots = selection.plan.materializableRoots();
+  if (selection.roots.empty()) {
+    selection.reason = "no_materializable_mixed_anchor";
+    return selection;
+  }
+  selection.supported = true;
+  return selection;
 }
 
 static bool
@@ -227,12 +328,13 @@ struct SelectSimdSimtCostModelPass
         actionSupported = false;
         applicationReason = "analysis_materialization_anchor_mismatch";
       } else {
-        selectedMixedAnchorPlan =
-            buildSelectedMixedAnchorPlan(report.stageModel, anchorPlan);
-        mixedAnchors = selectedMixedAnchorPlan.materializableRoots();
-        if (mixedAnchors.empty()) {
+        MixedAnchorSelection selection = selectMixedAnchors(
+            module, report.stageModel, anchorPlan, options);
+        selectedMixedAnchorPlan = std::move(selection.plan);
+        mixedAnchors = std::move(selection.roots);
+        if (!selection.supported) {
           actionSupported = false;
-          applicationReason = "no_materializable_mixed_anchor";
+          applicationReason = std::move(selection.reason);
         }
       }
       // A factor>1 mixed route needs batching of the surrounding SIMD
@@ -328,6 +430,12 @@ struct SelectSimdSimtCostModelPass
     }
     reportJSON["materialized_simt_anchor_count"] =
         static_cast<int64_t>(mixedAnchors.size());
+    reportJSON["materialized_stage_owned_scope_count"] = static_cast<int64_t>(
+        llvm::count_if(selectedMixedAnchorPlan.anchors,
+                       [](const SimtAnchorDescriptor &anchor) {
+                         return anchor.kind ==
+                                SimtAnchorKind::StageOwnedScope;
+                       }));
     reportJSON["selected_superblock_factor"] = selectedSuperblockFactor;
     reportJSON["logical_program_count_hint"] = options.logicalProgramCountHint;
     if (options.logicalProgramCountHint > 0) {

--- a/third_party/ascend/costmodel/lib/AscendModel/Transforms/SelectSimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Transforms/SelectSimdSimtCostModel.cpp
@@ -9,6 +9,7 @@
 
 #include "AscendModel/Analysis/SimtAnchorAnalysis.h"
 #include "AscendModel/RouteModel/SimdSimtCostModel.h"
+#include "AscendModel/Support/CostModelLogger.h"
 #include "AscendModel/Transforms/Passes.h"
 #include "AscendModel/Transforms/SimtSelection.h"
 
@@ -141,6 +142,8 @@ struct SelectSimdSimtCostModelPass
 
   void runOnOperation() override {
     ModuleOp module = getOperation();
+    COSTMODEL_TRACE("SelectSimdSimtCostModelPass::runOnOperation");
+    costModelLogIR("costmodel input module", module);
     clearPreviousSelection(module);
     const bool autoMode = mode.getValue() == "auto";
 
@@ -161,6 +164,8 @@ struct SelectSimdSimtCostModelPass
       }
       analysisModule = *parsedAnalysisModule;
     }
+    costModelLogIR("analysis module (post-layout/post-AutoBlockify TTIR)",
+                   analysisModule);
 
     SimdSimtCostModelOptions options;
     options.profilePath = profilePath.getValue();
@@ -285,6 +290,13 @@ struct SelectSimdSimtCostModelPass
                                          report.candidateCosts.mixedSimdSimt));
     module->setAttr(kSuperblockFactorAttr,
                     builder.getI64IntegerAttr(selectedSuperblockFactor));
+    costModelLog() << "decision: recommended=" << recommended
+                   << " effective=" << effective << " source=" << selectionSource
+                   << " reason=" << applicationReason
+                   << " superblock_factor=" << selectedSuperblockFactor
+                   << " (scores: all_simd=" << report.candidateCosts.allSimd
+                   << " all_simt_only=" << report.candidateCosts.allSimtOnly
+                   << " mixed=" << report.candidateCosts.mixedSimdSimt << ")\n";
 
     // Selector and Materializer consume the same immutable anchor plan in one
     // pass invocation.  No per-operation marker is persisted in TTIR.
@@ -294,6 +306,7 @@ struct SelectSimdSimtCostModelPass
       signalPassFailure();
       return;
     }
+    costModelLogIR("materialized module (SIMT scopes applied)", module);
 
     llvm::json::Object reportJSON = report.toJSON();
     reportJSON["mode"] = mode.getValue();

--- a/third_party/ascend/costmodel/lib/AscendModel/Transforms/SelectSimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Transforms/SelectSimdSimtCostModel.cpp
@@ -70,9 +70,8 @@ static bool containsExplicitVectorScope(ModuleOp module) {
 }
 
 static bool isBackendIntrinsicSimtScan(Operation *op) {
-  if (op->getName().getStringRef() != "tt.scan" ||
-      op->getNumOperands() == 0 || op->getNumRegions() == 0 ||
-      op->getRegion(0).empty())
+  if (op->getName().getStringRef() != "tt.scan" || op->getNumOperands() == 0 ||
+      op->getNumRegions() == 0 || op->getRegion(0).empty())
     return false;
 
   auto axisAttr = op->getAttrOfType<IntegerAttr>("axis");
@@ -175,10 +174,9 @@ using ModuleStageRun = llvm::SmallVector<const LogicalStage *, 4>;
 /// only requires the run's roots to be a continuous materializable range.
 /// Runs stay empty for scheduling Stages.  Returns false when the two
 /// partitions disagree.
-static bool
-alignModuleStages(const StageCostModelSummary &stageModel,
-                  const StagePartition &modulePartition,
-                  llvm::SmallVectorImpl<ModuleStageRun> &aligned) {
+static bool alignModuleStages(const StageCostModelSummary &stageModel,
+                              const StagePartition &modulePartition,
+                              llvm::SmallVectorImpl<ModuleStageRun> &aligned) {
   aligned.assign(stageModel.stages.size(), ModuleStageRun{});
   // Look-ahead helper: the kind of the next non-scheduling scored Stage.
   // Once a run already contains its scored kind, a trailing supporting
@@ -206,14 +204,14 @@ alignModuleStages(const StageCostModelSummary &stageModel,
     skipScheduling();
     if (moduleCursor >= modulePartition.stages.size()) {
       costModelLog() << "stage alignment failed: scored stage '" << scored.id
-                     << "' (" << scored.model
-                     << ") has no module stage left\n";
+                     << "' (" << scored.model << ") has no module stage left\n";
       return false;
     }
 
     ModuleStageRun run;
     if (stringifyStageCostModel(
-            modulePartition.stages[moduleCursor].costModelKind) == scored.model) {
+            modulePartition.stages[moduleCursor].costModelKind) ==
+        scored.model) {
       run.push_back(&modulePartition.stages[moduleCursor++]);
     } else {
       // Absorb supporting-kind Stages until the run already contains the
@@ -244,8 +242,8 @@ alignModuleStages(const StageCostModelSummary &stageModel,
         costModelLog() << "stage alignment failed: scored stage '" << scored.id
                        << "' (" << scored.model
                        << ") found no matching kind before module stage "
-                       << moduleCursor << "/"
-                       << modulePartition.stages.size() << "\n";
+                       << moduleCursor << "/" << modulePartition.stages.size()
+                       << "\n";
         return false;
       }
     }
@@ -267,8 +265,7 @@ alignModuleStages(const StageCostModelSummary &stageModel,
 /// Primitive anchors come from the shared plan; an anchor-free Stage chosen
 /// as SIMT is synthesized as a StageOwnedScope from the module's own Stage
 /// boundaries, so the wrapped root range is the range the route charged.
-static SimtAnchorPlan
-buildSelectedMixedAnchorPlan(
+static SimtAnchorPlan buildSelectedMixedAnchorPlan(
     const StageCostModelSummary &stageModel, const SimtAnchorPlan &completePlan,
     llvm::ArrayRef<ModuleStageRun> alignedStages, bool compileOn91095) {
   SimtAnchorPlan selected;
@@ -347,8 +344,8 @@ selectMixedAnchors(ModuleOp module, const StageCostModelSummary &stageModel,
     selection.reason = "module_stage_alignment_failed";
     return selection;
   }
-  selection.plan = buildSelectedMixedAnchorPlan(
-      stageModel, anchorPlan, aligned, options.compileOn91095);
+  selection.plan = buildSelectedMixedAnchorPlan(stageModel, anchorPlan, aligned,
+                                                options.compileOn91095);
   selection.roots = selection.plan.materializableRoots();
   if (selection.roots.empty()) {
     selection.reason = "no_materializable_mixed_anchor";
@@ -434,9 +431,8 @@ struct SelectSimdSimtCostModelPass
         if (auto count = object->getInteger("physical_vector_core_count_hint"))
           options.physicalVectorCoreCountHint = std::max<int64_t>(0, *count);
 
-    const SimtLoweringCapabilities capabilities =
-        querySimtLoweringCapabilities(options.actualTarget,
-                                      options.compileOn91095);
+    const SimtLoweringCapabilities capabilities = querySimtLoweringCapabilities(
+        options.actualTarget, options.compileOn91095);
     SimtAnchorPlan anchorPlan = buildMixedSimtAnchorPlan(module, capabilities);
     SimtAnchorPlan analysisAnchorPlan =
         buildMixedSimtAnchorPlan(analysisModule, capabilities);
@@ -524,8 +520,8 @@ struct SelectSimdSimtCostModelPass
         actionSupported = false;
         applicationReason = "analysis_materialization_anchor_mismatch";
       } else {
-        MixedAnchorSelection selection = selectMixedAnchors(
-            module, report.stageModel, anchorPlan, options);
+        MixedAnchorSelection selection =
+            selectMixedAnchors(module, report.stageModel, anchorPlan, options);
         selectedMixedAnchorPlan = std::move(selection.plan);
         mixedAnchors = std::move(selection.roots);
         if (!selection.supported) {
@@ -591,7 +587,8 @@ struct SelectSimdSimtCostModelPass
     module->setAttr(kSuperblockFactorAttr,
                     builder.getI64IntegerAttr(selectedSuperblockFactor));
     costModelLog() << "decision: recommended=" << recommended
-                   << " effective=" << effective << " source=" << selectionSource
+                   << " effective=" << effective
+                   << " source=" << selectionSource
                    << " reason=" << applicationReason
                    << " superblock_factor=" << selectedSuperblockFactor
                    << " (scores: all_simd=" << report.candidateCosts.allSimd
@@ -633,8 +630,7 @@ struct SelectSimdSimtCostModelPass
     reportJSON["materialized_stage_owned_scope_count"] = static_cast<int64_t>(
         llvm::count_if(selectedMixedAnchorPlan.anchors,
                        [](const SimtAnchorDescriptor &anchor) {
-                         return anchor.kind ==
-                                SimtAnchorKind::StageOwnedScope;
+                         return anchor.kind == SimtAnchorKind::StageOwnedScope;
                        }));
     reportJSON["selected_superblock_factor"] = selectedSuperblockFactor;
     reportJSON["logical_program_count_hint"] = options.logicalProgramCountHint;

--- a/third_party/ascend/costmodel/lib/AscendModel/Transforms/SelectSimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Transforms/SelectSimdSimtCostModel.cpp
@@ -9,6 +9,7 @@
 
 #include "AscendModel/Analysis/SimtAnchorAnalysis.h"
 #include "AscendModel/RouteModel/SimdSimtCostModel.h"
+#include "AscendModel/Support/CostModelError.h"
 #include "AscendModel/Support/CostModelLogger.h"
 #include "AscendModel/Transforms/Passes.h"
 #include "AscendModel/Transforms/SimtSelection.h"
@@ -66,6 +67,58 @@ static bool containsExplicitVectorScope(ModuleOp module) {
     return WalkResult::advance();
   });
   return found;
+}
+
+static bool isBackendIntrinsicSimtScan(Operation *op) {
+  if (op->getName().getStringRef() != "tt.scan" ||
+      op->getNumOperands() == 0 || op->getNumRegions() == 0 ||
+      op->getRegion(0).empty())
+    return false;
+
+  auto axisAttr = op->getAttrOfType<IntegerAttr>("axis");
+  auto srcTy = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+  if (!axisAttr || !srcTy || !srcTy.hasRank())
+    return false;
+  int64_t axis = axisAttr.getInt();
+  ArrayRef<int64_t> shape = srcTy.getShape();
+  if (axis < 0 || axis >= static_cast<int64_t>(shape.size()))
+    return false;
+  for (int64_t dim = 0; dim < static_cast<int64_t>(shape.size()); ++dim) {
+    if (dim != axis && shape[dim] != 1)
+      return false;
+  }
+
+  Operation *combineOp = nullptr;
+  for (Operation &bodyOp : op->getRegion(0).front().without_terminator()) {
+    llvm::StringRef name = bodyOp.getName().getStringRef();
+    if (name == "arith.extf" || name == "arith.truncf" ||
+        name == "arith.bitcast")
+      continue;
+    if (combineOp)
+      return false;
+    combineOp = &bodyOp;
+  }
+  if (!combineOp)
+    return false;
+  llvm::StringRef combineName = combineOp->getName().getStringRef();
+  return combineName == "arith.addf" || combineName == "arith.addi";
+}
+
+static bool requiresBackendIntrinsicSimtRouting(ModuleOp module,
+                                                bool compileOn91095) {
+  if (!compileOn91095)
+    return false;
+  bool required = false;
+  module.walk([&](Operation *op) {
+    llvm::StringRef name = op->getName().getStringRef();
+    if (name == "tt.gather" || name == "tt.histogram" ||
+        isBackendIntrinsicSimtScan(op)) {
+      required = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return required;
 }
 
 static void clearPreviousSelection(ModuleOp module) {
@@ -381,21 +434,70 @@ struct SelectSimdSimtCostModelPass
         if (auto count = object->getInteger("physical_vector_core_count_hint"))
           options.physicalVectorCoreCountHint = std::max<int64_t>(0, *count);
 
-    SimtAnchorPlan anchorPlan =
-        buildMixedSimtAnchorPlan(module, options.compileOn91095);
+    const SimtLoweringCapabilities capabilities =
+        querySimtLoweringCapabilities(options.actualTarget,
+                                      options.compileOn91095);
+    SimtAnchorPlan anchorPlan = buildMixedSimtAnchorPlan(module, capabilities);
     SimtAnchorPlan analysisAnchorPlan =
-        buildMixedSimtAnchorPlan(analysisModule, options.compileOn91095);
+        buildMixedSimtAnchorPlan(analysisModule, capabilities);
     auto reportOr =
         analyzeSimdSimtCandidates(analysisModule, analysisAnchorPlan, options);
     if (!reportOr) {
-      module.emitError("C++ SIMD/SIMT cost model failed: ")
-          << llvm::toString(reportOr.takeError());
-      signalPassFailure();
+      std::string reason;
+      bool recoverable = false;
+      llvm::Error unhandled = llvm::handleErrors(
+          reportOr.takeError(), [&](const UnsupportedCostModelIR &error) {
+            reason = error.getMessage().str();
+            recoverable = true;
+          });
+      if (unhandled) {
+        reason = llvm::toString(std::move(unhandled));
+        module.emitError("C++ SIMD/SIMT cost model internal failure: ")
+            << reason;
+        signalPassFailure();
+        return;
+      }
+      assert(recoverable && "typed costmodel error was not handled");
+      // Unsupported but valid TTIR is recoverable.  Internal partition/profile
+      // invariants are deliberately not swallowed by this path.
+      module.emitWarning("C++ SIMD/SIMT cost model fell back to "
+                         "backend_default: ")
+          << reason;
+      Builder builder(module.getContext());
+      module->setAttr(kEffectiveExecutionAttr,
+                      builder.getStringAttr(kBackendDefault));
+      module->setAttr(kSelectionSourceAttr,
+                      builder.getStringAttr("backend_default"));
+      llvm::json::Object reportJSON;
+      reportJSON["mode"] = mode.getValue();
+      reportJSON["recommended_decision_kind"] = kBackendDefault.str();
+      reportJSON["effective_decision_kind"] = kBackendDefault.str();
+      reportJSON["selection_source"] = "backend_default";
+      reportJSON["application_reason"] = reason;
+      reportJSON["action_supported"] = false;
+      std::string json =
+          llvm::formatv("{0}", llvm::json::Value(std::move(reportJSON))).str();
+      module->setAttr(kReportJSONAttr, builder.getStringAttr(json));
+      if (failed(appendJSONLine(reportFile.getValue(), json)))
+        module.emitWarning("failed to append C++ SIMD/SIMT report to ")
+            << reportFile.getValue();
       return;
     }
     SimdSimtCostReport report = std::move(*reportOr);
 
-    std::string recommended = stringifySimdSimtCandidate(report.decision).str();
+    std::string costOnlyRecommended =
+        stringifySimdSimtCandidate(report.decision).str();
+    std::string recommended = costOnlyRecommended;
+    // "all_simd" means that the Route Model does not need to materialize a
+    // local SIMT scope.  It must not disable backend-intrinsic SIMT lowering
+    // for operations such as tt.scan, whose strict SIMD lowering is not a
+    // valid executable candidate.  Preserve the proven backend route in this
+    // case instead of applying a semantically different all-SIMD contract.
+    const bool preserveBackendIntrinsicRoute =
+        autoMode && recommended == kAllSimd &&
+        requiresBackendIntrinsicSimtRouting(module, options.compileOn91095);
+    if (preserveBackendIntrinsicRoute)
+      recommended = kBackendDefault.str();
     std::string effective = kBackendDefault.str();
     std::string selectionSource = "backend_default";
     std::string applicationReason;
@@ -408,7 +510,7 @@ struct SelectSimdSimtCostModelPass
     else if (report.decision == SimdSimtCandidateKind::AllSIMTOnly)
       selectedSuperblockFactor =
           report.stageModel.allSimt.routeSuperblockFactor;
-    else
+    else if (recommended == kMixedSimdSimt)
       selectedSuperblockFactor = report.stageModel.mixed.routeSuperblockFactor;
 
     bool actionSupported = true;
@@ -465,7 +567,9 @@ struct SelectSimdSimtCostModelPass
     if (autoMode && actionSupported) {
       effective = recommended;
       selectionSource = "cpp_cost_model";
-      applicationReason = "minimum_cost_candidate";
+      applicationReason = preserveBackendIntrinsicRoute
+                              ? "backend_intrinsic_simt_required"
+                              : "minimum_cost_candidate";
     } else if (!autoMode) {
       applicationReason = "report_mode";
     } else if (applicationReason.empty()) {
@@ -506,6 +610,8 @@ struct SelectSimdSimtCostModelPass
 
     llvm::json::Object reportJSON = report.toJSON();
     reportJSON["mode"] = mode.getValue();
+    reportJSON["cost_only_decision_kind"] = costOnlyRecommended;
+    reportJSON["decision_kind"] = recommended;
     reportJSON["recommended_decision_kind"] = recommended;
     reportJSON["effective_decision_kind"] = effective;
     reportJSON["selection_source"] = selectionSource;

--- a/third_party/ascend/costmodel/lib/AscendModel/Transforms/SelectSimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Transforms/SelectSimdSimtCostModel.cpp
@@ -90,15 +90,56 @@ static bool isSchedulingStageKind(const LogicalStage &stage) {
          stage.costModelKind == StageCostModelKind::AutoBlockifyLoop;
 }
 
+/// Kinds StageBoundaryAnalysis may merge across statement boundaries inside
+/// one plain Stage (its isSupportingSemanticKind set).  The analysis view
+/// replaces program-id bookkeeping with AutoBlockify scheduling ops, so one
+/// scored Stage can correspond to a run of consecutive module Stages whose
+/// kinds all belong to this family.
+static bool isSupportingStageKind(StageCostModelKind kind) {
+  switch (kind) {
+  case StageCostModelKind::ScalarIssue:
+  case StageCostModelKind::ScalarControl:
+  case StageCostModelKind::ScalarMath:
+  case StageCostModelKind::IndexGeneration:
+  case StageCostModelKind::PredicateMask:
+  case StageCostModelKind::LoopPredicate:
+    return true;
+  default:
+    return false;
+  }
+}
+
+using ModuleStageRun = llvm::SmallVector<const LogicalStage *, 4>;
+
 /// Align the scored (analysis) Stages with the materialization module's
-/// Stages.  Scheduling Stages are skipped on both sides; the remaining
-/// Stages must agree in order and kind.  Aligned entries for scheduling
-/// Stages stay null.  Returns false when the two partitions disagree.
+/// Stages.  Scheduling Stages are skipped on both sides.  A scored Stage
+/// first tries an exact single-Stage kind match; otherwise it absorbs the
+/// surrounding run of consecutive supporting-kind module Stages containing
+/// the scored kind.  Containment (not kind equality) is the acceptance
+/// rule: the analysis view replaces program-id bookkeeping with
+/// AutoBlockify scheduling ops and regroups plain roots, so run boundaries
+/// need not coincide exactly with scored Stage boundaries — materialization
+/// only requires the run's roots to be a continuous materializable range.
+/// Runs stay empty for scheduling Stages.  Returns false when the two
+/// partitions disagree.
 static bool
 alignModuleStages(const StageCostModelSummary &stageModel,
                   const StagePartition &modulePartition,
-                  llvm::SmallVectorImpl<const LogicalStage *> &aligned) {
-  aligned.assign(stageModel.stages.size(), nullptr);
+                  llvm::SmallVectorImpl<ModuleStageRun> &aligned) {
+  aligned.assign(stageModel.stages.size(), ModuleStageRun{});
+  // Look-ahead helper: the kind of the next non-scheduling scored Stage.
+  // Once a run already contains its scored kind, a trailing supporting
+  // module Stage of exactly that kind belongs to the next scored Stage,
+  // not to this run.  Without this guard a leading supporting Stage of the
+  // following scored Stage (e.g. the loop-index scalar_issue right after a
+  // split loop shell) is stolen by the current run's greedy absorption and
+  // the following scored Stage finds no match left.
+  auto nextScoredKind = [&stageModel](size_t index) {
+    for (size_t next = index + 1; next < stageModel.stages.size(); ++next)
+      if (!isSchedulingModelName(stageModel.stages[next].model))
+        return llvm::StringRef(stageModel.stages[next].model);
+    return llvm::StringRef();
+  };
   size_t moduleCursor = 0;
   auto skipScheduling = [&]() {
     while (moduleCursor < modulePartition.stages.size() &&
@@ -106,18 +147,66 @@ alignModuleStages(const StageCostModelSummary &stageModel,
       ++moduleCursor;
   };
   for (size_t index = 0; index < stageModel.stages.size(); ++index) {
-    if (isSchedulingModelName(stageModel.stages[index].model))
+    const LogicalStageCost &scored = stageModel.stages[index];
+    if (isSchedulingModelName(scored.model))
       continue;
     skipScheduling();
-    if (moduleCursor >= modulePartition.stages.size())
+    if (moduleCursor >= modulePartition.stages.size()) {
+      costModelLog() << "stage alignment failed: scored stage '" << scored.id
+                     << "' (" << scored.model
+                     << ") has no module stage left\n";
       return false;
-    const LogicalStage &moduleStage = modulePartition.stages[moduleCursor++];
-    if (stageModel.stages[index].model !=
-        stringifyStageCostModel(moduleStage.costModelKind))
-      return false;
-    aligned[index] = &moduleStage;
+    }
+
+    ModuleStageRun run;
+    if (stringifyStageCostModel(
+            modulePartition.stages[moduleCursor].costModelKind) == scored.model) {
+      run.push_back(&modulePartition.stages[moduleCursor++]);
+    } else {
+      // Absorb supporting-kind Stages until the run already contains the
+      // scored kind; the next copy belongs to the following scored Stage.
+      // The scored kind itself may be non-supporting (e.g. PrefixScan or
+      // LoopCarriedRecurrence): such a Stage must still be absorbed when it
+      // is the scored kind, so matchesScored is checked before the
+      // non-supporting break.
+      bool sawScoredKind = false;
+      const llvm::StringRef followKind = nextScoredKind(index);
+      while (moduleCursor < modulePartition.stages.size()) {
+        const LogicalStage &candidate = modulePartition.stages[moduleCursor];
+        const bool matchesScored =
+            stringifyStageCostModel(candidate.costModelKind) == scored.model;
+        if (matchesScored && sawScoredKind)
+          break;
+        if (isSchedulingStageKind(candidate) ||
+            (!matchesScored && !isSupportingStageKind(candidate.costModelKind)))
+          break;
+        if (sawScoredKind && !followKind.empty() &&
+            stringifyStageCostModel(candidate.costModelKind) == followKind)
+          break;
+        sawScoredKind |= matchesScored;
+        run.push_back(&candidate);
+        ++moduleCursor;
+      }
+      if (!sawScoredKind) {
+        costModelLog() << "stage alignment failed: scored stage '" << scored.id
+                       << "' (" << scored.model
+                       << ") found no matching kind before module stage "
+                       << moduleCursor << "/"
+                       << modulePartition.stages.size() << "\n";
+        return false;
+      }
+    }
+    if (run.size() > 1)
+      costModelLog() << "aligned scored stage '" << scored.id << "' ("
+                     << scored.model << ") with " << run.size()
+                     << " module stages\n";
+    aligned[index] = std::move(run);
   }
   skipScheduling();
+  if (moduleCursor != modulePartition.stages.size())
+    costModelLog() << "stage alignment failed: "
+                   << (modulePartition.stages.size() - moduleCursor)
+                   << " trailing module stages unmapped\n";
   return moduleCursor == modulePartition.stages.size();
 }
 
@@ -126,10 +215,9 @@ alignModuleStages(const StageCostModelSummary &stageModel,
 /// as SIMT is synthesized as a StageOwnedScope from the module's own Stage
 /// boundaries, so the wrapped root range is the range the route charged.
 static SimtAnchorPlan
-buildSelectedMixedAnchorPlan(const StageCostModelSummary &stageModel,
-                             const SimtAnchorPlan &completePlan,
-                             llvm::ArrayRef<const LogicalStage *> alignedStages,
-                             bool compileOn91095) {
+buildSelectedMixedAnchorPlan(
+    const StageCostModelSummary &stageModel, const SimtAnchorPlan &completePlan,
+    llvm::ArrayRef<ModuleStageRun> alignedStages, bool compileOn91095) {
   SimtAnchorPlan selected;
   selected.kernelLowerability = completePlan.kernelLowerability;
   if (!stageModel.mixed.legal ||
@@ -157,15 +245,21 @@ buildSelectedMixedAnchorPlan(const StageCostModelSummary &stageModel,
       continue;
     }
 
-    const LogicalStage *moduleStage = alignedStages[stageIndex];
-    if (!moduleStage || !moduleStage->localSimtMaterializable)
+    const ModuleStageRun &moduleStages = alignedStages[stageIndex];
+    if (moduleStages.empty() ||
+        llvm::any_of(moduleStages, [](const LogicalStage *moduleStage) {
+          return !moduleStage->localSimtMaterializable;
+        }))
       return SimtAnchorPlan{};
-    auto descriptor = buildStageOwnedScopeDescriptor(moduleStage->operations,
-                                                     compileOn91095);
+    llvm::SmallVector<Operation *, 16> scopeRoots;
+    for (const LogicalStage *moduleStage : moduleStages)
+      llvm::append_range(scopeRoots, moduleStage->operations);
+    auto descriptor =
+        buildStageOwnedScopeDescriptor(scopeRoots, compileOn91095);
     if (!descriptor)
       return SimtAnchorPlan{};
     costModelLog() << "selected stage-owned scope: stage '" << stage.id
-                   << "' roots=" << moduleStage->operations.size() << "\n";
+                   << "' roots=" << scopeRoots.size() << "\n";
     selected.anchors.push_back(std::move(*descriptor));
   }
   return selected;
@@ -195,7 +289,7 @@ selectMixedAnchors(ModuleOp module, const StageCostModelSummary &stageModel,
     selection.reason = "module_partition_failed";
     return selection;
   }
-  llvm::SmallVector<const LogicalStage *> aligned;
+  llvm::SmallVector<ModuleStageRun, 4> aligned;
   if (!alignModuleStages(stageModel, *modulePartition, aligned)) {
     selection.reason = "module_stage_alignment_failed";
     return selection;

--- a/third_party/ascend/unittest/costmodel_ut/PassesTest.cpp
+++ b/third_party/ascend/unittest/costmodel_ut/PassesTest.cpp
@@ -591,6 +591,64 @@ TEST(CostModelPassesTest, SimdSimtScoresGenericSemanticStages) {
   EXPECT_EQ(*reportReason, "report_mode");
 }
 
+TEST(CostModelPassesTest, AllSimdPreservesBackendIntrinsicSimtRouting) {
+  mlir::MLIRContext context;
+  context.allowUnregisteredDialects();
+  auto module = parseModule(context, R"mlir(
+module {
+  func.func @main(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>)
+      -> tensor<4xf32> {
+    %0 = arith.addf %arg0, %arg1 : tensor<4xf32>
+    return %0 : tensor<4xf32>
+  }
+  func.func private @intrinsic_scan(%input: tensor<1xf32>)
+      -> tensor<1xf32> {
+    %scan = "tt.scan"(%input) ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      "tt.scan.return"(%sum) : (f32) -> ()
+    }) {axis = 0 : i32, reverse = false}
+      : (tensor<1xf32>) -> tensor<1xf32>
+    return %scan : tensor<1xf32>
+  }
+}
+)mlir");
+  ASSERT_TRUE(module);
+
+  SelectSimdSimtCostModelPassOptions options;
+  options.mode = "auto";
+  options.profilePath = TRITON_ASCEND_SIMD_SIMT_TEST_PROFILE_PATH;
+  options.actualTarget = "Ascend950PR_9579";
+  options.numWarps = 4;
+  options.compileOn91095 = true;
+  ASSERT_TRUE(runPasses(*module,
+                        createSelectSimdSimtCostModelPass(options)));
+
+  auto effective = (*module)->getAttrOfType<StringAttr>(
+      "ascend.simt_costmodel.effective");
+  auto reportAttr = (*module)->getAttrOfType<StringAttr>(
+      "ascend.simt_costmodel.report_json");
+  ASSERT_TRUE(effective);
+  ASSERT_TRUE(reportAttr);
+  EXPECT_EQ(effective.getValue(), "backend_default");
+  auto report = llvm::json::parse(reportAttr.getValue());
+  ASSERT_TRUE(static_cast<bool>(report));
+  auto *object = report->getAsObject();
+  ASSERT_NE(object, nullptr);
+  auto costOnly = object->getString("cost_only_decision_kind");
+  auto decision = object->getString("decision_kind");
+  auto reportedEffective = object->getString("effective_decision_kind");
+  auto reason = object->getString("application_reason");
+  ASSERT_TRUE(costOnly);
+  ASSERT_TRUE(decision);
+  ASSERT_TRUE(reportedEffective);
+  ASSERT_TRUE(reason);
+  EXPECT_EQ(*costOnly, "all_simd");
+  EXPECT_EQ(*decision, "backend_default");
+  EXPECT_EQ(*reportedEffective, "backend_default");
+  EXPECT_EQ(*reason, "backend_intrinsic_simt_required");
+}
+
 TEST(CostModelPassesTest, SimdSimtSelectionUsesExternalAnalysisIR) {
   mlir::MLIRContext context;
   auto module = parseModule(context, kOutOfSimdSimtCoverageModule);

--- a/third_party/ascend/unittest/costmodel_ut/PassesTest.cpp
+++ b/third_party/ascend/unittest/costmodel_ut/PassesTest.cpp
@@ -621,13 +621,12 @@ module {
   options.actualTarget = "Ascend950PR_9579";
   options.numWarps = 4;
   options.compileOn91095 = true;
-  ASSERT_TRUE(runPasses(*module,
-                        createSelectSimdSimtCostModelPass(options)));
+  ASSERT_TRUE(runPasses(*module, createSelectSimdSimtCostModelPass(options)));
 
-  auto effective = (*module)->getAttrOfType<StringAttr>(
-      "ascend.simt_costmodel.effective");
-  auto reportAttr = (*module)->getAttrOfType<StringAttr>(
-      "ascend.simt_costmodel.report_json");
+  auto effective =
+      (*module)->getAttrOfType<StringAttr>("ascend.simt_costmodel.effective");
+  auto reportAttr =
+      (*module)->getAttrOfType<StringAttr>("ascend.simt_costmodel.report_json");
   ASSERT_TRUE(effective);
   ASSERT_TRUE(reportAttr);
   EXPECT_EQ(effective.getValue(), "backend_default");

--- a/third_party/ascend/unittest/costmodel_ut/SimdSimtCostModelTest.cpp
+++ b/third_party/ascend/unittest/costmodel_ut/SimdSimtCostModelTest.cpp
@@ -1,4 +1,5 @@
 #include "AscendModel/RouteModel/SimdSimtCostModel.h"
+#include "AscendModel/Analysis/SimtAnchorAnalysis.h"
 #include "AscendModel/Analysis/StagePartitioner.h"
 #include "AscendModel/RouteModel/StageCostModels.h"
 
@@ -31,6 +32,22 @@ using mlir::ascend::StageWorkloadAnalysis;
 using mlir::ascend::TriangularSolveFacts;
 
 namespace {
+
+TEST(SimdSimtCostModelTest, CumsumCapabilitiesDistinguishMixedLocalScope) {
+  auto capabilities = mlir::ascend::querySimtLoweringCapabilities(
+      "Ascend950PR_9579", /*compileOn91095=*/true);
+  EXPECT_TRUE(capabilities.supportsLocalSimtScopes);
+  EXPECT_TRUE(capabilities.supportsPlainCumsumSIMD);
+  EXPECT_TRUE(capabilities.supportsPlainCumsumSIMTOnly);
+  EXPECT_FALSE(capabilities.supportsPlainCumsumInLocalSIMTScope);
+
+  auto genericCapabilities = mlir::ascend::querySimtLoweringCapabilities(
+      "Ascend910B", /*compileOn91095=*/false);
+  EXPECT_FALSE(genericCapabilities.supportsLocalSimtScopes);
+  EXPECT_TRUE(genericCapabilities.supportsPlainCumsumSIMD);
+  EXPECT_FALSE(genericCapabilities.supportsPlainCumsumSIMTOnly);
+  EXPECT_FALSE(genericCapabilities.supportsPlainCumsumInLocalSIMTScope);
+}
 
 SimdSimtFeatureSummary triangularBt16StageFeatures() {
   SimdSimtFeatureSummary f;
@@ -1369,7 +1386,7 @@ TEST(SimdSimtCostModelTest, PointerInductionLoopIsNotADataRecurrence) {
             StageCostModelKind::IndependentPipelinedLoop);
 }
 
-TEST(SimdSimtCostModelTest, IncompatibleDominantStructuresRequireStageSplit) {
+TEST(SimdSimtCostModelTest, HybridDominantStructuresClassifyAsDominantKind) {
   StagePartition partition;
   partition.operationOwnershipComplete = true;
   LogicalStage stage =
@@ -1379,9 +1396,15 @@ TEST(SimdSimtCostModelTest, IncompatibleDominantStructuresRequireStageSplit) {
   stage.features.hasIndirectMemory = true;
   partition.stages.push_back(std::move(stage));
 
+  // A Stage mixing tt.dot with another dominant structure cannot always be
+  // split (the dot may sit inside the other structure's serial chain), so
+  // the classifier models it with the dominant structure's kind instead of
+  // failing: derive() ranks dot above indirect memory for straight-line
+  // Stages, and the workload keeps charging both structures.
   llvm::Error error =
       mlir::ascend::StageKindClassifier().analyze(partition, 16384);
-  ASSERT_TRUE(static_cast<bool>(error));
-  EXPECT_NE(llvm::toString(std::move(error)).find("requires_split"),
-            std::string::npos);
+  ASSERT_TRUE(static_cast<bool>(error) == false)
+      << llvm::toString(std::move(error));
+  EXPECT_EQ(partition.stages.front().costModelKind,
+            StageCostModelKind::TinyCubeRoofline);
 }

--- a/third_party/ascend/unittest/pytest_ut/test_simd_simt_costmodel_cases.py
+++ b/third_party/ascend/unittest/pytest_ut/test_simd_simt_costmodel_cases.py
@@ -492,3 +492,94 @@ def test_costmodel_fbgemm_rowwise_quant(tmp_path):
         documented_us,
         tolerance=1.25,
     )
+
+
+@triton.jit
+def anchorless_mixed_stage_scope_kernel(
+    x_ptr,
+    y_ptr,
+    seed_ptr,
+    out_ptr,
+    scalar_out_ptr,
+    BLOCK: tl.constexpr,
+    SCALAR_ITERATIONS: tl.constexpr,
+):
+    # Continuous elementwise tile pass: memory-bound work on unit-stride
+    # addresses, so the SIMD MTE/vector roofline dominates.
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    x = tl.load(x_ptr + offs)
+    y = tl.load(y_ptr + offs)
+    tl.store(out_ptr + offs, x * y + 1.0)
+    # Scalar loop-carried recurrence on 0-d values: no gather, no
+    # loaded-index address, no atomic, no scan, so the kernel contains no
+    # primitive SIMT anchor anywhere.  The dependent scalar chain pays the
+    # SIMD front-end ~1 op/cycle, while SIMT issues 4 scalar ops/cycle, so
+    # this anchor-free Stage is cheaper in SIMT and must be materialized as
+    # a StageOwnedScope local SIMT scope by the mixed route.
+    s = tl.load(seed_ptr + pid)
+    for _ in range(SCALAR_ITERATIONS):
+        s = s * 1.0000001 + 1e-7
+    tl.store(scalar_out_ptr + pid, s)
+
+
+@simd_simt_910_95_only
+def test_costmodel_anchorless_mixed_stage_scope(tmp_path):
+    logical_programs = _vector_core_count()
+    block = 8192
+    iterations = 4096
+    torch.manual_seed(3)
+    x = torch.randn((logical_programs * block, ), dtype=torch.float32, device="npu")
+    y = torch.randn((logical_programs * block, ), dtype=torch.float32, device="npu")
+    seed = torch.rand((logical_programs, ), dtype=torch.float32, device="npu")
+    output = torch.empty_like(x)
+    scalar_output = torch.empty((logical_programs, ), dtype=torch.float32, device="npu")
+    report_path = tmp_path / "anchorless_mixed_route.json"
+
+    def launch():
+        anchorless_mixed_stage_scope_kernel[(logical_programs, )](
+            x,
+            y,
+            seed,
+            output,
+            scalar_output,
+            BLOCK=block,
+            SCALAR_ITERATIONS=iterations,
+            **_launch_options(report_path, logical_programs),
+        )
+
+    launch()
+    torch.testing.assert_close(output, x * y + 1.0, rtol=1e-5, atol=1e-5)
+    # Reproduce the FP32 scalar recurrence in the kernel's operation order.
+    # One ULP of FMA-vs-mul-add difference may accumulate over 4096 steps.
+    reference = seed.clone()
+    for _ in range(iterations):
+        reference = reference * 1.0000001 + 1e-7
+    torch.testing.assert_close(scalar_output, reference, rtol=1e-3, atol=1e-3)
+
+    report = _load_route_report(report_path, "mixed_simd_simt")
+    # The whole kernel is anchor-free: this is exactly the scenario where the
+    # legacy gate disabled mixed before stage-owned scopes existed.
+    assert report["features"]["simt_anchors"]["count"] == 0
+    assert report["materialized_simt_anchor_count"] > 0
+    assert report["materialized_stage_owned_scope_count"] > 0
+    assert report["application_reason"] == "minimum_cost_candidate"
+
+    stages = report["stage_model"]["logical_stages"]
+    mixed = report["stage_model"]["routes"]["mixed_simd_simt"]
+    assert mixed["legal"]
+    simt_indices = [
+        index for index, stage in enumerate(mixed["stages"])
+        if stage["implementation"]["mode"] == "simt"
+    ]
+    assert simt_indices, "mixed route selected no SIMT Stage"
+    for index in simt_indices:
+        implementation = mixed["stages"][index]["implementation"]
+        # The SIMT-selected Stages have no primitive anchor, so each one must
+        # have been synthesized and materialized as a stage-owned scope.
+        assert implementation["materialization"] == "local_simt_scope_with_kernel_v1"
+        assert stages[index]["simt_anchor_indices"] == []
+        assert stages[index]["local_simt_materializable"]
+    assert any(stages[index]["model"] == "loop_carried_recurrence"
+               for index in simt_indices), (
+        "the anchor-free scalar recurrence Stage should be the SIMT scope")

--- a/third_party/ascend/unittest/pytest_ut/test_simd_simt_costmodel_cases.py
+++ b/third_party/ascend/unittest/pytest_ut/test_simd_simt_costmodel_cases.py
@@ -49,7 +49,7 @@ def _launch_options(report_path, logical_programs):
     return options
 
 
-def _assert_performance(case, launch, profile_root, documented_us, tolerance=1.2):
+def _profile_median_us(case, launch, profile_root):
     for _ in range(20):
         launch()
     torch.npu.synchronize()
@@ -91,7 +91,11 @@ def _assert_performance(case, launch, profile_root, documented_us, tolerance=1.2
                 if row.get("Duration(us)"):
                     durations.append(float(row["Duration(us)"]))
     assert durations, f"{case}: profiler generated no kernel duration"
-    duration_us = statistics.median(durations)
+    return statistics.median(durations)
+
+
+def _assert_performance(case, launch, profile_root, documented_us, tolerance=1.2):
+    duration_us = _profile_median_us(case, launch, profile_root)
     maximum_us = documented_us * tolerance
     print(
         f"{case}: profiler median {duration_us:.3f} us (documented {documented_us:.3f} us, limit {maximum_us:.3f} us)")
@@ -511,16 +515,20 @@ def anchorless_mixed_stage_scope_kernel(
     x = tl.load(x_ptr + offs)
     y = tl.load(y_ptr + offs)
     tl.store(out_ptr + offs, x * y + 1.0)
-    # Scalar loop-carried recurrence on 0-d values: no gather, no
+    # Scalar loop-carried recurrence on a length-1 vector: no gather, no
     # loaded-index address, no atomic, no scan, so the kernel contains no
     # primitive SIMT anchor anywhere.  The dependent scalar chain pays the
     # SIMD front-end ~1 op/cycle, while SIMT issues 4 scalar ops/cycle, so
     # this anchor-free Stage is cheaper in SIMT and must be materialized as
-    # a StageOwnedScope local SIMT scope by the mixed route.
-    s = tl.load(seed_ptr + pid)
+    # a StageOwnedScope local SIMT scope by the mixed route.  The recurrence
+    # state is a length-1 tensor because the SIMT VF scope ABI requires
+    # every scope return value to be a ranked tensor: a plain scalar
+    # live-out cannot cross the scope boundary.
+    lane = tl.arange(0, 1)
+    s = tl.load(seed_ptr + pid + lane)
     for _ in range(SCALAR_ITERATIONS):
         s = s * 1.0000001 + 1e-7
-    tl.store(scalar_out_ptr + pid, s)
+    tl.store(scalar_out_ptr + pid + lane, s)
 
 
 @simd_simt_910_95_only
@@ -583,3 +591,253 @@ def test_costmodel_anchorless_mixed_stage_scope(tmp_path):
     assert any(stages[index]["model"] == "loop_carried_recurrence"
                for index in simt_indices), (
         "the anchor-free scalar recurrence Stage should be the SIMT scope")
+
+
+@triton.jit
+def mixed_route_anchor_and_anchorless_kernel(
+    x_ptr,
+    y_ptr,
+    table_ptr,
+    idx_ptr,
+    seed_ptr,
+    out_ptr,
+    gather_out_ptr,
+    scalar_out_ptr,
+    TILE_BLOCK: tl.constexpr,
+    TILE_LOOP_COUNT: tl.constexpr,
+    GATHER_BLOCK: tl.constexpr,
+    SCALAR_ITERATIONS: tl.constexpr,
+):
+    # Segment 1 (SIMD): streamed contiguous tile loop on unit-stride
+    # addresses.  The SIMD MTE/vector roofline dominates, so the mixed route
+    # must keep every Stage of this loop on the SIMD side.
+    pid = tl.program_id(0)
+    base = pid * (TILE_LOOP_COUNT * TILE_BLOCK)
+    for i in range(TILE_LOOP_COUNT):
+        offs = base + i * TILE_BLOCK + tl.arange(0, TILE_BLOCK)
+        x = tl.load(x_ptr + offs)
+        y = tl.load(y_ptr + offs)
+        tl.store(out_ptr + offs, x * y + 1.0)
+    # Segment 2 (anchored SIMT): the table pointer is addressed by a loaded
+    # index, so the load is loaded-index-dependent memory, a primitive SIMT
+    # anchor.  The gather must be large enough that the SIMD-side emulation
+    # cost exceeds the local SIMT scope's fixed mode-switch plus UB handoff
+    # overhead; otherwise the mixed route correctly keeps even the anchored
+    # gather on the SIMD side.
+    goffs = pid * GATHER_BLOCK + tl.arange(0, GATHER_BLOCK)
+    indices = tl.load(idx_ptr + goffs).to(tl.int32)
+    t = tl.load(table_ptr + indices)
+    tl.store(gather_out_ptr + goffs, t)
+    # Segment 3 (anchorless SIMT): scalar loop-carried recurrence on a
+    # length-1 tensor.  No gather, no loaded-index address, no atomic and no
+    # scan, so the segment contains no primitive SIMT anchor anywhere; the
+    # mixed route must still recognize it as SIMT-cheaper and synthesize a
+    # stage-owned SIMT scope.  The recurrence state is a length-1 tensor
+    # because the SIMT VF scope ABI requires every scope return value to be
+    # a ranked tensor.
+    lane = tl.arange(0, 1)
+    s = tl.load(seed_ptr + pid + lane)
+    for _ in range(SCALAR_ITERATIONS):
+        s = s * 1.0000001 + 1e-7
+    tl.store(scalar_out_ptr + pid + lane, s)
+
+
+@simd_simt_910_95_only
+def test_costmodel_mixed_route_anchor_and_anchorless(tmp_path):
+    logical_programs = _vector_core_count()
+    # The unified buffer frame must hold the tile buffers plus the gather's
+    # double-buffered indices and gathered table: int16 indices and float16
+    # gathered values keep the 8192-element gather inside the ~216KB AIV UB
+    # budget, while the gather stays large enough for the SIMD-side gather
+    # emulation to cost more than the local SIMT scope.
+    tile_block = 8192
+    tile_loop = 32
+    gather_block = 8192
+    iterations = 4096
+    table_size = 30000
+    torch.manual_seed(5)
+    x = torch.randn((logical_programs * tile_block * tile_loop, ), dtype=torch.float32, device="npu")
+    y = torch.randn((logical_programs * tile_block * tile_loop, ), dtype=torch.float32, device="npu")
+    table = torch.randn((table_size, ), dtype=torch.float16, device="npu")
+    idx = torch.randint(0, table_size, (logical_programs * gather_block, ), dtype=torch.int16, device="npu")
+    seed = torch.rand((logical_programs, ), dtype=torch.float32, device="npu")
+    output = torch.empty_like(x)
+    gather_output = torch.empty((logical_programs * gather_block, ), dtype=torch.float16, device="npu")
+    scalar_output = torch.empty((logical_programs, ), dtype=torch.float32, device="npu")
+    report_path = tmp_path / "mixed_route_anchor_and_anchorless.json"
+    constexprs = {
+        "TILE_BLOCK": tile_block,
+        "TILE_LOOP_COUNT": tile_loop,
+        "GATHER_BLOCK": gather_block,
+        "SCALAR_ITERATIONS": iterations,
+    }
+    args = (x, y, table, idx, seed, output, gather_output, scalar_output)
+
+    def launch_mixed():
+        mixed_route_anchor_and_anchorless_kernel[(logical_programs, )](
+            *args, **constexprs, **_launch_options(report_path, logical_programs))
+
+    def launch_all_simd():
+        mixed_route_anchor_and_anchorless_kernel[(logical_programs, )](
+            *args, **constexprs, num_warps=4, compile_mode="simd")
+
+    def launch_all_simt():
+        mixed_route_anchor_and_anchorless_kernel[(logical_programs, )](
+            *args, **constexprs, num_warps=4, compile_mode="simt_only")
+
+    # Correctness of the mixed execution.
+    launch_mixed()
+    torch.testing.assert_close(output, x * y + 1.0, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(gather_output, table[idx.long()], rtol=1e-5, atol=1e-5)
+    reference = seed.clone()
+    for _ in range(iterations):
+        reference = reference * 1.0000001 + 1e-7
+    torch.testing.assert_close(scalar_output, reference, rtol=1e-3, atol=1e-3)
+
+    # The cost model must compute the mixed route as the cheapest candidate.
+    report = _load_route_report(report_path, "mixed_simd_simt")
+    routes = report["stage_model"]["routes"]
+    mixed = routes["mixed_simd_simt"]
+    assert mixed["legal"]
+    assert mixed["total_system_cycles"] < routes["all_simd"]["total_system_cycles"]
+    assert mixed["total_system_cycles"] < routes["all_simt_only"]["total_system_cycles"]
+
+    stages = report["stage_model"]["logical_stages"]
+    mixed_stages = mixed["stages"]
+    assert len(stages) == len(mixed_stages)
+    simt_indices = [
+        index for index, stage in enumerate(mixed_stages)
+        if stage["implementation"]["mode"] == "simt"
+    ]
+    anchored_indices = [
+        index for index in simt_indices if stages[index]["simt_anchor_indices"]
+    ]
+    anchorless_indices = [
+        index for index in simt_indices if not stages[index]["simt_anchor_indices"]
+    ]
+    assert anchored_indices, "mixed route selected no SIMT stage with a primitive anchor"
+    assert anchorless_indices, "mixed route selected no anchor-free SIMT stage"
+    for index in anchored_indices:
+        assert stages[index]["features"]["has_indirect_memory"]
+        assert mixed_stages[index]["implementation"]["materialization"] == "local_simt_scope_with_kernel_v1"
+    for index in anchorless_indices:
+        assert stages[index]["model"] == "loop_carried_recurrence"
+        assert stages[index]["local_simt_materializable"]
+        assert mixed_stages[index]["implementation"]["materialization"] == "local_simt_scope_with_kernel_v1"
+    assert report["materialized_simt_anchor_count"] >= 1
+    assert report["materialized_stage_owned_scope_count"] >= 1
+
+    # Every other stage (the contiguous tile loop and the AutoBlockify V1
+    # dispatch/loop control stages) stays on the SIMD side.
+    simd_tile_indices = [
+        index for index, stage in enumerate(stages)
+        if mixed_stages[index]["implementation"]["mode"] == "simd"
+        and stage["workload"]["store_bytes_per_iteration"] >= tile_block * 4
+    ]
+    assert simd_tile_indices, "the contiguous elementwise tile pass should stay SIMD"
+    for index, stage in enumerate(stages):
+        if index not in simt_indices:
+            assert mixed_stages[index]["implementation"]["mode"] == "simd"
+
+    # Measured performance: the mixed execution must beat both single-mode
+    # executions of the very same kernel.
+    mixed_us = _profile_median_us("mixed_route_anchor_and_anchorless/mixed", launch_mixed,
+                                   tmp_path / "profile_mixed")
+    all_simd_us = _profile_median_us("mixed_route_anchor_and_anchorless/all_simd", launch_all_simd,
+                                     tmp_path / "profile_all_simd")
+    all_simt_us = _profile_median_us("mixed_route_anchor_and_anchorless/all_simt", launch_all_simt,
+                                     tmp_path / "profile_all_simt")
+    baseline_us = min(all_simd_us, all_simt_us)
+    print(f"mixed_route_anchor_and_anchorless: mixed {mixed_us:.3f} us vs "
+          f"all_simd {all_simd_us:.3f} us, all_simt {all_simt_us:.3f} us")
+    assert mixed_us <= baseline_us * 1.05, (
+        f"mixed execution ({mixed_us:.3f} us) is not faster than the best "
+        f"single mode ({baseline_us:.3f} us)")
+
+
+@triton.jit
+def loop_body_split_stage_kernel(
+    x_ptr,
+    out_ptr,
+    BLOCK: tl.constexpr,
+    LOOP_COUNT: tl.constexpr,
+):
+    # Each program owns one contiguous (LOOP_COUNT + 1) * BLOCK region: the
+    # first BLOCK elements are a plain unit-stride tile pass, the remaining
+    # LOOP_COUNT * BLOCK elements are written by the loop below.
+    pid = tl.program_id(0)
+    region = pid * (BLOCK * (LOOP_COUNT + 1))
+    offs = region + tl.arange(0, BLOCK)
+    x = tl.load(x_ptr + offs)
+    tl.store(out_ptr + offs, x * 2.0 + 1.0)
+    # Independent structured loop: the induction value feeds addresses only
+    # (no algorithmic loop-carried dependency), so the loop must NOT be
+    # staged as a whole.  The shell has to remain a control-only Stage while
+    # the body's load/multiply/store become separate semantic roots that are
+    # partitioned, costed, and routed per iteration like any plain root.
+    base = region + BLOCK
+    for i in range(LOOP_COUNT):
+        loffs = base + i * BLOCK + tl.arange(0, BLOCK)
+        v = tl.load(x_ptr + loffs)
+        tl.store(out_ptr + loffs, v * 3.0 + 0.5)
+
+
+@simd_simt_910_95_only
+def test_costmodel_loop_body_split_stages(tmp_path):
+    logical_programs = _vector_core_count()
+    block = 2048
+    loop_count = 8
+    torch.manual_seed(4)
+    x = torch.randn((logical_programs * block * (loop_count + 1), ), dtype=torch.float32, device="npu")
+    output = torch.empty_like(x)
+    report_path = tmp_path / "loop_body_split_route.json"
+
+    def launch():
+        loop_body_split_stage_kernel[(logical_programs, )](
+            x,
+            output,
+            BLOCK=block,
+            LOOP_COUNT=loop_count,
+            **_launch_options(report_path, logical_programs),
+        )
+
+    launch()
+    x_blocks = x.view(logical_programs, loop_count + 1, block)
+    out_blocks = output.view(logical_programs, loop_count + 1, block)
+    torch.testing.assert_close(out_blocks[:, 0, :], x_blocks[:, 0, :] * 2.0 + 1.0, rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(out_blocks[:, 1:, :], x_blocks[:, 1:, :] * 3.0 + 0.5, rtol=1e-6, atol=1e-6)
+
+    report = json.loads(report_path.read_text())
+    assert report["stage_model"]["applied"]
+    stages = report["stage_model"]["logical_stages"]
+
+    # The independent loop's shell is staged separately and owns control
+    # overhead only: it must not carry the body's memory workload.
+    shells = [stage for stage in stages if stage["model"] == "independent_pipelined_loop"]
+    assert len(shells) == 1, f"expected one loop shell stage, got {[s['id'] for s in shells]}"
+    shell = shells[0]
+    assert shell["iteration_count"] == loop_count
+    assert shell["workload"]["load_bytes_per_iteration"] == 0
+    assert shell["workload"]["store_bytes_per_iteration"] == 0
+    assert shell["features"]["loop_backedge_count"] >= 1
+
+    # The body's memory work is staged outside the shell and charged once
+    # per loop iteration.
+    bodies = [
+        stage for stage in stages
+        if stage["iteration_count"] == loop_count
+        and stage["workload"]["store_bytes_per_iteration"] > 0
+    ]
+    assert bodies, "loop body memory work was not staged separately from the shell"
+    for body in bodies:
+        assert body["model"] != "independent_pipelined_loop"
+
+    # Store-traffic accounting: the staged per-program store traffic must
+    # equal the kernel's real store traffic (prologue once + body once per
+    # iteration), proving the body is costed per iteration while the shell
+    # does not double-charge body work.
+    total_store_bytes = sum(
+        stage["iteration_count"] * stage["workload"]["store_bytes_per_iteration"]
+        for stage in stages
+    )
+    assert total_store_bytes == (loop_count + 1) * block * 4

--- a/third_party/ascend/unittest/pytest_ut/test_simd_simt_costmodel_cases.py
+++ b/third_party/ascend/unittest/pytest_ut/test_simd_simt_costmodel_cases.py
@@ -643,7 +643,13 @@ def mixed_route_anchor_and_anchorless_kernel(
 
 
 @simd_simt_910_95_only
-def test_costmodel_mixed_route_anchor_and_anchorless(tmp_path):
+def test_costmodel_mixed_route_anchor_and_anchorless(tmp_path, monkeypatch):
+    # TRITON_ASCEND_COMPILE_MODE unconditionally overrides any explicit
+    # compile_mode kwarg (AscendOptions.__post_init__).  With it exported the
+    # all_simd/all_simt baseline launches below would silently compile as
+    # simd_simt too, and the measured baseline comparison would compare
+    # three identical mixed binaries.
+    monkeypatch.delenv("TRITON_ASCEND_COMPILE_MODE", raising=False)
     logical_programs = _vector_core_count()
     # The unified buffer frame must hold the tile buffers plus the gather's
     # double-buffered indices and gathered table: int16 indices and float16

--- a/third_party/ascend/unittest/pytest_ut/test_simd_simt_costmodel_cases.py
+++ b/third_party/ascend/unittest/pytest_ut/test_simd_simt_costmodel_cases.py
@@ -576,10 +576,7 @@ def test_costmodel_anchorless_mixed_stage_scope(tmp_path):
     stages = report["stage_model"]["logical_stages"]
     mixed = report["stage_model"]["routes"]["mixed_simd_simt"]
     assert mixed["legal"]
-    simt_indices = [
-        index for index, stage in enumerate(mixed["stages"])
-        if stage["implementation"]["mode"] == "simt"
-    ]
+    simt_indices = [index for index, stage in enumerate(mixed["stages"]) if stage["implementation"]["mode"] == "simt"]
     assert simt_indices, "mixed route selected no SIMT Stage"
     for index in simt_indices:
         implementation = mixed["stages"][index]["implementation"]
@@ -589,8 +586,7 @@ def test_costmodel_anchorless_mixed_stage_scope(tmp_path):
         assert stages[index]["simt_anchor_indices"] == []
         assert stages[index]["local_simt_materializable"]
     assert any(stages[index]["model"] == "loop_carried_recurrence"
-               for index in simt_indices), (
-        "the anchor-free scalar recurrence Stage should be the SIMT scope")
+               for index in simt_indices), ("the anchor-free scalar recurrence Stage should be the SIMT scope")
 
 
 @triton.jit
@@ -680,16 +676,16 @@ def test_costmodel_mixed_route_anchor_and_anchorless(tmp_path, monkeypatch):
     args = (x, y, table, idx, seed, output, gather_output, scalar_output)
 
     def launch_mixed():
-        mixed_route_anchor_and_anchorless_kernel[(logical_programs, )](
-            *args, **constexprs, **_launch_options(report_path, logical_programs))
+        mixed_route_anchor_and_anchorless_kernel[(logical_programs, )](*args, **constexprs,
+                                                                       **_launch_options(report_path, logical_programs))
 
     def launch_all_simd():
-        mixed_route_anchor_and_anchorless_kernel[(logical_programs, )](
-            *args, **constexprs, num_warps=4, compile_mode="simd")
+        mixed_route_anchor_and_anchorless_kernel[(logical_programs, )](*args, **constexprs, num_warps=4,
+                                                                       compile_mode="simd")
 
     def launch_all_simt():
-        mixed_route_anchor_and_anchorless_kernel[(logical_programs, )](
-            *args, **constexprs, num_warps=4, compile_mode="simt_only")
+        mixed_route_anchor_and_anchorless_kernel[(logical_programs, )](*args, **constexprs, num_warps=4,
+                                                                       compile_mode="simt_only")
 
     # Correctness of the mixed execution.
     launch_mixed()
@@ -711,16 +707,9 @@ def test_costmodel_mixed_route_anchor_and_anchorless(tmp_path, monkeypatch):
     stages = report["stage_model"]["logical_stages"]
     mixed_stages = mixed["stages"]
     assert len(stages) == len(mixed_stages)
-    simt_indices = [
-        index for index, stage in enumerate(mixed_stages)
-        if stage["implementation"]["mode"] == "simt"
-    ]
-    anchored_indices = [
-        index for index in simt_indices if stages[index]["simt_anchor_indices"]
-    ]
-    anchorless_indices = [
-        index for index in simt_indices if not stages[index]["simt_anchor_indices"]
-    ]
+    simt_indices = [index for index, stage in enumerate(mixed_stages) if stage["implementation"]["mode"] == "simt"]
+    anchored_indices = [index for index in simt_indices if stages[index]["simt_anchor_indices"]]
+    anchorless_indices = [index for index in simt_indices if not stages[index]["simt_anchor_indices"]]
     assert anchored_indices, "mixed route selected no SIMT stage with a primitive anchor"
     assert anchorless_indices, "mixed route selected no anchor-free SIMT stage"
     for index in anchored_indices:
@@ -736,8 +725,7 @@ def test_costmodel_mixed_route_anchor_and_anchorless(tmp_path, monkeypatch):
     # Every other stage (the contiguous tile loop and the AutoBlockify V1
     # dispatch/loop control stages) stays on the SIMD side.
     simd_tile_indices = [
-        index for index, stage in enumerate(stages)
-        if mixed_stages[index]["implementation"]["mode"] == "simd"
+        index for index, stage in enumerate(stages) if mixed_stages[index]["implementation"]["mode"] == "simd"
         and stage["workload"]["store_bytes_per_iteration"] >= tile_block * 4
     ]
     assert simd_tile_indices, "the contiguous elementwise tile pass should stay SIMD"
@@ -747,8 +735,7 @@ def test_costmodel_mixed_route_anchor_and_anchorless(tmp_path, monkeypatch):
 
     # Measured performance: the mixed execution must beat both single-mode
     # executions of the very same kernel.
-    mixed_us = _profile_median_us("mixed_route_anchor_and_anchorless/mixed", launch_mixed,
-                                   tmp_path / "profile_mixed")
+    mixed_us = _profile_median_us("mixed_route_anchor_and_anchorless/mixed", launch_mixed, tmp_path / "profile_mixed")
     all_simd_us = _profile_median_us("mixed_route_anchor_and_anchorless/all_simd", launch_all_simd,
                                      tmp_path / "profile_all_simd")
     all_simt_us = _profile_median_us("mixed_route_anchor_and_anchorless/all_simt", launch_all_simt,
@@ -756,9 +743,8 @@ def test_costmodel_mixed_route_anchor_and_anchorless(tmp_path, monkeypatch):
     baseline_us = min(all_simd_us, all_simt_us)
     print(f"mixed_route_anchor_and_anchorless: mixed {mixed_us:.3f} us vs "
           f"all_simd {all_simd_us:.3f} us, all_simt {all_simt_us:.3f} us")
-    assert mixed_us <= baseline_us * 1.05, (
-        f"mixed execution ({mixed_us:.3f} us) is not faster than the best "
-        f"single mode ({baseline_us:.3f} us)")
+    assert mixed_us <= baseline_us * 1.05, (f"mixed execution ({mixed_us:.3f} us) is not faster than the best "
+                                            f"single mode ({baseline_us:.3f} us)")
 
 
 @triton.jit
@@ -831,8 +817,7 @@ def test_costmodel_loop_body_split_stages(tmp_path):
     # per loop iteration.
     bodies = [
         stage for stage in stages
-        if stage["iteration_count"] == loop_count
-        and stage["workload"]["store_bytes_per_iteration"] > 0
+        if stage["iteration_count"] == loop_count and stage["workload"]["store_bytes_per_iteration"] > 0
     ]
     assert bodies, "loop body memory work was not staged separately from the shell"
     for body in bodies:
@@ -842,8 +827,6 @@ def test_costmodel_loop_body_split_stages(tmp_path):
     # equal the kernel's real store traffic (prologue once + body once per
     # iteration), proving the body is costed per iteration while the shell
     # does not double-charge body work.
-    total_store_bytes = sum(
-        stage["iteration_count"] * stage["workload"]["store_bytes_per_iteration"]
-        for stage in stages
-    )
+    total_store_bytes = sum(stage["iteration_count"] * stage["workload"]["store_bytes_per_iteration"]
+                            for stage in stages)
     assert total_store_bytes == (loop_count + 1) * block * 4


### PR DESCRIPTION
## 1. Scope

This document categorizes the changes introduced by the following commits:

```text
d245e1a9c  [sim_costmodel][log] trace cost model decisions
c0539ddd8  [sim_costmodel](feat) allow mixed route without anchors
05000517f  [sim_costmodel][stage] split independent loop bodies
4496403c3  [sim_costmodel][scan] model nested scan scopes and fallback safely
c712b2d1c  fix(costmodel): expand AutoBlockify V1 scf.execute_region
```

## 2. Change Categories

### 2.1 Feature Enhancements

These changes add capabilities that were not previously available.

1. CostModel decision logging. This is an independent change and may be removed after the feature becomes stable.
2. Mixed SIMD/SIMT routing for stages without anchors.
3. Fine-grained separation of independent loop shells and bodies into stages.

### 2.2 Bug Fixes

These changes correct incorrect decisions, inaccurate cost accounting, improper failures, and missing IR recognition in the existing flow.

1. The lowering capabilities of scan/cumsum were conflated across different routes.
2. Work outside a local scope in a mixed stage was incorrectly charged as SIMT work.
3. An all-SIMD cost decision could override a backend intrinsic route.
4. Valid but unsupported TTIR could cause the pass to fail directly.
5. Unsplittable hybrid stages could be rejected incorrectly, or their dot cost could be omitted.
6. The dynamic trip count of nested loops was incorrectly approximated using the maximum trip count.
7. AutoBlockify V1 `scf.execute_region` wrappers could hide the actual algorithm.

### 2.3 Relationship Between Features and Fixes

```text
Feature enhancements: expand what the CostModel can do
    │
    ├─ Logging: make the decision process observable
    ├─ Anchor-free materialization: expand the applicability of mixed routing
    └─ Loop-stage splitting: improve modeling granularity

Bug fixes: ensure both new and existing capabilities behave correctly
    │
    ├─ Determine whether each route is executable
    ├─ Account for the workload of each route correctly
    ├─ Preserve safe backend routes
    ├─ Fall back safely for recoverable cases
    └─ Recognize hybrid, nested-loop, and wrapper IR correctly
```

---

# Category 1: Feature Enhancements

## 3. Decision Logging

Related commit: `d245e1a9c`, with thread-safety and log-level fixes added by `4496403c3`.

### Problem

Previously, only the final selection result was visible. It was difficult to determine whether an issue came from anchor recognition, stage partitioning, workload accounting, cost evaluation, route legality, or final materialization.

### Solution

A centralized `CostModelLogger` was added:

- `COSTMODEL_LOG_LEVEL=0/off`: disable logging;
- `COSTMODEL_LOG_LEVEL=1`: print major stages, costs, routes, and IR;
- `COSTMODEL_LOG_LEVEL=2/verbose/debug`: additionally print internal call traces.

The main interfaces are:

- `CostModelTraceScope`: uses RAII to log function entry and exit;
- `costModelLog()`: prints normal decision information;
- `costModelDebug()`: prints detailed debugging information;
- `costModelLogIR()`: prints IR snapshots before and after analysis or materialization.

The final implementation stores trace depth per thread so that concurrent compilations do not interfere with one another.

### Result

Issues can now be located directly in recognition, partitioning, accounting, route selection, or materialization. Logging only improves observability: it is disabled by default and does not affect cost values or the selected execution mode.

### Before and After

| Before | After |
|---|---|
| Only the fact that `mixed` is unavailable is visible | The exact stage and rejection reason are visible |
| Temporary print statements must be added repeatedly | The full flow can be traced by setting `COSTMODEL_LOG_LEVEL` |
| Scoring IR and materialization IR are difficult to compare | IR snapshots from both phases can be printed directly |

```text
Before: result = mixed_simd_simt unavailable
After : stage_1 local_simt_materializable=false → mixed legal=false
```

---

## 4. Mixed Routing for Anchor-Free Stages

Related commit: `c0539ddd8`.

### Problem

The old mixed route depended on primitive anchors such as gather, atomic, and loaded-index memory operations. A kernel with zero anchors caused the mixed candidate to be disabled immediately.

However, an anchor-free kernel may still contain both SIMD-friendly bulk memory work and a SIMT-friendly scalar recurrence. Rejecting mixed routing solely because `anchors == 0` loses optimization opportunities.

### Solution

`SimtAnchorKind::StageOwnedScope` was introduced. Instead of requiring a special operation to act as an anchor, it wraps a contiguous range of roots owned by a stage into a local SIMT scope.

The key functions are:

- `isStageScopeWrappable()`: checks whether roots are in the same block, contiguous, and free of invalid structures;
- `buildStageOwnedScopeDescriptor()`: builds the stage-owned scope descriptor;
- `deriveStageOwnedScopes()`: derives local-SIMT materializability for anchor-free stages;
- `alignModuleStages()`: aligns stages between the scoring IR and materialization IR, ensuring that the range being scored is the same range being wrapped.

Live-out types and the scope ABI are also validated. If the range cannot be wrapped safely, only that local mixed implementation is disabled; the original IR is left unchanged.

### Result

The absence of primitive anchors no longer makes mixed routing unconditionally illegal. Safely wrappable computation, control-flow, and scalar-recurrence stages can participate in mixed routing, while stages that violate ABI or boundary constraints remain non-materializable.

### Before and After

```mlir
// Stage A: SIMD-friendly
%x = tt.load %x_ptr
%y = arith.mulf %x, %factor
tt.store %out_ptr, %y

// Stage B: no primitive anchor, but potentially SIMT-friendly
%r = scf.for %i = %c0 to %c4096 step %c1
    iter_args(%state = %seed) -> tensor<1xf32> {
  %next = arith.addf %state, %epsilon
  scf.yield %next
}
```

| Scenario | Before | After |
|---|---|---|
| `anchors=0` and the stage boundary is safe | Mixed routing is rejected immediately | A `StageOwnedScope` can be created |
| Stage A favors SIMD and Stage B favors SIMT | The entire kernel must use one mode | A can use SIMD while B uses local SIMT |
| Roots are non-contiguous or the live-out violates the ABI | Mixed routing is unavailable | It remains unavailable, and the IR is not forcibly rewritten |

Schematic materialization:

```mlir
// Before: the recurrence stage remains in normal TTIR and cannot use local
// SIMT independently.
%r = scf.for ... {
  %next = arith.addf %state, %epsilon
  scf.yield %next
}

// After: when mixed routing selects the stage, the same contiguous roots are
// wrapped in a scope.
scope.scope {
  %r = scf.for ... {
    %next = arith.addf %state, %epsilon
    scf.yield %next
  }
}
```

---

## 5. Fine-Grained Stages for Independent Loop Shells and Bodies

Related commit: `05000517f`.

### Problem

The old implementation generally treated an entire `scf.for` or `scf.while` as one indivisible semantic root. Loop control, address generation, loads, computation, and stores were therefore mixed into one stage.

This caused two problems: different resources could not select execution modes independently, and a loop shell that recursively owned its body could double-count body work.

### Solution

`isIndependentStructuredLoop()` determines whether a loop has a true cross-iteration data dependency:

- Address induction or memory-mask control only: iterations are algorithmically independent, so the loop can be split;
- A value produced by one iteration is consumed by the next: this is a true recurrence, so the loop remains an atomic stage.

For a splittable loop:

```text
scf.for
   ├─ loop shell: loop-control work
   └─ body roots: actual loads, computation, stores, and other work
```

`splitIndependentLoopBody` is propagated consistently through root collection, ownership, workload analysis, cost evaluation, and materialization. `ModuleStageRun` allows one scored stage to align with a contiguous run of supporting stages in the materialization IR.

### Result

Stage granularity changes from one whole loop to a control shell plus body-work stages. Control overhead and load/compute/store work are charged separately without double counting. Only loops with true recurrences remain atomic.

### Before and After

```mlir
scf.for %i = %c0 to %c8 step %c1 {
  %ptr = tt.addptr %base, %i
  %x = tt.load %ptr
  %y = arith.mulf %x, %c3
  tt.store %ptr, %y
}
```

| Before | After |
|---|---|
| One stage contains the shell, loads, computation, and stores | The shell and body are represented by separate stages |
| The shell may recursively account for body work | The shell has `load/store bytes = 0` |
| The body cannot select a route independently | The body participates independently in SIMD/SIMT scoring |

```text
Before: Stage A = shell + address + load + multiply + store
After : Stage A = shell, bytes=0
        Stage B = address + load + multiply + store, iteration_count=8
```

This primarily changes the CostModel's semantic-root and stage view; it does not rewrite the original loop IR in advance:

```text
Original IR: scf.for { address; load; multiply; store }

Roots before the change:
  root[0] = scf.for, recursively owning the entire body

Roots after the change:
  root[0] = scf.for shell
  root[1] = address/load/compute/store body
```

---

# Category 2: Bug Fixes

## 6. Fix Route-Specific Scan/Cumsum Capability Modeling

Related commit: `4496403c3`.

### Bug

`tt.scan/cumsum` has different lowering capabilities on different routes:

| Route | Current capability |
|---|---|
| Normal SIMD | Supported |
| Whole-kernel SIMT | Supported |
| Mixed local-SIMT scope | `vcumsum` legalization is unsupported |

The old code approximated all routes with one target Boolean. Whole-kernel SIMT support for cumsum could therefore be misinterpreted as local-SIMT-scope support.

### Fix

`SimtLoweringCapabilities` was introduced with separate fields for:

- `supportsLocalSimtScopes`;
- `supportsPlainCumsumSIMD`;
- `supportsPlainCumsumSIMTOnly`;
- `supportsPlainCumsumInLocalSIMTScope`.

Anchor recognition, route-specific lowering legality, and local-scope materializability no longer share one Boolean.

### Result

The three execution paths are checked independently. Scan can still use normal SIMD or whole-kernel SIMT, but mixed routing no longer creates a local scan scope that the backend cannot legalize. This prevents `vcumsum` lowering failures at the source.

### Before and After

| Route | Before | After |
|---|---|---|
| Whole-kernel SIMT | Shares one check with local scope | `supported` |
| Mixed local-SIMT | May be misclassified as supported | `unsupported` |
| Final result | May create an illegal `vcumsum` scope | `local_simt_materializable=false` |

Schematic IR comparison:

```mlir
%scan = "tt.scan"(%input) ({
^bb0(%lhs: f32, %rhs: f32):
  %sum = arith.addf %lhs, %rhs : f32
  "tt.scan.return"(%sum) : (f32) -> ()
}) {axis = 0 : i32} : (tensor<256xf32>) -> tensor<256xf32>
```

```text
Mixed plan before the fix:
  local SIMT scope = [tt.scan]
  → may produce vcumsum that cannot be legalized on this path

Mixed plan after the fix:
  residual SIMD    = [tt.scan]
  local SIMT scope = [] or another genuinely materializable anchor
```

---

## 7. Fix Over-Accounting of Mixed-Stage Workloads

Related commit: `4496403c3`.

### Bug

Only a small subset of anchor operations in a stage may actually enter a local SIMT scope, while the remaining operations stay in SIMD. The old model could charge the entire stage using the SIMT profile, making the mixed cost inconsistent with the materialized scope.

### Fix

The following fields were added to each stage:

- `localSimtOperations`: operations that actually enter the local scope;
- `localSimtWorkload`: workload contributed by those operations.

The cost is now calculated as:

```text
residual workload = total workload - localSimtWorkload

mixed cost = residual SIMD cost
           + local SIMT cost
           + switching/handoff cost
```

### Result

Scoring and materialization now cover the same range. Work that remains outside the scope is charged as SIMD, while work inside the scope is charged as SIMT. Comparisons between mixed, all-SIMD, and all-SIMT routes therefore become reliable.

### Before and After

Assume a stage has a total workload of 100 and only 20 units actually enter local SIMT:

| Before | After |
|---|---|
| `100 × SIMT cost` | `80 × SIMD cost + 20 × SIMT cost + scope overhead` |
| The SIMT accounting range is overstated | Only the real local workload is charged as SIMT |

Corresponding stage/IR ownership:

```text
Stage operations = [tt.scan, address, gather, add, store]
local scope      = [address, gather]

Before: SIMT workload = [tt.scan, address, gather, add, store]
After : SIMT workload = [address, gather]
        SIMD workload = [tt.scan, add, store]
```

---

## 8. Prevent All-SIMD Decisions from Overriding Backend Intrinsic Routes

Related commit: `4496403c3`.

### Bug

The cost-only result may favor all-SIMD even when scan, gather, or histogram depends on a backend-validated intrinsic route. Applying all-SIMD directly can change the backend lowering contract and lead to compilation or execution failures.

### Fix

`requiresBackendIntrinsicSimtRouting()` checks whether the kernel must preserve a backend intrinsic route. If the cost-only recommendation is all-SIMD but applying it would break that route, the final recommendation becomes `backend_default`.

The report distinguishes:

```text
cost_only_decision_kind
recommended_decision_kind
effective_decision_kind
application_reason
```

### Result

The cost-only result remains available for analysis, but the actual execution choice falls back to `backend_default`. A performance recommendation therefore cannot alter a backend intrinsic lowering path that must be preserved for correctness.

### Before and After

| Field | Before | After |
|---|---|---|
| Cost recommendation | `all_simd` | `all_simd`, retained for analysis |
| Effective execution | Apply `all_simd` directly | `backend_default` |
| Reason | Not stated explicitly | `backend_intrinsic_simt_required` |

The performance recommendation remains visible without being enforced at the expense of compilation correctness.

Module decision attributes:

```mlir
// Before: the cost-only result directly becomes the effective execution mode.
module attributes {
  ascend.effective_execution = "all_simd"
}

// After: retain the cost recommendation but use the safe backend route.
module attributes {
  ascend.effective_execution = "backend_default",
  ascend.selection_source = "backend_default"
}
```

---

## 9. Fall Back Safely When Valid TTIR Has No Supported Candidate

Related commit: `4496403c3`.

### Bug

Some TTIR is valid but temporarily outside the CostModel's modeling or materialization coverage. The old flow could treat this as an internal error and fail the entire pass.

### Fix

An explicit `UnsupportedCostModelIR` error type was introduced:

- If this error is caught, the IR is valid but unsupported by the model, so execution falls back to `backend_default`;
- Profile parsing failures, inconsistent internal state, and other errors still call `signalPassFailure()`.

### Result

“Unsupported by the model” is now distinguished from “the CostModel itself is broken.” The former continues through the default backend flow, while the latter still reports an error. This improves compilation success without hiding real defects.

### Before and After

| Case | Before | After |
|---|---|---|
| Valid TTIR with no materializable candidate | `pass failure` | `UnsupportedCostModelIR → backend_default` |
| Profile or internal invariant error | `pass failure` | Still a `pass failure` |

IR handling comparison:

```text
Input: valid TTIR containing a structure not yet covered by the CostModel

Before:
  analyzeSimdSimtCandidates() returns an error
  → signalPassFailure()
  → compilation stops

After:
  returns UnsupportedCostModelIR
  → IR remains unchanged
  → module is marked effective_execution="backend_default"
  → compilation continues through the original backend flow
```

In simple terms, work the CostModel cannot handle is passed back to the original backend, while genuine system errors are still reported.

---

## 10. Fix Rejection and Dot Under-Accounting in Unsplittable Hybrid Stages

Related commit: `4496403c3`.

### Bug

When a stage contained both `tt.dot` and a reduction, indirect memory access, or loop-carried recurrence, the old implementation returned `requires_split` immediately.

However, some dots are already part of the serial dependency chain and have no safe stage boundary at which they can be split. Requiring a split rejects a valid stage, while modeling only the reduction or recurrence can omit the dot cost.

### Fix

When no safe split exists, the stage is classified by its dominant serial structure, such as `LoopCarriedRecurrence`. Dot work is still included in the stage's critical path.

### Result

A valid stage without a safe split point can still be modeled. Dot work is included in the serial critical path, avoiding a new problem where analysis succeeds but the cost is underestimated.

### Before and After

| `Stage = recurrence + dot` | Before | After |
|---|---|---|
| Stage classification | `requires_split`, cannot continue | `model=recurrence` |
| Dot cost | No result, or the cost may be omitted | Included in the same `critical_path` |
| Final result | CostModel fails | Produces a complete, conservative cost |

IR/stage example:

```mlir
%state = scf.for ... iter_args(%acc = %init) -> tensor<...> {
  %dot = tt.dot %a, %b, %acc
  %next = arith.addf %dot, %bias
  scf.yield %next
}
```

```text
Before: features = {dot, loop_carried_recurrence} → requires_split
After : model = loop_carried_recurrence
        critical_path includes both recurrence and dot workload
```

In simple terms, when two kinds of work are already tied to the same serial pipeline, the model no longer tries to split them forcibly. Instead, it estimates the entire pipeline and includes all expensive work.

---

## 11. Fix Underestimated Execution Counts for Nested Independent Loops

Original related commit: `4496403c3`. In terms of responsibility, this is a loop-stage accounting fix.

### Bug

After a loop body was split into an independent stage, the number of dynamic entries for nested loops was approximated using the maximum trip count:

```text
max(outer, inner)
```

This significantly underestimated the actual number of inner-body executions.

### Fix

`enclosingSplitLoopTripCount()` now multiplies the trip counts of all enclosing independent loops. It checks for `int64_t` overflow before multiplication and uses a saturated value if overflow would occur.

### Result

Loads, stores, arithmetic work, and issue workload in the inner body are charged using the actual total execution count. This prevents underestimated work from incorrectly biasing route selection toward one mode.

### Before and After

For an outer loop with four iterations and an inner loop with eight iterations:

| Before | After |
|---|---|
| `max(4, 8) = 8` | `4 × 8 = 32` |
| The inner workload is charged only eight times | The inner workload is correctly charged 32 times |

Corresponding IR:

```mlir
scf.for %i = %c0 to %c4 step %c1 {
  scf.for %j = %c0 to %c8 step %c1 {
    %x = tt.load %ptr
    %y = arith.addf %x, %bias
    tt.store %out, %y
  }
}
```

```text
Before: inner body entry multiplicity = 8
After : inner body entry multiplicity = 4 × 8 = 32
```

---

## 12. Expose Semantic Roots Hidden by AutoBlockify V1 Wrappers

Related commit: `c712b2d1c`.

### Bug

When AutoBlockify V1 processes a multi-block function, it may generate the following operation inside a scheduling loop:

```mlir
scf.execute_region attributes {ta.auto_blockify_v1.schedule}
```

This operation is only a scheduling wrapper; it does not represent actual algorithmic work. The old root collector treated the wrapper itself as a semantic root, hiding the enclosed loads, stores, scans, dots, and other operations. The entire region could therefore be misclassified as `auto_blockify_dispatch`.

### Fix

`collectTopLevelSemanticRoots()` now collects roots recursively and transparently expands a wrapper only when all of the following conditions hold:

1. It is inside an AutoBlockify V1 loop;
2. The operation is `scf.execute_region`;
3. It has the `ta.auto_blockify_v1.schedule` attribute.

`getTopLevelSemanticRoot()` uses the same boundary rule. Normal `scf.execute_region` operations are not expanded, which limits the scope of the change.

### Result

The scheduling wrapper no longer masquerades as an algorithmic stage. Enclosed loads, scans, dots, and stores can participate independently in stage classification, workload analysis, anchor ownership, and route selection. Normal `scf.execute_region` operations are unaffected.

### Before and After

```mlir
scf.for ... attributes {ta.auto_blockify_v1.loop} {
  scf.execute_region attributes {ta.auto_blockify_v1.schedule} {
    %x = tt.load %ptr
    %sum = "tt.scan"(%x) ...
    tt.store %out, %sum
  }
}
```

| Before | After |
|---|---|
| `root[1] = scf.execute_region` | `root[1] = tt.load` |
| Algorithmic work inside the wrapper is invisible | `root[2] = tt.scan`, `root[3] = tt.store` |
| The region may be classified as one dispatch stage | Operations are classified and charged according to their actual work |

---

## 13. Overall Impact

Before these changes, the main issues were limited decision visibility, overly coarse stage granularity, conflated route capabilities, inaccurate workload ranges, and compilation failures when valid IR was outside the model's coverage.

The updated flow is:

```text
Expand scheduling wrappers and collect the actual semantic roots
                              │
                              ▼
Split independent loops and establish accurate stage boundaries
                              │
                              ▼
Check whether each stage is executable on each route
                              │
                              ▼
Charge only the workload inside a local scope as SIMT
                              │
                              ▼
Select a legal route with an appropriate cost
                              │
                    ┌─────────┴─────────┐
                    ▼                   ▼
          Materialize safely     Fall back to backend_default
```

The final effects are:

- Better observability: every decision can be explained;
- Broader optimization coverage: anchor-free stages and independent loop bodies can participate in fine-grained mixed routing;
- More accurate costs: loop trip counts, local workloads, and hybrid critical paths are neither omitted nor overstated;
- Safer execution: the model does not select local scopes that the backend cannot materialize;
- More robust compilation: valid IR outside the model's current coverage can fall back safely, while real internal errors remain visible.
