### PR TITLE
[Utils](fix) handle permuted strides in boundary sizes

### DIFF
--- a/third_party/ascend/lib/Utils/Utils.cpp
+++ b/third_party/ascend/lib/Utils/Utils.cpp
@@ -60,6 +60,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <functional>
 #include <limits>
 #include <map>
@@ -422,8 +423,24 @@ getBoundarySizes(llvm::ArrayRef<int32_t> boundaryCheck, Value ptr,
   OpFoldResult offsetShift = subOpFoldResult(
       curPtrOffset, fullShapeReCast.getConstifiedMixedOffset(), loc, rewriter);
 
-  for (int i = 0; i < shapedType.getRank(); ++i) {
-    OpFoldResult curStride = fullShapeReCast.getConstifiedMixedStrides()[i];
+  auto strides = fullShapeReCast.getConstifiedMixedStrides();
+  SmallVector<int> axisOrder;
+  axisOrder.reserve(shapedType.getRank());
+  for (int i = 0; i < shapedType.getRank(); ++i)
+    axisOrder.push_back(i);
+
+  bool allStridesConstant = llvm::all_of(strides, [](OpFoldResult stride) {
+    return getConstantIntValue(stride).has_value();
+  });
+  if (allStridesConstant) {
+    llvm::stable_sort(axisOrder, [&strides](int lhs, int rhs) {
+      return std::abs(*getConstantIntValue(strides[lhs])) >
+             std::abs(*getConstantIntValue(strides[rhs]));
+    });
+  }
+
+  for (int i : axisOrder) {
+    OpFoldResult curStride = strides[i];
     if (llvm::find(boundaryCheck, i) != boundaryCheck.end()) {
       if (isZero(curStride)) {
         emitWarning(loc)

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_make_block_ptr_boundary_size.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/test_make_block_ptr_boundary_size.mlir
@@ -7,7 +7,7 @@
 // `tl.make_block_ptr` is lowered to `tt.make_tensor_ptr` before
 // TritonToLinalg runs.  getBoundarySizes() reconstructs the per-axis
 // in-bounds size by decomposing the flat block offset with the full-shape
-// strides; two defects in that decomposition are covered here:
+// strides; three defects in that decomposition are covered here:
 //
 //  1. (primary) An axis that is *not* boundary-checked never reduced the
 //     flat offset (offset % stride), so a checked trailing axis saw the
@@ -19,6 +19,11 @@
 //     reached divOpFoldResult(offsetShift, 0), which emits "cannot div 0!"
 //     and returns an empty OpFoldResult, crashing the compiler.  The fix
 //     skips such axes (emitting a warning) and keeps the current block size.
+//
+//  3. Logical axis order need not be physical major-to-minor order.  For a
+//     permuted layout with strides [1, 800, 20], decomposing axes as [0, 1, 2]
+//     treats the entire linear offset as axis 0.  The fix visits axes in
+//     descending stride order [1, 2, 0].
 
 // The skipped zero-stride axis of the second case is reported through a
 // warning instead of the previous "cannot div 0!" error (the diagnostic
@@ -78,6 +83,38 @@ module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
     %data = tt.load %load_ptr {boundaryCheck = array<i32: 0, 1>} : !tt.ptr<tensor<16x32xf32>>
     %store_ptr = tt.make_tensor_ptr %out_ptr, [%c64_i64, %c60_i64], [%c64_i64, %c1_i64], [%c0_i32, %c36_i32] {order = array<i32: 1, 0>} : <tensor<16x32xf32>>
     tt.store %store_ptr, %data {boundaryCheck = array<i32: 1>} : !tt.ptr<tensor<16x32xf32>>
+    tt.return
+  }
+}
+
+// -----
+// Permuted layout: logical axes [0, 1, 2] have physical strides [1, 800, 20].
+// The block starts at logical offset [7, 18, 32] in shape [20, 30, 40].  Its
+// flat offset is 7 + 18*800 + 32*20 = 15047.  Decomposing in physical order
+// [1, 2, 0] recovers [18, 32, 7], which maps back to logical boundary sizes
+// [1, min(16, 30-18), min(64, 40-32)] = [1, 12, 8].
+
+// CHECK-LABEL: func.func @boundary_size_permuted_strides
+// CHECK: memref.subview {{.*}}[0, 0, 0] [1, 12, 8] [1, 1, 1]
+// CHECK: memref.copy
+module attributes {hacc.target = #hacc.target<"Ascend910B2">} {
+  tt.func public @boundary_size_permuted_strides(
+      %base_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+      %out_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}
+  ) attributes {noinline = false} {
+    %c1_i64 = arith.constant 1 : i64
+    %c7_i32 = arith.constant 7 : i32
+    %c18_i32 = arith.constant 18 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c20_i64 = arith.constant 20 : i64
+    %c30_i64 = arith.constant 30 : i64
+    %c40_i64 = arith.constant 40 : i64
+    %c800_i64 = arith.constant 800 : i64
+    %c1200_i64 = arith.constant 1200 : i64
+    %load_ptr = tt.make_tensor_ptr %base_ptr, [%c20_i64, %c30_i64, %c40_i64], [%c1_i64, %c800_i64, %c20_i64], [%c7_i32, %c18_i32, %c32_i32] {order = array<i32: 2, 1, 0>} : <tensor<1x16x64xf32>>
+    %data = tt.load %load_ptr {boundaryCheck = array<i32: 0, 1, 2>} : !tt.ptr<tensor<1x16x64xf32>>
+    %store_ptr = tt.make_tensor_ptr %out_ptr, [%c20_i64, %c30_i64, %c40_i64], [%c1200_i64, %c40_i64, %c1_i64], [%c7_i32, %c18_i32, %c32_i32] {order = array<i32: 2, 1, 0>} : <tensor<1x16x64xf32>>
+    tt.store %store_ptr, %data {boundaryCheck = array<i32: 0, 1, 2>} : !tt.ptr<tensor<1x16x64xf32>>
     tt.return
   }
 }

--- a/third_party/ascend/unittest/pytest_ut/test_make_block_ptr_boundary_size.py
+++ b/third_party/ascend/unittest/pytest_ut/test_make_block_ptr_boundary_size.py
@@ -19,13 +19,16 @@
 # SOFTWARE.
 """
 getBoundarySizes() reconstructs the per-axis in-bounds size by decomposing the
-flat block offset with the full-shape strides.  Two defects in that
+flat block offset with the full-shape strides.  Three defects in that
 decomposition are covered:
 
 an axis that is *not* boundary-checked used to leave its
 contribution in the flat offset, so a checked trailing axis computed its
 boundary from the un-reduced value and clipped it to 0, silently dropping
 the loaded/stored block;
+
+a permuted layout whose logical axis order differs from physical stride order
+must be decomposed in major-to-minor stride order.
 """
 
 import torch
@@ -62,6 +65,50 @@ def boundary_size_unchecked_axis_kernel(in_ptr, out_ptr, TOTAL_M, TOTAL_N, OFF_M
     tl.store(out, val, boundary_check=(1, ))
 
 
+@triton.jit
+def boundary_size_permuted_strides_kernel(in_ptr, out_ptr, size_0, size_1, size_2, BLOCK_0: tl.constexpr,
+                                          BLOCK_1: tl.constexpr, BLOCK_2: tl.constexpr):
+    """Copy a dynamically shaped, permuted tensor through block pointers.
+
+    The input's logical strides are [1, 800, 20], so its physical stride order
+    is [0, 2, 1].  Runtime shapes make the lowering exercise
+    getBoundarySizes()'s linear-offset reconstruction rather than replacing it
+    with the original per-axis offsets.
+    """
+    pid = tl.program_id(0)
+    num_tiles_1 = tl.cdiv(size_1, BLOCK_1)
+    num_tiles_2 = tl.cdiv(size_2, BLOCK_2)
+
+    tile_2 = pid % num_tiles_2
+    pid = pid // num_tiles_2
+    tile_1 = pid % num_tiles_1
+    tile_0 = pid // num_tiles_1
+
+    offset_0 = tile_0 * BLOCK_0
+    offset_1 = tile_1 * BLOCK_1
+    offset_2 = tile_2 * BLOCK_2
+
+    src = tl.make_block_ptr(
+        base=in_ptr,
+        shape=(size_0, size_1, size_2),
+        strides=(1, 800, 20),
+        offsets=(offset_0, offset_1, offset_2),
+        block_shape=(BLOCK_0, BLOCK_1, BLOCK_2),
+        order=(0, 2, 1),
+    )
+    value = tl.load(src, boundary_check=(0, 1, 2), padding_option="zero")
+
+    dst = tl.make_block_ptr(
+        base=out_ptr,
+        shape=(size_0, size_1, size_2),
+        strides=(1200, 40, 1),
+        offsets=(offset_0, offset_1, offset_2),
+        block_shape=(BLOCK_0, BLOCK_1, BLOCK_2),
+        order=(2, 1, 0),
+    )
+    tl.store(dst, value, boundary_check=(0, 1, 2))
+
+
 def _check_boundary(actual: torch.Tensor, expected: torch.Tensor, tag: str):
     torch.testing.assert_close(
         actual,
@@ -95,3 +142,32 @@ def test_boundary_size_unchecked_axis():
         x[OFF_M:OFF_M + BLOCK_M, OFF_N:TOTAL_N]
 
     _check_boundary(out_kernel, out_ref, "unchecked_axis")
+
+
+def test_boundary_size_permuted_strides():
+    shape = (20, 30, 40)
+    block_shape = (1, 16, 64)
+
+    # [30, 40, 20] contiguous has strides [800, 20, 1].  Moving its last
+    # axis to the front produces logical shape [20, 30, 40] and the target
+    # non-major-to-minor strides [1, 800, 20].
+    src = torch.arange(20 * 30 * 40, dtype=torch.float32, device="npu").reshape(30, 40, 20).permute(2, 0, 1)
+    assert src.shape == shape
+    assert src.stride() == (1, 800, 20)
+
+    actual = torch.zeros(shape, dtype=torch.float32, device="npu")
+    grid = (triton.cdiv(shape[0], block_shape[0]) * triton.cdiv(shape[1], block_shape[1]) *
+            triton.cdiv(shape[2], block_shape[2]), )
+    boundary_size_permuted_strides_kernel[grid](
+        src,
+        actual,
+        shape[0],
+        shape[1],
+        shape[2],
+        BLOCK_0=block_shape[0],
+        BLOCK_1=block_shape[1],
+        BLOCK_2=block_shape[2],
+    )
+    torch.npu.synchronize()
+
+    _check_boundary(actual, src, "permuted_strides")


### PR DESCRIPTION
## Summary

Fix incorrect `make_block_ptr` boundary-size calculation when logical axis order differs from physical memory order.

## Root cause

`getBoundarySizes()` reconstructs logical offsets from a flattened memref offset using division and remainder. Previously, it always processed axes in logical order.

For example:

```text
shape   = [20, 30, 40]
strides = [1, 800, 20]
offsets = [7, 18, 32]
```

The flattened offset is:

```text
L = 7 + 18 * 800 + 32 * 20 = 15047
```

Processing axis 0 first uses stride `1`:

```text
15047 / 1 = 15047
15047 % 1 = 0
```

This incorrectly consumes the entire offset and reconstructs offsets as
`[15047, 0, 0]`, producing boundary sizes `[0, 16, 40]`. A zero-sized first
axis can silently drop the whole block.

The correct physical major-to-minor order is determined by descending strides:

```text
800 -> 20 -> 1
axis 1 -> axis 2 -> axis 0
```

This correctly recovers offsets `[7, 18, 32]` and boundary sizes `[1, 12, 8]`.

## Fix

When all strides are compile-time constants, sort axes by descending absolute
stride before decomposing the flattened offset. The calculated sizes are still
written back to their original logical axes.