### PR TITLE
[compiler](chore) Rename enable-bishengir-simt-optimization option

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -1094,15 +1094,17 @@ class NPUOptions:
     is_pure_simt: bool = field(default=False, init=False)
     # Only takes effect on the pure-SIMT path.
     shared_mem_dynamic_size: int = None
-    # A5 pure-SIMT-only option passed as -enable-bishengir-simt-optimization
+    # A5 pure-SIMT-only option passed as -simt-optimization-mode
     # to bishengir-compile. Its value grammar belongs to the toolchain.
-    enable_bishengir_simt_optimization: int = 000
+    # Individual digits are passed to various passes to control behavior,
+    # and are parsed right-to-left.
+    # For example, a value of 101 is interpreted as 0000101.
+    # If left as 0, bishengir-compile sets this to 900101
+    simt_optimization_mode: int = 0000000
     # Canonical modes: SIMD (D), SIMD with template-SIMT (P), and pure-SIMT
     # (T). ``unstructured_in_simt`` is an equivalent P spelling.
     compile_mode: str = "simd_simt_template"
     simt_stack_limit: int = None
-    # take effect on the reorder instruction pattern for SIMT. The pattern is disabled by default.
-    enable_simt_reorder_instruction: bool = False
     # disable simt fma optimization to get high precision
     disable_fma: bool = False
 
@@ -1185,7 +1187,7 @@ def _is_internal_npu_options(options, target_arch: str) -> bool:
 
 def _normalize_bishengir_simt_optimization_for_context(options: NPUOptions, raw_options) -> None:
     """Restrict the vendor SIMT optimization switch to its A5 pure-SIMT path."""
-    option_name = "enable_bishengir_simt_optimization"
+    option_name = "simt_optimization_mode"
     if option_name not in raw_options:
         return
 
@@ -1195,7 +1197,7 @@ def _normalize_bishengir_simt_optimization_for_context(options: NPUOptions, raw_
         return
 
     warnings.warn(
-        "enable_bishengir_simt_optimization only takes effect for A5 "
+        "simt_optimization_mode only takes effect for A5 "
         "pure-SIMT compilation; ignoring the explicit value.",
         UserWarning,
         stacklevel=3,
@@ -1228,15 +1230,11 @@ def ttir_to_npubin(mod, metadata, opt):
             _compile_option_list += ["--pure-simt"]
             _compile_option_list += [f"--num-warps={opt.num_warps}"]
             _compile_option_list += [f"--threads-per-warp={opt.warp_size}"]
-            if opt.enable_bishengir_simt_optimization != 000:
-                _compile_option_list += [
-                    f"--enable-bishengir-simt-optimization={opt.enable_bishengir_simt_optimization}"
-                ]
+            if opt.simt_optimization_mode != 0000000:
+                _compile_option_list += [f"--simt-optimization-mode={opt.simt_optimization_mode}"]
             _compile_option_list += [f"--simt-stack-limit={get_simt_stack_limit(opt.simt_stack_limit)}"]
             if opt.shared_mem_dynamic_size is not None:
                 _compile_option_list += [f"--shared-mem-dynamic-size={opt.shared_mem_dynamic_size}"]
-            if opt.enable_simt_reorder_instruction:
-                _compile_option_list += ["--enable-simt-reorder-instruction=true"]
             if opt.disable_fma:
                 _compile_option_list += [f"--disable-fma"]
 

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -76,6 +76,7 @@ _DEPRECATED_NPU_OPTIONS = frozenset({
     "ops_reorder",
     "optimize_dynamic_offset",
     "parallel_mode",
+    "simt_reorder_instruction",
     "storage_align",
     "stream",
     "use_bytecode",
@@ -110,6 +111,7 @@ _DEPRECATED_NPU_OPTION_ALIASES = {
     "intra_cache_num": "buf_slot_num_of_veccore",
     "inter_cache_num": "buf_slot_num_of_crosscore",
     "load_cache_num": "buf_slot_num_of_gm",
+    "enable_bishengir_simt_optimization": "simt_optimization_mode",
 }
 
 # Removed no-op options keep using the compatibility path above.  This table
@@ -150,6 +152,8 @@ _DEPRECATED_NPU_OPTION_DETAILS = {
     "ops_reorder": "it is ignored; the removed vendor compiler control has no replacement.",
     "optimize_dynamic_offset": "it is ignored; the backend fixes dynamic-offset optimization to False.",
     "parallel_mode": "it is ignored; parallel mode is derived from compile_mode and Linalg IR.",
+    "simt_reorder_instruction":
+    "it is ignored; this option has been moved into the first digit of simt_optimization_mode.",
     "storage_align": "it is ignored; the removed vendor compiler control has no replacement.",
     "stream": "it is ignored; launch streams are managed by the runtime and driver.",
     "use_bytecode": "it is ignored; the bytecode pipeline is always enabled.",

--- a/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
@@ -288,20 +288,18 @@ def _make_opt(
     *,
     is_pure_simt,
     superblock_factor=0,
-    enable_bishengir_simt_optimization=0,
+    simt_optimization_mode=0,
     simt_stack_limit=None,
     shared_mem_dynamic_size=None,
-    enable_simt_reorder_instruction=False,
     disable_fma=False,
 ):
     return SimpleNamespace(
         is_pure_simt=is_pure_simt,
         num_warps=4,
         warp_size=32,
-        enable_bishengir_simt_optimization=enable_bishengir_simt_optimization,
+        simt_optimization_mode=simt_optimization_mode,
         simt_stack_limit=simt_stack_limit,
         shared_mem_dynamic_size=shared_mem_dynamic_size,
-        enable_simt_reorder_instruction=enable_simt_reorder_instruction,
         disable_fma=disable_fma,
         superblock_factor=superblock_factor,
     )
@@ -317,11 +315,10 @@ def _run_ttir_to_npubin(
     row_coalescing_applied=False,
     superblock_factor=0,
     common_options=(),
-    enable_bishengir_simt_optimization=0,
+    simt_optimization_mode=0,
     simt_stack_limit=None,
     resolved_simt_stack_limit=1152,
     shared_mem_dynamic_size=None,
-    enable_simt_reorder_instruction=False,
     disable_fma=False,
 ):
     events = []
@@ -380,10 +377,9 @@ def _run_ttir_to_npubin(
         _make_opt(
             is_pure_simt=is_pure_simt,
             superblock_factor=superblock_factor,
-            enable_bishengir_simt_optimization=enable_bishengir_simt_optimization,
+            simt_optimization_mode=simt_optimization_mode,
             simt_stack_limit=simt_stack_limit,
             shared_mem_dynamic_size=shared_mem_dynamic_size,
-            enable_simt_reorder_instruction=enable_simt_reorder_instruction,
             disable_fma=disable_fma,
         ),
     )
@@ -598,10 +594,9 @@ def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
         "--pure-simt",
         "--num-warps=4",
         "--threads-per-warp=32",
-        "--enable-bishengir-simt-optimization=17",
+        "--simt-optimization-mode=1000017",
         "--simt-stack-limit=64",
         "--shared-mem-dynamic-size=4096",
-        "--enable-simt-reorder-instruction=true",
         "--disable-fma",
     ]
     auto_blockify_flag = "--enable-auto-blockify-loop"
@@ -621,10 +616,9 @@ def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
                 row_coalescing_applied=row_applied,
                 superblock_factor=superblock,
                 common_options=common_options,
-                enable_bishengir_simt_optimization=17,
+                simt_optimization_mode=1000017,
                 resolved_simt_stack_limit=64,
                 shared_mem_dynamic_size=4096,
-                enable_simt_reorder_instruction=True,
                 disable_fma=True,
             )
 

--- a/third_party/ascend/unittest/pytest_ut/test_layout_memory_895_closure_differential.py
+++ b/third_party/ascend/unittest/pytest_ut/test_layout_memory_895_closure_differential.py
@@ -197,10 +197,9 @@ def _make_opt(
         is_pure_simt=True,
         num_warps=4,
         warp_size=32,
-        enable_bishengir_simt_optimization=17,
+        simt_optimization_mode=1000017,
         simt_stack_limit=64,
         shared_mem_dynamic_size=4096,
-        enable_simt_reorder_instruction=True,
         disable_fma=True,
         superblock_factor=superblock_factor,
     )
@@ -312,10 +311,9 @@ def test_895_pure_simt_bisheng_argv_matrix_after_row_make_ttir_migration(source_
         "--enable-global-scratch-allocation",
         "--num-warps=4",
         "--threads-per-warp=32",
-        "--enable-bishengir-simt-optimization=17",
+        "--simt-optimization-mode=1000017",
         "--simt-stack-limit=64",
         "--shared-mem-dynamic-size=4096",
-        "--enable-simt-reorder-instruction=true",
         "--disable-fma",
     ]
     cases = itertools.product((False, True),  # E: TRITON_ALL_BLOCKS_PARALLEL


### PR DESCRIPTION
# Rationale

In AscendNPU-IR, the enable-bishengir-simt-optimziation option has been renamed to simt-optimization-mode, and the simt-reorder-instruction option has been integrated into the simt-optimization-mode option. However, Triton Ascend currently still attempts to use the old options enable-bishengir-simt-optimization and simt-reorder-instruction. 

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- [x] This PR does not need a test because it refactors an option whose related test cases have been adjusted to match.

- [x] I have not added any `lit` tests.
