### PR TITLE
[ssbuffer](fix) sink i1 without control op

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/SinkI1ProducersIntoUsersPass.cpp
@@ -144,8 +144,7 @@ void SinkI1ProducersIntoUsersPass::runOnOperation() {
     // 1. Move into first consumer blockId
     int consumerBlockId = bm.getBlockIdByOp(orderedConsumuers[0]);
     if (consumerBlockId == -1) {
-      // if i1 break by one control op, couldn't change. //FIXME: wait for
-      // multi-region...
+      // if i1 break by one control op, couldn't change.
       LOG_DEBUG("First consumer's blockid is -1.\n");
       seenBlockIds.insert(bm.getBlockIdByOp(p));
       blockId2Producer.insert({bm.getBlockIdByOp(p), p});
@@ -163,6 +162,10 @@ void SinkI1ProducersIntoUsersPass::runOnOperation() {
     // 2. if there are other consumer, then clone producer.
     for (auto consumerInblock : orderedConsumuers) {
       int consumerBlockId = bm.getBlockIdByOp(consumerInblock);
+      if (consumerBlockId == -1) {
+        // if i1 break by one control op (scf.for/yield), couldn't change.
+        continue;
+      }
       if (!seenBlockIds.insert(consumerBlockId).second) {
         auto producer = blockId2Producer[consumerBlockId];
         for (auto info : llvm::enumerate(p->getResults())) {


### PR DESCRIPTION
fixbug: i1->if/for


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
