### PR TITLE
[Libdevice](fix) Remove redundant negative libdevice guards

### DIFF
--- a/third_party/ascend/language/cann/libdevice.py
+++ b/third_party/ascend/language/cann/libdevice.py
@@ -317,7 +317,7 @@ def ilogb(arg0, _semantic=None):
 
 @core.extern
 def logb(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.logb for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -348,7 +348,7 @@ def ldexp(arg0, arg1, _semantic=None):
 
 @core.extern
 def scalbn(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.scalbn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -443,7 +443,7 @@ def isnan(arg0, _semantic=None):
 
 @core.extern
 def clz(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.clz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -453,7 +453,7 @@ def clz(arg0, _semantic=None):
 
 @core.extern
 def popc(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.popc for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -463,7 +463,7 @@ def popc(arg0, _semantic=None):
 
 @core.extern
 def byte_perm(arg0, arg1, arg2, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.byte_perm for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1, arg2], {
@@ -473,7 +473,7 @@ def byte_perm(arg0, arg1, arg2, _semantic=None):
 
 @core.extern
 def mulhi(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         arg0 = _semantic.to_tensor(arg0)
         arg1 = _semantic.to_tensor(arg1)
         if arg0.dtype == core.uint32 and arg1.dtype == arg0.dtype:
@@ -489,7 +489,7 @@ def mulhi(arg0, arg1, _semantic=None):
 
 @core.extern
 def mul24(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.mul24 for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise(
@@ -501,7 +501,7 @@ def mul24(arg0, arg1, _semantic=None):
 
 @core.extern
 def brev(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.brev for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -511,7 +511,7 @@ def brev(arg0, _semantic=None):
 
 @core.extern
 def sad(arg0, arg1, arg2, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.sad for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise(
@@ -538,7 +538,7 @@ def ffs(arg0, _semantic=None):
 
 @core.extern
 def saturatef(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.saturatef for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -548,7 +548,7 @@ def saturatef(arg0, _semantic=None):
 
 @core.extern
 def hadd(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.hadd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise(
@@ -560,7 +560,7 @@ def hadd(arg0, arg1, _semantic=None):
 
 @core.extern
 def rhadd(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.rhadd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise(
@@ -572,7 +572,7 @@ def rhadd(arg0, arg1, _semantic=None):
 
 @core.extern
 def fdim(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fdim for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -582,7 +582,7 @@ def fdim(arg0, arg1, _semantic=None):
 
 @core.extern
 def exp10(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.exp10 for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -592,7 +592,7 @@ def exp10(arg0, _semantic=None):
 
 @core.extern
 def add_rn(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.add_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -602,7 +602,7 @@ def add_rn(arg0, arg1, _semantic=None):
 
 @core.extern
 def add_rz(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.add_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -612,7 +612,7 @@ def add_rz(arg0, arg1, _semantic=None):
 
 @core.extern
 def add_rd(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.add_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -622,7 +622,7 @@ def add_rd(arg0, arg1, _semantic=None):
 
 @core.extern
 def add_ru(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.add_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -632,7 +632,7 @@ def add_ru(arg0, arg1, _semantic=None):
 
 @core.extern
 def sub_rn(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.sub_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -642,7 +642,7 @@ def sub_rn(arg0, arg1, _semantic=None):
 
 @core.extern
 def sub_rz(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.sub_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -652,7 +652,7 @@ def sub_rz(arg0, arg1, _semantic=None):
 
 @core.extern
 def sub_rd(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.sub_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -662,7 +662,7 @@ def sub_rd(arg0, arg1, _semantic=None):
 
 @core.extern
 def sub_ru(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.sub_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -672,7 +672,7 @@ def sub_ru(arg0, arg1, _semantic=None):
 
 @core.extern
 def mul_rn(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.mul_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -682,7 +682,7 @@ def mul_rn(arg0, arg1, _semantic=None):
 
 @core.extern
 def mul_rz(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.mul_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -692,7 +692,7 @@ def mul_rz(arg0, arg1, _semantic=None):
 
 @core.extern
 def mul_ru(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.mul_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -702,7 +702,7 @@ def mul_ru(arg0, arg1, _semantic=None):
 
 @core.extern
 def mul_rd(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.mul_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -712,7 +712,7 @@ def mul_rd(arg0, arg1, _semantic=None):
 
 @core.extern
 def div_rd(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.div_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -722,7 +722,7 @@ def div_rd(arg0, arg1, _semantic=None):
 
 @core.extern
 def div_ru(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.div_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -740,7 +740,7 @@ def div_rz(arg0, arg1, _semantic=None):
     :param arg1: The divisor tensor. Supported dtype: fp32.
     :type arg1: tl.tensor
     """
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         arg0 = _semantic.to_tensor(arg0)
         arg1 = _semantic.to_tensor(arg1)
         ret = _semantic.fdiv(arg0, arg1, False)
@@ -752,7 +752,7 @@ def div_rz(arg0, arg1, _semantic=None):
 
 @core.extern
 def rcp_rn(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.rcp_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -762,7 +762,7 @@ def rcp_rn(arg0, _semantic=None):
 
 @core.extern
 def rcp_rz(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.rcp_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -772,7 +772,7 @@ def rcp_rz(arg0, _semantic=None):
 
 @core.extern
 def rcp_rd(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.rcp_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -782,7 +782,7 @@ def rcp_rd(arg0, _semantic=None):
 
 @core.extern
 def rcp_ru(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.rcp_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -804,7 +804,7 @@ def sqrt_rn(arg0, _semantic=None):
 
 @core.extern
 def sqrt_rz(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.sqrt_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -814,7 +814,7 @@ def sqrt_rz(arg0, _semantic=None):
 
 @core.extern
 def sqrt_rd(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.sqrt_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -824,7 +824,7 @@ def sqrt_rd(arg0, _semantic=None):
 
 @core.extern
 def sqrt_ru(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.sqrt_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -834,7 +834,7 @@ def sqrt_ru(arg0, _semantic=None):
 
 @core.extern
 def rsqrt_rn(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.rsqrt_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -844,7 +844,7 @@ def rsqrt_rn(arg0, _semantic=None):
 
 @core.extern
 def fma_rn(arg0, arg1, arg2, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fma_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1, arg2], {
@@ -854,7 +854,7 @@ def fma_rn(arg0, arg1, arg2, _semantic=None):
 
 @core.extern
 def fma_rz(arg0, arg1, arg2, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fma_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1, arg2], {
@@ -864,7 +864,7 @@ def fma_rz(arg0, arg1, arg2, _semantic=None):
 
 @core.extern
 def fma_rd(arg0, arg1, arg2, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fma_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1, arg2], {
@@ -874,7 +874,7 @@ def fma_rd(arg0, arg1, arg2, _semantic=None):
 
 @core.extern
 def fma_ru(arg0, arg1, arg2, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fma_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1, arg2], {
@@ -921,7 +921,7 @@ def fast_expf(arg0, _semantic=None):
 
 @core.builtin
 def fast_exp10f(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fast_exp10f for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -931,7 +931,7 @@ def fast_exp10f(arg0, _semantic=None):
 
 @core.builtin
 def fast_sinf(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fast_sinf for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -941,7 +941,7 @@ def fast_sinf(arg0, _semantic=None):
 
 @core.builtin
 def fast_cosf(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fast_cosf for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -951,7 +951,7 @@ def fast_cosf(arg0, _semantic=None):
 
 @core.builtin
 def fast_tanf(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fast_tanf for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -961,7 +961,7 @@ def fast_tanf(arg0, _semantic=None):
 
 @core.builtin
 def fast_tanhf(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fast_tanhf for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -971,7 +971,7 @@ def fast_tanhf(arg0, _semantic=None):
 
 @core.builtin
 def fast_log2f(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fast_log2f for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -981,7 +981,7 @@ def fast_log2f(arg0, _semantic=None):
 
 @core.builtin
 def fast_logf(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fast_logf for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -991,7 +991,7 @@ def fast_logf(arg0, _semantic=None):
 
 @core.builtin
 def fast_log10f(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fast_log10f for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1001,7 +1001,7 @@ def fast_log10f(arg0, _semantic=None):
 
 @core.builtin
 def fast_powf(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.fast_powf for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -1019,7 +1019,7 @@ def fmod(arg0, arg1, _semantic=None):
     :param arg1: The divisor tensor. Supported dtype: fp32.
     :type arg1: tl.tensor
     """
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         arg0 = _semantic.to_tensor(arg0)
         arg1 = _semantic.to_tensor(arg1)
         ret = _semantic.mod(arg0, arg1)
@@ -1031,7 +1031,7 @@ def fmod(arg0, arg1, _semantic=None):
 
 @core.extern
 def remainder(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.remainder for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -1047,7 +1047,7 @@ def float_as_int(arg0, _semantic=None):
     :param arg0: The input tensor. Supported dtype: fp32.
     :type arg0: tl.tensor
     """
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float_as_int for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1057,7 +1057,7 @@ def float_as_int(arg0, _semantic=None):
 
 @core.extern
 def int_as_float(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.int_as_float for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1067,7 +1067,7 @@ def int_as_float(arg0, _semantic=None):
 
 @core.extern
 def float_as_uint(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float_as_uint for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1077,7 +1077,7 @@ def float_as_uint(arg0, _semantic=None):
 
 @core.extern
 def uint_as_float(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.uint_as_float for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1087,7 +1087,7 @@ def uint_as_float(arg0, _semantic=None):
 
 @core.extern
 def float2int_rn(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2int_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1097,7 +1097,7 @@ def float2int_rn(arg0, _semantic=None):
 
 @core.extern
 def float2int_rz(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2int_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1107,7 +1107,7 @@ def float2int_rz(arg0, _semantic=None):
 
 @core.extern
 def float2int_rd(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2int_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1117,7 +1117,7 @@ def float2int_rd(arg0, _semantic=None):
 
 @core.extern
 def float2int_ru(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2int_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1127,7 +1127,7 @@ def float2int_ru(arg0, _semantic=None):
 
 @core.extern
 def int2float_rn(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.int2float_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1137,7 +1137,7 @@ def int2float_rn(arg0, _semantic=None):
 
 @core.extern
 def int2float_rz(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.int2float_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1147,7 +1147,7 @@ def int2float_rz(arg0, _semantic=None):
 
 @core.extern
 def int2float_rd(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.int2float_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1157,7 +1157,7 @@ def int2float_rd(arg0, _semantic=None):
 
 @core.extern
 def int2float_ru(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.int2float_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1167,7 +1167,7 @@ def int2float_ru(arg0, _semantic=None):
 
 @core.extern
 def float2uint_rn(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2uint_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1177,7 +1177,7 @@ def float2uint_rn(arg0, _semantic=None):
 
 @core.extern
 def float2uint_rz(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2uint_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1187,7 +1187,7 @@ def float2uint_rz(arg0, _semantic=None):
 
 @core.extern
 def float2uint_rd(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2uint_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1197,7 +1197,7 @@ def float2uint_rd(arg0, _semantic=None):
 
 @core.extern
 def float2uint_ru(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2uint_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1207,7 +1207,7 @@ def float2uint_ru(arg0, _semantic=None):
 
 @core.extern
 def uint2float_rn(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.uint2float_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1217,7 +1217,7 @@ def uint2float_rn(arg0, _semantic=None):
 
 @core.extern
 def uint2float_rz(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.uint2float_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1227,7 +1227,7 @@ def uint2float_rz(arg0, _semantic=None):
 
 @core.extern
 def uint2float_rd(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.uint2float_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1237,7 +1237,7 @@ def uint2float_rd(arg0, _semantic=None):
 
 @core.extern
 def uint2float_ru(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.uint2float_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1247,7 +1247,7 @@ def uint2float_ru(arg0, _semantic=None):
 
 @core.extern
 def float2ll_rn(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2ll_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1257,7 +1257,7 @@ def float2ll_rn(arg0, _semantic=None):
 
 @core.extern
 def float2ll_rz(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2ll_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1267,7 +1267,7 @@ def float2ll_rz(arg0, _semantic=None):
 
 @core.extern
 def float2ll_rd(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2ll_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1277,7 +1277,7 @@ def float2ll_rd(arg0, _semantic=None):
 
 @core.extern
 def float2ll_ru(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2ll_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1287,7 +1287,7 @@ def float2ll_ru(arg0, _semantic=None):
 
 @core.extern
 def ll2float_rn(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.ll2float_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1297,7 +1297,7 @@ def ll2float_rn(arg0, _semantic=None):
 
 @core.extern
 def ll2float_rz(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.ll2float_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1307,7 +1307,7 @@ def ll2float_rz(arg0, _semantic=None):
 
 @core.extern
 def ll2float_rd(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.ll2float_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1317,7 +1317,7 @@ def ll2float_rd(arg0, _semantic=None):
 
 @core.extern
 def ll2float_ru(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.ll2float_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1327,7 +1327,7 @@ def ll2float_ru(arg0, _semantic=None):
 
 @core.extern
 def float2ull_rn(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2ull_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1337,7 +1337,7 @@ def float2ull_rn(arg0, _semantic=None):
 
 @core.extern
 def float2ull_rz(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2ull_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1347,7 +1347,7 @@ def float2ull_rz(arg0, _semantic=None):
 
 @core.extern
 def float2ull_rd(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2ull_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1357,7 +1357,7 @@ def float2ull_rd(arg0, _semantic=None):
 
 @core.extern
 def float2ull_ru(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2ull_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1367,7 +1367,7 @@ def float2ull_ru(arg0, _semantic=None):
 
 @core.extern
 def ull2float_rn(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.ull2float_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1377,7 +1377,7 @@ def ull2float_rn(arg0, _semantic=None):
 
 @core.extern
 def ull2float_rz(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.ull2float_rz for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1387,7 +1387,7 @@ def ull2float_rz(arg0, _semantic=None):
 
 @core.extern
 def ull2float_rd(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.ull2float_rd for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1397,7 +1397,7 @@ def ull2float_rd(arg0, _semantic=None):
 
 @core.extern
 def ull2float_ru(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.ull2float_ru for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1816,7 +1816,7 @@ def hypot(arg0: core.tensor, arg1: core.tensor, _semantic=None):
 
 @core.extern
 def cbrt(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.cbrt for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1826,7 +1826,7 @@ def cbrt(arg0, _semantic=None):
 
 @core.extern
 def rcbrt(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.rcbrt for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1836,7 +1836,7 @@ def rcbrt(arg0, _semantic=None):
 
 @core.extern
 def rhypot(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.rhypot for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -1846,7 +1846,7 @@ def rhypot(arg0, arg1, _semantic=None):
 
 @core.extern
 def norm3d(arg0, arg1, arg2, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.norm3d for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1, arg2], {
@@ -1856,7 +1856,7 @@ def norm3d(arg0, arg1, arg2, _semantic=None):
 
 @core.extern
 def rnorm3d(arg0, arg1, arg2, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.rnorm3d for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1, arg2], {
@@ -1866,7 +1866,7 @@ def rnorm3d(arg0, arg1, arg2, _semantic=None):
 
 @core.extern
 def norm4d(arg0, arg1, arg2, arg3, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.norm4d for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise(
@@ -1878,7 +1878,7 @@ def norm4d(arg0, arg1, arg2, arg3, _semantic=None):
 
 @core.extern
 def rnorm4d(arg0, arg1, arg2, arg3, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.rnorm4d for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise(
@@ -1890,7 +1890,7 @@ def rnorm4d(arg0, arg1, arg2, arg3, _semantic=None):
 
 @core.extern
 def j0(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.j0 for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1900,7 +1900,7 @@ def j0(arg0, _semantic=None):
 
 @core.extern
 def j1(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.j1 for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1910,7 +1910,7 @@ def j1(arg0, _semantic=None):
 
 @core.extern
 def jn(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.jn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -1920,7 +1920,7 @@ def jn(arg0, arg1, _semantic=None):
 
 @core.extern
 def y0(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.y0 for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1930,7 +1930,7 @@ def y0(arg0, _semantic=None):
 
 @core.extern
 def y1(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.y1 for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -1940,7 +1940,7 @@ def y1(arg0, _semantic=None):
 
 @core.extern
 def yn(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.yn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0, arg1], {
@@ -2063,7 +2063,7 @@ def cyl_bessel_i0(arg0: core.tensor, _semantic=None):
 
 @core.extern
 def cyl_bessel_i1(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.cyl_bessel_i1 for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -2120,7 +2120,7 @@ def erf(arg0, _semantic=None):
 
 @core.extern
 def erfc(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.erfc for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -2130,7 +2130,7 @@ def erfc(arg0, _semantic=None):
 
 @core.extern
 def erfcx(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.erfcx for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -2140,7 +2140,7 @@ def erfcx(arg0, _semantic=None):
 
 @core.extern
 def erfcinv(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.erfcxinv for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -2268,7 +2268,7 @@ def erfinv(arg0, _semantic=None):
 
 @core.extern
 def normcdf(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.normcdf for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -2278,7 +2278,7 @@ def normcdf(arg0, _semantic=None):
 
 @core.extern
 def normcdfinv(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.normcdfinv for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -2354,7 +2354,7 @@ def gamma(arg0, _semantic=None):
 
 @core.extern
 def tgamma(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.tgamma for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -2460,7 +2460,7 @@ def nearbyint(arg0: core.tensor, _semantic=None):
 
 @core.extern
 def sinpi(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.sinpi for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -2470,7 +2470,7 @@ def sinpi(arg0, _semantic=None):
 
 @core.extern
 def cospi(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.cospi for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -2631,7 +2631,7 @@ def rint(arg0: core.tensor, _semantic=None):
 
 @core.extern
 def llrint(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.llrint for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -2641,7 +2641,7 @@ def llrint(arg0, _semantic=None):
 
 @core.extern
 def llround(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.llround for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -2745,18 +2745,8 @@ def exp2(arg0, _semantic=None):
 
 
 @core.extern
-def fast_exp2f(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
-        core.static_print("libdevice.fast_exp2f for simd is unsupported for now.")
-        core.static_assert(False)
-    return core.extern_elementwise("", "", [arg0], {
-        (core.dtype("fp32"), ): ("__hmf_fast_exp2_fp32", core.dtype("fp32")),
-    }, is_pure=True, _semantic=_semantic)
-
-
-@core.extern
 def float2half_rn(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.float2half_rn for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -2794,7 +2784,7 @@ def fma(arg0, arg1, arg2, _semantic=None):
 
 @core.extern
 def max(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.max for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise(
@@ -2806,7 +2796,7 @@ def max(arg0, arg1, _semantic=None):
 
 @core.extern
 def min(arg0, arg1, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.min for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise(
@@ -2818,7 +2808,7 @@ def min(arg0, arg1, _semantic=None):
 
 @core.extern
 def half2float(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.half2float for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {
@@ -2852,7 +2842,7 @@ def log2(arg0, _semantic=None):
 
 @core.extern
 def nan(arg0, _semantic=None):
-    if not _is_libdevice_simt_enabled(_semantic):
+    if not _is_a5_target(_semantic):
         core.static_print("libdevice.nan for simd is unsupported for now.")
         core.static_assert(False)
     return core.extern_elementwise("", "", [arg0], {


### PR DESCRIPTION
Replace "_is_libdevice_simt_enabled" condition with "_is_a5_target"