### PR TITLE
[costmodel](fix) Scan op in loopCarriedRecurrence applies factor

### DIFF
--- a/third_party/ascend/costmodel/include/AscendModel/RouteModel/StageRouteCostModel.h
+++ b/third_party/ascend/costmodel/include/AscendModel/RouteModel/StageRouteCostModel.h
@@ -90,6 +90,10 @@ struct StageWorkload {
   double storeWarpInstructions = 0.0;
   double predicateElements = 0.0;
   double shuffleLaneSteps = 0.0;
+  /// Portion of shuffleLaneSteps contributed by tt.scan (prefix-scan class).
+  /// The remainder is contributed by tt.reduce.  Only the scan portion
+  /// consumes the prefix-scan dependency factor inside recurrence stages.
+  double scanShuffleLaneSteps = 0.0;
   double dotFlops = 0.0;
   double issueElements = 0.0;
   double estimatedSpillTransactions = 0.0;
@@ -110,6 +114,8 @@ struct StageResourceCycles {
   double compute = 0.0;
   double predicate = 0.0;
   double shuffle = 0.0;
+  /// Cycles for the tt.scan-contributed portion of shuffle at the ideal rate.
+  double scanShuffle = 0.0;
   double dot = 0.0;
   double loopControl = 0.0;
   double branchControl = 0.0;

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
@@ -165,7 +165,7 @@ static void accumulateDotWorkload(Operation *operation, StageWorkload &work) {
 }
 
 static void accumulateReductionWorkload(Operation *operation,
-                                        StageWorkload &work) {
+                                        StageWorkload &work, bool isScan) {
   if (operation->getNumOperands() == 0)
     return;
   auto input = dyn_cast<ShapedType>(operation->getOperand(0).getType());
@@ -181,7 +181,10 @@ static void accumulateReductionWorkload(Operation *operation,
   if (extent <= 1)
     return;
   const double depth = std::ceil(std::log2(static_cast<double>(extent)));
-  work.shuffleLaneSteps += getTypeElementCount(input) * depth;
+  const double steps = getTypeElementCount(input) * depth;
+  work.shuffleLaneSteps += steps;
+  if (isScan)
+    work.scanShuffleLaneSteps += steps;
 }
 
 static void accumulateOneOperation(Operation *operation, StageWorkload &work) {
@@ -210,7 +213,7 @@ static void accumulateOneOperation(Operation *operation, StageWorkload &work) {
     return;
   }
   if (name == "tt.reduce" || name == "tt.scan")
-    accumulateReductionWorkload(operation, work);
+    accumulateReductionWorkload(operation, work, name == "tt.scan");
   if (name == "arith.cmpi" || name == "arith.cmpf") {
     work.predicateElements += elements;
     return;
@@ -235,6 +238,7 @@ static void scaleWorkload(StageWorkload &work, double scale) {
   work.storeWarpInstructions *= scale;
   work.predicateElements *= scale;
   work.shuffleLaneSteps *= scale;
+  work.scanShuffleLaneSteps *= scale;
   work.dotFlops *= scale;
   work.estimatedSpillTransactions *= scale;
   for (auto &entry : work.operationElements)
@@ -323,6 +327,7 @@ static void mergeWorkload(StageWorkload &into, StageWorkload from) {
   into.storeWarpInstructions += from.storeWarpInstructions;
   into.predicateElements += from.predicateElements;
   into.shuffleLaneSteps += from.shuffleLaneSteps;
+  into.scanShuffleLaneSteps += from.scanShuffleLaneSteps;
   into.dotFlops += from.dotFlops;
   into.estimatedSpillTransactions += from.estimatedSpillTransactions;
   for (const auto &[name, elements] : from.operationElements)

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageCostModels.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageCostModels.cpp
@@ -122,6 +122,8 @@ static StageResourceCycles mapWorkload(const LogicalStage &stage,
             : work.predicateElements) /
       profile.predicateOperationsPerCycle;
   resources.shuffle = work.shuffleLaneSteps / profile.shuffleLanesPerCycle;
+  resources.scanShuffle =
+      work.scanShuffleLaneSteps / profile.shuffleLanesPerCycle;
   if (work.dotFlops > 0.0) {
     resources.setup += profile.dotSetupCycles;
     resources.dot = work.dotFlops / profile.dotFlopsPerCycle;
@@ -233,11 +235,29 @@ static double estimateStage(const LogicalStage &stage,
                   r.spill);
     return serial;
   case StageCostModelKind::LoopCarriedRecurrence: {
-    const double critical = r.criticalPath > 0.0
-                                ? std::max(r.criticalPath + r.load + r.store +
-                                               controlBody(r) + r.spill,
-                                           r.issue)
-                                : serialBody(r);
+    // A prefix scan nested inside a recurrence keeps its lane dependency
+    // chain: each scan level must complete before the next starts, so the
+    // scan's shuffle traffic cannot reach the ideal vector throughput.
+    // Scale only the tt.scan-contributed portion of the shuffle critical
+    // path with the same mode-specific dependency factor the standalone
+    // PrefixScan model uses (identity for SIMT).  tt.reduce-contributed
+    // shuffle keeps the ideal rate: tree reductions halve their active
+    // lanes per level, so the N*log2(N) lane-step billing already carries
+    // enough slack to absorb per-level inefficiency.
+    double critical = r.criticalPath > 0.0
+                          ? std::max(r.criticalPath + r.load + r.store +
+                                         controlBody(r) + r.spill,
+                                     r.issue)
+                          : serialBody(r);
+    if (r.criticalPath > 0.0 && stage.features.hasPrefixScan) {
+      const double dependencyFactor =
+          mode == StageMode::SIMD ? profile.simd.prefixScanDependencyFactor
+                                  : profile.simt.prefixScanDependencyFactor;
+      critical =
+          std::max(r.criticalPath + (dependencyFactor - 1.0) * r.scanShuffle +
+                       r.load + r.store + controlBody(r) + r.spill,
+                   r.issue);
+    }
     if (mode == StageMode::SIMD) {
       // A loop-carried tensor is not ordinary embarrassingly-parallel vector
       // work: the updated state must remain live until the next recurrence

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageRouteCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageRouteCostModel.cpp
@@ -157,13 +157,14 @@ bool StageModelFeatures::permitsSimdRoofline() const {
 }
 
 bool StageWorkload::isFiniteAndNonNegative() const {
-  const std::array<double, 10> values = {scalarOperations,
+  const std::array<double, 11> values = {scalarOperations,
                                          loadBytes,
                                          storeBytes,
                                          loadWarpInstructions,
                                          storeWarpInstructions,
                                          predicateElements,
                                          shuffleLaneSteps,
+                                         scanShuffleLaneSteps,
                                          dotFlops,
                                          issueElements,
                                          estimatedSpillTransactions};
@@ -189,6 +190,7 @@ llvm::json::Object StageWorkload::toJSON() const {
   result["store_warp_instructions_per_iteration"] = storeWarpInstructions;
   result["predicate_elements_per_iteration"] = predicateElements;
   result["shuffle_lane_steps_per_iteration"] = shuffleLaneSteps;
+  result["scan_shuffle_lane_steps_per_iteration"] = scanShuffleLaneSteps;
   result["dot_flops_per_iteration"] = dotFlops;
   result["issue_elements_per_iteration"] = issueElements;
   result["estimated_spill_transactions_per_iteration"] =
@@ -220,10 +222,13 @@ llvm::json::Object StageModelFeatures::toJSON() const {
 }
 
 bool StageResourceCycles::isFiniteAndNonNegative() const {
-  const std::array<double, 15> values = {
-      setup,      scalar,          load,  store,       compute,
-      predicate,  shuffle,         dot,   loopControl, branchControl,
-      divergence, synchronization, spill, issue,       criticalPath};
+  const std::array<double, 16> values = {
+      setup,           scalar,        load,
+      store,           compute,       predicate,
+      shuffle,         scanShuffle,   dot,
+      loopControl,     branchControl, divergence,
+      synchronization, spill,         issue,
+      criticalPath};
   return std::all_of(values.begin(), values.end(), [](double value) {
     return std::isfinite(value) && value >= 0.0;
   });
@@ -238,6 +243,7 @@ llvm::json::Object StageResourceCycles::toJSON() const {
   result["compute_per_iteration"] = compute;
   result["predicate_per_iteration"] = predicate;
   result["shuffle_per_iteration"] = shuffle;
+  result["scan_shuffle_per_iteration"] = scanShuffle;
   result["dot_per_iteration"] = dot;
   result["loop_control_per_iteration"] = loopControl;
   result["branch_control_per_iteration"] = branchControl;

--- a/third_party/ascend/unittest/costmodel_ut/SimdSimtCostModelTest.cpp
+++ b/third_party/ascend/unittest/costmodel_ut/SimdSimtCostModelTest.cpp
@@ -367,6 +367,75 @@ TEST(SimdSimtCostModelTest, PrefixScanUsesModeSpecificDependencyFactor) {
   EXPECT_GT(implementations[0].totalCycles, implementations[1].totalCycles);
 }
 
+TEST(SimdSimtCostModelTest, LoopCarriedRecurrenceAppliesScanDependencyFactor) {
+  auto buildStage = [] {
+    LogicalStage stage = logicalStage(
+        "recurrence_scan", StageCostModelKind::LoopCarriedRecurrence,
+        StageScheduleKind::LoopCarriedSerial, /*iterations=*/4);
+    stage.features.hasLoop = true;
+    stage.features.hasLoopCarriedDataDependency = true;
+    stage.features.hasPrefixScan = true;
+    stage.workload.operationElements.clear();
+    stage.workload.scalarOperations = 0.0;
+    stage.workload.issueElements = 64.0;
+    // Mixed shuffle pool: 320 scan-class steps (tt.scan) + 320 reduce-class
+    // steps (tt.reduce).
+    stage.workload.shuffleLaneSteps = 640.0;
+    stage.workload.scanShuffleLaneSteps = 320.0;
+    return stage;
+  };
+
+  // Identity factors keep the legacy recurrence scoring.
+  HardwareProfile baselineProfile = hardwareProfile();
+  baselineProfile.simd.prefixScanDependencyFactor = 1.0;
+  baselineProfile.simt.prefixScanDependencyFactor = 1.0;
+  auto baseline = evaluateOneStage(buildStage(), baselineProfile);
+  if (!baseline)
+    FAIL() << llvm::toString(baseline.takeError());
+  ASSERT_EQ(baseline->stages.front().implementations.size(), 2u);
+
+  // Scan factors: SIMD 2.5 / SIMT 1.0 (production profile shape).
+  HardwareProfile scanProfile = baselineProfile;
+  scanProfile.simd.prefixScanDependencyFactor = 2.5;
+  auto scaled = evaluateOneStage(buildStage(), scanProfile);
+  if (!scaled)
+    FAIL() << llvm::toString(scaled.takeError());
+  ASSERT_EQ(scaled->stages.front().implementations.size(), 2u);
+
+  // Only the scan-class half is scaled: SIMD scan-shuffle cycles grow from
+  // 320/32 = 10 to 10 * 2.5 = 25, so the stage total grows by 4 iterations *
+  // (25 - 10) = 60 cycles.  The reduce-class half keeps the ideal rate and
+  // SIMT keeps the identity factor, so both must not move.
+  EXPECT_DOUBLE_EQ(scaled->stages.front().implementations[0].totalCycles,
+                   baseline->stages.front().implementations[0].totalCycles +
+                       60.0);
+  EXPECT_DOUBLE_EQ(scaled->stages.front().implementations[1].totalCycles,
+                   baseline->stages.front().implementations[1].totalCycles);
+  EXPECT_GT(scaled->stages.front().implementations[0].totalCycles,
+            scaled->stages.front().implementations[1].totalCycles);
+
+  // A recurrence whose shuffle pool is purely reduce-class must not consume
+  // the scan factor even though the scan feature flag is set.
+  LogicalStage reduceOnlyStage = buildStage();
+  reduceOnlyStage.workload.scanShuffleLaneSteps = 0.0;
+  auto reduceOnlyScaled =
+      evaluateOneStage(std::move(reduceOnlyStage), scanProfile);
+  if (!reduceOnlyScaled)
+    FAIL() << llvm::toString(reduceOnlyScaled.takeError());
+  EXPECT_DOUBLE_EQ(
+      reduceOnlyScaled->stages.front().implementations[0].totalCycles,
+      baseline->stages.front().implementations[0].totalCycles);
+
+  // A recurrence without a prefix scan must not consume the scan factor.
+  LogicalStage plainStage = buildStage();
+  plainStage.features.hasPrefixScan = false;
+  auto plainScaled = evaluateOneStage(std::move(plainStage), scanProfile);
+  if (!plainScaled)
+    FAIL() << llvm::toString(plainScaled.takeError());
+  EXPECT_DOUBLE_EQ(plainScaled->stages.front().implementations[0].totalCycles,
+                   baseline->stages.front().implementations[0].totalCycles);
+}
+
 TEST(SimdSimtCostModelTest, IndependentLoopUsesSimdRooflineAndSerialSimtCost) {
   LogicalStage stage =
       logicalStage("independent", StageCostModelKind::IndependentPipelinedLoop,

--- a/third_party/ascend/unittest/costmodel_ut/test_costmodel_recurrence_scan_route.py
+++ b/third_party/ascend/unittest/costmodel_ut/test_costmodel_recurrence_scan_route.py
@@ -1,0 +1,132 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import json
+import os
+import tempfile
+import unittest
+
+import torch
+import torch_npu
+import triton
+import triton.language as tl
+
+from triton.backends.ascend.utils import is_compile_on_910_95
+
+# Routes whose fast path is SIMT (all SIMT, or SIMD host with a SIMT scope).
+SIMT_ROUTES = {"all_simt_only", "mixed_simd_simt"}
+
+# The launch options below are passed explicitly, but these environment
+# variables still leak in from the caller's shell: TRITON_ASCEND_COMPILE_MODE
+# *overrides* the explicit compile_mode option, and TRITON_ASCEND_AUTO_SIMT_PROFILE
+# replaces the calibrated cost profile (the scope mode/dump env vars are only
+# fallbacks, cleared here for symmetry).  Removing them keeps the route decision
+# deterministic no matter how the caller configured the shell.
+ISOLATED_ENV = (
+    "TRITON_ASCEND_COMPILE_MODE",
+    "TRITON_ASCEND_AUTO_SIMT_SCOPE",
+    "TRITON_ASCEND_AUTO_SIMT_SCOPE_DUMP",
+    "TRITON_ASCEND_AUTO_SIMT_PROFILE",
+)
+
+
+@triton.jit(do_not_specialize=["T"])
+def _recurrence_scan_kernel(s_ptr, o_ptr, T, BT: tl.constexpr, H: tl.constexpr):
+    """Loop-carried recurrence with a nested prefix scan.
+
+    Mirrors the structure of fla ``chunk_global_cumsum_scalar_kernel``: the
+    carried scalar ``b_z`` accumulates the running total across chunks while
+    ``tl.cumsum`` scans the chunk.  Guard target: "[sim_costmodel](fix)
+    LoopCarriedRecurrence applies prefixScanDependencyFactor to nested scans".
+    Before that fix the scan shuffle nested in the recurrence was billed at the
+    ideal SIMD rate, under-estimating the SIMD cost and routing the kernel to
+    ``all_simd``; the scan-contributed shuffle must now consume the prefix-scan
+    dependency factor, which makes SIMT the cheaper candidate.
+    """
+    i_nh = tl.program_id(0)
+    i_n, i_h = i_nh // H, i_nh % H
+    base = i_n * T * H + i_h
+    b_z = tl.zeros([], dtype=tl.float32)
+    NT = tl.cdiv(T, BT)
+    for i_c in range(NT):
+        offs = i_c * BT + tl.arange(0, BT)
+        mask = offs < T
+        b_s = tl.load(s_ptr + base + offs * H, mask=mask, other=0.0).to(tl.float32)
+        b_o = tl.cumsum(b_s, axis=0) + b_z
+        b_z += tl.sum(b_s, axis=0)
+        tl.store(o_ptr + base + offs * H, b_o.to(o_ptr.dtype.element_ty), mask=mask)
+
+
+class CostmodelRecurrenceScanRouteTest(unittest.TestCase):
+
+    def setUp(self):
+        self._saved_env = {name: os.environ.get(name) for name in ISOLATED_ENV}
+        for name in ISOLATED_ENV:
+            os.environ.pop(name, None)
+
+    def tearDown(self):
+        for name, value in self._saved_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+    def test_recurrence_scan_routes_to_simt(self):
+        if not is_compile_on_910_95():
+            self.skipTest("SIMD/SIMT cost model only supports 910_95")
+
+        batch, sequence, heads, block = 4, 1024, 8, 256
+        torch.manual_seed(0)
+        source = torch.randn(batch, sequence, heads, dtype=torch.float32, device="npu")
+        output = torch.empty_like(source)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # The costmodel dumps one JSON line per compile; the directory must exist.
+            report_path = os.path.join(tmpdir, "output.json")
+            _recurrence_scan_kernel[(batch * heads, )](
+                source,
+                output,
+                sequence,
+                BT=block,
+                H=heads,
+                num_warps=4,
+                compile_mode="simd_simt",
+                auto_simt_scope_mode="auto",
+                auto_simt_scope_dump=report_path,
+            )
+            torch.npu.synchronize()
+
+            expected = source.cumsum(dim=1)
+            torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
+
+            self.assertTrue(os.path.exists(report_path), "costmodel route report was not written")
+            with open(report_path, "r", encoding="utf-8") as stream:
+                reports = [json.loads(line) for line in stream if line.strip()]
+            self.assertTrue(reports, "costmodel route report is empty")
+            report = reports[-1]
+            self.assertTrue(report["stage_model"]["applied"])
+            self.assertIn(
+                report["effective_decision_kind"], SIMT_ROUTES,
+                f"expected a SIMT route, got {report['effective_decision_kind']} "
+                f"with candidate costs {report['candidate_costs']}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[sim_costmodel](fix) apply prefix-scan dependency factor only to the tt.scan portion of recurrence shuffle

## Why

`chunk_global_cumsum_scalar_kernel` (fla) was mis-routed to `all_simd` under costmodel auto even though SIMT is measurably faster on hardware. Its loop body carries a loop-carried dependency (`b_z`) together with `tt.scan` + `tt.reduce`, so the stage classifies as LoopCarriedRecurrence — the loop-carried dependency wins over hasPrefixScan, making the PrefixScan model unreachable. That model billed shuffle at the ideal vector rate and never consumed the measured `prefix_scan_dependency_factor`; only the unreachable PrefixScan model did.

The first fix (f37e1b217) multiplied the factor into the *whole* shuffle pool of the recurrence stage. That over-corrects: in this kernel `tt.scan` and `tt.reduce` each contribute exactly 50% of the shuffle steps, and a tree reduction does not suffer the scan's serialized lane-dependency chain (active lanes halve every level, so the N·log2(N) lane-step billing already carries enough slack). Shapes that should have stayed SIMD flipped to all_simt.

## What

- Split `StageWorkload.shuffleLaneSteps` by reduction source: `scanShuffleLaneSteps` records the `tt.scan` contribution, the remainder is `tt.reduce`. Both channels stay in sync across stage merge and loop-multiplicity scaling.
- LoopCarriedRecurrence now scales only the scan-class shuffle with the mode-specific `prefixScanDependencyFactor` (SIMD 17.35 / SIMT identity), semantically aligned with the standalone PrefixScan model.
- Route dump exposes `scan_shuffle_lane_steps_per_iteration` and `scan_shuffle_per_iteration` for calibration auditing.

## Effect (chunk_global_cumsum_scalar_kernel, stage_4 SIMD cycles, 4096-lane shape)

- before any fix: 84.6 — mis-routed to all_simd
- whole-pool factor: 1131.0 — over-corrected
- this change: 607.8 = 84.6 + 16.35 × 2048/64 — exact match with the
  scan-only prediction; 768-lane flips back to all_simd, 1792/4096-lane
  stay all_simt_only.

## Tests

- **C++ unit test — `SimdSimtCostModelTest.LoopCarriedRecurrenceAppliesScanDependencyFactor`** (new): a recurrence stage with a mixed shuffle pool (320 `tt.scan` + 320 `tt.reduce` lane-steps) shows that only the scan-contributed half consumes the dependency factor (+60 cycles over 4 iterations), that the SIMT side stays at the identity factor, and a reduce-only negative case proves the factor is not consumed when only `hasPrefixScan` is set.  `SimdSimtCostModel`: 35/35 pass.

- **End-to-end route guard — `third_party/ascend/unittest/costmodel_ut/test_costmodel_recurrence_scan_route.py`** (new): a self-contained kernel with a loop-carried recurrence and a nested `tl.cumsum` (structure mirrors fla `chunk_global_cumsum_scalar_kernel`) is compiled in auto mode with `auto_simt_scope_dump`; the test asserts both the numerics (against `torch.cumsum`) and that the dumped decision is a SIMT route (`all_simt_only` / `mixed_simd_simt`).  Sensitivity check: neutralising the SIMD `prefix_scan.dependency_factor` to 1.0 (equivalent to the pre-fix behaviour) makes the same kernel route to `all_simd`, i.e. the guard fails without this change.  Verified on 910_95; passes standalone (`python …`) and under `pytest`.

- **Existing route guards — `pytest_ut/test_simd_simt_costmodel_cases.py`**: 10/10 pass (needs `TRITON_RUN_SIMD_SIMT_COSTMODEL_GUARDS=1`), confirming the previously-calibrated routes are unchanged.

- **End-to-end**: fla `chunk_global_cumsum` auto route now selects `all_simt_only` (620.8 SIMD vs 428.4 SIMT system cycles).

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  `https://cbea.ms/git-commit/#why-not-how` .
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/unittest` for C++ tests (`SimdSimtCostModelTest.cpp`)
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these `https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices` , including the "tests should be minimal" section.