### PR TITLE
[ssbuffer](fix) remove memeffects of alloc_tensor

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/MemoryEffectsTracker.cpp
@@ -317,8 +317,7 @@ MemoryDependenceGraph::collectOuterEffects(Operation *op, bool &unknown,
   }
 
   if (auto allocTensorOp = dyn_cast<bufferization::AllocTensorOp>(op)) {
-    MemoryEffects::EffectInstance scopedAlloc(MemoryEffects::Allocate::get());
-    return {remapEffectValue(scopedAlloc, allocTensorOp.getResult())};
+    return {};
   }
 
   std::optional<SmallVector<MemoryEffects::EffectInstance>> raw;


### PR DESCRIPTION
Completely mark alloc_tensor as no mem effects to avoid unneccessary dependencies and syncs