### PR TITLE
[testing](feat) update do_bench_npu

### DIFF
--- a/third_party/ascend/backend/testing.py
+++ b/third_party/ascend/backend/testing.py
@@ -349,6 +349,7 @@ def do_bench_npu(
     :type target_kernel_name: str, optional
     """
     import math
+    import os
     mspti_available = True
     if KernelMonitor is None:
         mspti_available = False
@@ -357,10 +358,15 @@ def do_bench_npu(
 
     if not isinstance(funcs, list):
         funcs = [funcs]
+        use_autotune = False
+    else:
+        use_autotune = os.getenv("TRITON_BENCH_METHOD", "default").lower() == "npu"
+
     results = None
     need_fallback = True
-    force_fallback = (prof_dir is not None) or keep_res
-    if mspti_available and target_kernel_name is None and not force_fallback:
+    force_fallback = (prof_dir is not None) or keep_res or (target_kernel_name is not None and not use_autotune)
+
+    if mspti_available and not force_fallback:
         try:
             results = do_bench_npu_mspti(funcs, warmup, active, clear_l2_cache, target_kernel_name)
             first_val = results[0] if isinstance(results, list) else results


### PR DESCRIPTION
relate to https://github.com/triton-lang/triton-ascend/issues/1938
1、Modify warnings and errors.
If the profiler files is empty or the number of task records is inconsistent with the expected value, return inf and display an error message. 
If the table recording the task data on the device side in the file is empty, return 0 and display a warning message.
2、Fix he bug that occurs when the CPU fallback operator without a kernel is returned to the device.
3、Revise the criteria for selecting do_bench_npu_mspti.
Originally, due to the fuzzy matching of `target_kernel_name` in `do_bench_npu_mspti`, when `target_kernel_name`is not None, we chose not to call  `do_bench_npu_mspti`. But for Autotune, there will only be one kernel passed in each time, so there is no need to worry about this issue. Therefore, revise the condition for following  `do_bench_npu_mspti`.
Implementation method: 
There are instances where both `prof_dir` and `keep_res` do not go to  `do_bench_npu_mspti`, and when `target_kernel_name` exists and `use_autotune` is False, they also do not go to `do_bench_npu_mspti`. 
The judgment of `use_autotune`: `TRITON_BENCH_METHOD=="npu"`and the passed funcs are lists, `use_autotune` is true.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
