### PR TITLE
[TritonToGraph](feat) speedup Radix topk by 2x

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -184,6 +184,7 @@ def make_ttir(mod, metadata, opt):
             pm,
             ub_capacity_bytes=graph_ub_budget_bytes_for_arch(opt.target_arch),
             compile_mode=opt.compile_mode,
+            compile_on_910_95=opt.compile_on_910_95,
         )
     pm.run(mod, 'make_ttir')
     if opt.debug:

--- a/third_party/ascend/include/TritonToGraph/GraphOptimization.h
+++ b/third_party/ascend/include/TritonToGraph/GraphOptimization.h
@@ -119,6 +119,7 @@ struct GraphOptimizationOptions {
   // compile_mode="simt_only".  Keep the source selector rather than a
   // second derived force flag so every consumer follows one mode contract.
   std::string compileMode = "simd_simt_template";
+  bool compileOn91095 = false;
 };
 
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/third_party/ascend/include/TritonToGraph/Passes.td
+++ b/third_party/ascend/include/TritonToGraph/Passes.td
@@ -73,6 +73,8 @@ def GraphOptimize : Pass<"graph-optimize", "mlir::ModuleOp"> {
   let summary = "Optimize Triton IR with graph analyses";
   let constructor = "mlir::triton::cfg::createGraphOptimizePass()";
   let options = [
+    Option<"compileOn91095", "compile-on-910-95", "bool", "false",
+           "Enable histogram rewrites relying on Ascend 910_95 templates">,
     Option<"ruleMask", "rule-mask", "uint64_t", "511",
            "Bitmask of registered graph rule identities; this pass executes only native graph-rule phases">,
     Option<"maxRewritesPerFunction", "max-rewrites-per-function", "uint64_t",

--- a/third_party/ascend/lib/TritonToGraph/GraphOptimizationPass.cpp
+++ b/third_party/ascend/lib/TritonToGraph/GraphOptimizationPass.cpp
@@ -20,6 +20,8 @@
  * THE SOFTWARE.
  */
 
+#include "Rules/FoldHistogramParking.h"
+#include "Rules/NarrowUnsignedTensor.h"
 #include "TritonToGraph/GraphOptimizationContext.h"
 #include "TritonToGraph/GraphOptimizationRule.h"
 #include "TritonToGraph/Passes.h"
@@ -27,6 +29,7 @@
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
@@ -102,10 +105,12 @@ public:
     this->maxRewritesPerFunction = options.maxRewritesPerFunction;
     this->ubCapacityBytes = options.ubCapacityBytes;
     this->compileMode = options.compileMode;
+    this->compileOn91095 = options.compileOn91095;
   }
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<tensor::TensorDialect>();
+    registry.insert<tensor::TensorDialect, arith::ArithDialect,
+                    triton::TritonDialect>();
   }
 
   void runOnOperation() override;
@@ -152,12 +157,24 @@ GraphOptimizePass::getStableOptions(GraphOptimizationOptions &options) {
   options.maxRewritesPerFunction = static_cast<unsigned>(cliMaxRewrites);
   options.ubCapacityBytes = static_cast<unsigned>(cliUBCapacityBytes);
   options.compileMode = this->compileMode;
+  options.compileOn91095 = this->compileOn91095;
   return success();
 }
 
 void GraphOptimizePass::runOnOperation() {
   GraphOptimizationOptions options;
   if (failed(getStableOptions(options))) {
+    signalPassFailure();
+    return;
+  }
+
+  // Simplify tensor values before constructing any graph analyses so layout
+  // rules observe the reduced workload, without retaining stale graph state.
+  RewritePatternSet patterns(&getContext());
+  patterns.add<narrow_unsigned_tensor::Narrow>(&getContext());
+  if (compileOn91095)
+    patterns.add<FoldHistogramParking>(&getContext());
+  if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
     signalPassFailure();
     return;
   }

--- a/third_party/ascend/lib/TritonToGraph/Rules/FoldHistogramParking.h
+++ b/third_party/ascend/lib/TritonToGraph/Rules/FoldHistogramParking.h
@@ -1,0 +1,98 @@
+// Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#ifndef TRITON_ASCEND_GRAPH_FOLD_HISTOGRAM_PARKING_H
+#define TRITON_ASCEND_GRAPH_FOLD_HISTOGRAM_PARKING_H
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir::triton {
+
+// Ascend histogram templates ignore out-of-range indices, including -1.
+// hist(select(mask, x, 0)) - select(bin_id == 0, sum(!mask), 0)
+// therefore equals hist(select(mask, x, -1)). Keep the histogram unmasked so
+// the existing SIMD implementation remains available; do not change its ABI.
+struct FoldHistogramParking : OpRewritePattern<arith::SubIOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::SubIOp op,
+                                PatternRewriter &rewriter) const override {
+    auto hist = op.getLhs().getDefiningOp<HistogramOp>();
+    auto correction = op.getRhs().getDefiningOp<arith::SelectOp>();
+    // Do not duplicate an expensive histogram used elsewhere.
+    if (!hist || !hist->hasOneUse() || hist->getNumOperands() != 1 ||
+        !correction || !matchPattern(correction.getFalseValue(), m_Zero()))
+      return failure();
+    auto inputType = dyn_cast<RankedTensorType>(hist.getSrc().getType());
+    auto binsType = dyn_cast<RankedTensorType>(hist.getType());
+    if (!inputType || inputType.getRank() != 1 ||
+        !inputType.getElementType().isInteger(32) || !binsType ||
+        binsType.getRank() != 1 || !binsType.getElementType().isInteger(32) ||
+        binsType.getDimSize(0) <= 0)
+      return failure();
+    auto input = hist.getSrc().getDefiningOp<arith::SelectOp>();
+    if (!input || !matchPattern(input.getFalseValue(), m_Zero()))
+      return failure();
+
+    auto isZero = correction.getCondition().getDefiningOp<arith::CmpIOp>();
+    if (!isZero || isZero.getPredicate() != arith::CmpIPredicate::eq)
+      return failure();
+    Value ids = isZero.getLhs();
+    if (matchPattern(ids, m_Zero()))
+      ids = isZero.getRhs();
+    else if (!matchPattern(isZero.getRhs(), m_Zero()))
+      return failure();
+    auto range = ids.getDefiningOp<MakeRangeOp>();
+    if (!range || range.getStart() != 0 ||
+        range.getEnd() != binsType.getDimSize(0))
+      return failure();
+
+    auto countSplat = correction.getTrueValue().getDefiningOp<SplatOp>();
+    if (!countSplat)
+      return failure();
+    auto count = countSplat.getSrc().getDefiningOp<ReduceOp>();
+    if (!count || count->getNumOperands() != 1 || count->getNumResults() != 1 ||
+        count.getAxis() != 0)
+      return failure();
+    Block &body = count->getRegion(0).front();
+    if (body.getNumArguments() != 2 ||
+        !llvm::hasSingleElement(body.without_terminator()))
+      return failure();
+    auto add = dyn_cast<arith::AddIOp>(body.front());
+    if (!add || body.getTerminator()->getNumOperands() != 1 ||
+        body.getTerminator()->getOperand(0) != add.getResult() ||
+        !((add.getLhs() == body.getArgument(0) &&
+           add.getRhs() == body.getArgument(1)) ||
+          (add.getLhs() == body.getArgument(1) &&
+           add.getRhs() == body.getArgument(0))))
+      return failure();
+
+    Value counted = count->getOperand(0);
+    if (auto reshape = counted.getDefiningOp<ReshapeOp>())
+      counted = reshape.getSrc();
+    auto extend = counted.getDefiningOp<arith::ExtUIOp>();
+    if (!extend)
+      return failure();
+    auto invert = extend.getIn().getDefiningOp<arith::XOrIOp>();
+    if (!invert || !((invert.getLhs() == input.getCondition() &&
+                      matchPattern(invert.getRhs(), m_One())) ||
+                     (invert.getRhs() == input.getCondition() &&
+                      matchPattern(invert.getLhs(), m_One()))))
+      return failure();
+
+    Value invalid = rewriter.create<arith::ConstantOp>(
+        op.getLoc(), inputType,
+        DenseElementsAttr::get(inputType, rewriter.getI32IntegerAttr(-1)));
+    Value indices = rewriter.create<arith::SelectOp>(
+        op.getLoc(), input.getCondition(), input.getTrueValue(), invalid);
+    // Preserve attributes (e.g. source provenance). Other uses of count remain
+    // intact; the original histogram becomes dead after replacing subtraction.
+    Operation *replacement = rewriter.clone(*hist.getOperation());
+    replacement->setOperand(0, indices);
+    rewriter.replaceOp(op, replacement->getResults());
+    return success();
+  }
+};
+} // namespace mlir::triton
+#endif

--- a/third_party/ascend/lib/TritonToGraph/Rules/NarrowUnsignedTensor.h
+++ b/third_party/ascend/lib/TritonToGraph/Rules/NarrowUnsignedTensor.h
@@ -1,0 +1,150 @@
+// Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#ifndef TRITON_ASCEND_GRAPH_NARROW_UNSIGNED_TENSOR_H
+#define TRITON_ASCEND_GRAPH_NARROW_UNSIGNED_TENSOR_H
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir::triton {
+namespace narrow_unsigned_tensor {
+
+inline bool constant(Value value, uint64_t &bits) {
+  APInt integer;
+  if (!matchPattern(value, m_ConstantInt(&integer)))
+    return false;
+  bits = integer.getZExtValue();
+  return true;
+}
+
+// Only values proven to have zero upper bits may change signed right shift
+// into unsigned right shift. In particular, an arbitrary i64 is NOT a u32.
+inline bool isU32(Value value) {
+  if (auto ext = value.getDefiningOp<arith::ExtUIOp>())
+    return getElementTypeOrSelf(ext.getIn().getType()).isInteger(32);
+  uint64_t bits;
+  return constant(value, bits) && bits <= UINT32_MAX;
+}
+
+inline Type i32Type(Type type, PatternRewriter &rewriter) {
+  if (auto tensor = dyn_cast<RankedTensorType>(type))
+    return tensor.clone(rewriter.getI32Type());
+  return rewriter.getI32Type();
+}
+
+// Compute the low 32 bits without materializing wide bitwise temporaries.
+// Truncation commutes with these operations, but not with right shift.
+inline Value lowBits(Value value, PatternRewriter &rewriter,
+                     unsigned depth = 0) {
+  Location loc = value.getLoc();
+  Type type = i32Type(value.getType(), rewriter);
+  if (value.getType() == type)
+    return value;
+  if (auto ext = value.getDefiningOp<arith::ExtUIOp>())
+    if (ext.getIn().getType() == type)
+      return ext.getIn();
+  if (auto ext = value.getDefiningOp<arith::ExtSIOp>())
+    if (ext.getIn().getType() == type)
+      return ext.getIn();
+  uint64_t bits;
+  if (constant(value, bits)) {
+    auto attr =
+        rewriter.getIntegerAttr(rewriter.getI32Type(), bits & UINT32_MAX);
+    if (auto tensor = dyn_cast<RankedTensorType>(type))
+      return rewriter.create<arith::ConstantOp>(
+          loc, type, DenseElementsAttr::get(tensor, attr));
+    return rewriter.create<arith::ConstantOp>(loc, attr);
+  }
+  if (depth < 8) {
+    if (auto op = value.getDefiningOp<SplatOp>())
+      return rewriter.create<SplatOp>(
+          loc, type, lowBits(op.getSrc(), rewriter, depth + 1));
+    Operation *op = value.getDefiningOp();
+    if (op && isa<arith::AndIOp, arith::OrIOp, arith::XOrIOp>(op)) {
+      Value lhs = lowBits(op->getOperand(0), rewriter, depth + 1);
+      Value rhs = lowBits(op->getOperand(1), rewriter, depth + 1);
+      if (isa<arith::AndIOp>(op))
+        return rewriter.create<arith::AndIOp>(loc, lhs, rhs);
+      if (isa<arith::OrIOp>(op))
+        return rewriter.create<arith::OrIOp>(loc, lhs, rhs);
+      return rewriter.create<arith::XOrIOp>(loc, lhs, rhs);
+    }
+  }
+  return rewriter.create<arith::TruncIOp>(loc, type, value);
+}
+
+struct Narrow : RewritePattern {
+  explicit Narrow(MLIRContext *context)
+      : RewritePattern(MatchAnyOpTypeTag(), 1, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    if (op->getNumResults() != 1 || op->getNumOperands() < 2)
+      return failure();
+    auto type = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+    // Select has a predicate operand first.
+    if (isa<arith::SelectOp>(op))
+      type = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+    if (!type || !type.getElementType().isInteger(64))
+      return failure();
+    Location loc = op->getLoc();
+    Value result;
+    if (auto select = dyn_cast<arith::SelectOp>(op)) {
+      if (!isU32(select.getTrueValue()) || !isU32(select.getFalseValue()))
+        return failure();
+      result = rewriter.create<arith::SelectOp>(
+          loc, select.getCondition(), lowBits(select.getTrueValue(), rewriter),
+          lowBits(select.getFalseValue(), rewriter));
+    } else if (isa<arith::AndIOp, arith::OrIOp, arith::XOrIOp>(op)) {
+      Value lhs = op->getOperand(0), rhs = op->getOperand(1);
+      uint64_t mask;
+      bool masked = isa<arith::AndIOp>(op) &&
+                    ((constant(lhs, mask) && mask <= UINT32_MAX) ||
+                     (constant(rhs, mask) && mask <= UINT32_MAX));
+      if (!masked && !(isU32(lhs) && isU32(rhs)))
+        return failure();
+      result = lowBits(op->getResult(0), rewriter);
+    } else if (isa<arith::ShRSIOp, arith::ShRUIOp>(op)) {
+      uint64_t shift;
+      if (!isU32(op->getOperand(0)) || !constant(op->getOperand(1), shift) ||
+          shift >= 32)
+        return failure();
+      result = rewriter.create<arith::ShRUIOp>(
+          loc, lowBits(op->getOperand(0), rewriter),
+          lowBits(op->getOperand(1), rewriter));
+    } else if (auto cmp = dyn_cast<arith::CmpIOp>(op)) {
+      if (cmp.getPredicate() != arith::CmpIPredicate::eq ||
+          !isU32(cmp.getLhs()))
+        return failure();
+      if (isU32(cmp.getRhs())) {
+        rewriter.replaceOpWithNewOp<arith::CmpIOp>(
+            op, cmp.getPredicate(), lowBits(cmp.getLhs(), rewriter),
+            lowBits(cmp.getRhs(), rewriter));
+        return success();
+      }
+      // A scalar threshold may still be i64: keep its upper-bit check scalar,
+      // instead of silently truncating or creating a tensor<i64> comparison.
+      auto splat = cmp.getRhs().getDefiningOp<SplatOp>();
+      if (!splat)
+        return failure();
+      Value limit = rewriter.create<arith::ConstantIntOp>(loc, UINT32_MAX, 64);
+      Value fits = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::ule, splat.getSrc(), limit);
+      Value equal = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::eq, lowBits(cmp.getLhs(), rewriter),
+          lowBits(cmp.getRhs(), rewriter));
+      Value fitsTensor = rewriter.create<SplatOp>(loc, equal.getType(), fits);
+      rewriter.replaceOpWithNewOp<arith::AndIOp>(op, equal, fitsTensor);
+      return success();
+    } else {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<arith::ExtUIOp>(op, type, result);
+    return success();
+  }
+};
+} // namespace narrow_unsigned_tensor
+} // namespace mlir::triton
+#endif

--- a/third_party/ascend/triton_ascend.cc
+++ b/third_party/ascend/triton_ascend.cc
@@ -145,7 +145,7 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
       "add_graph_optimize",
       [](mlir::PassManager &pm, std::uint64_t ruleMask,
          std::uint64_t maxRewritesPerFunction, std::uint64_t ubCapacityBytes,
-         const std::string &compileMode) {
+         const std::string &compileMode, bool compileOn91095) {
         if (ruleMask > std::numeric_limits<std::uint16_t>::max())
           throw py::value_error("rule_mask must fit in uint16_t");
         if (maxRewritesPerFunction > std::numeric_limits<unsigned>::max())
@@ -160,12 +160,14 @@ void init_triton_ascend_passes_ttir(py::module &&m) {
             static_cast<unsigned>(maxRewritesPerFunction);
         options.ubCapacityBytes = static_cast<unsigned>(ubCapacityBytes);
         options.compileMode = compileMode;
+        options.compileOn91095 = compileOn91095;
         pm.addPass(mlir::triton::cfg::createGraphOptimizePass(options));
       },
       py::arg("pm"), py::arg("rule_mask") = 511,
       py::arg("max_rewrites_per_function") = 64,
       py::arg("ub_capacity_bytes") = 0,
-      py::arg("compile_mode") = "simd_simt_template");
+      py::arg("compile_mode") = "simd_simt_template",
+      py::arg("compile_on_910_95") = false);
 
   m.def("set_buffer_count", [](mlir::ModuleOp &module, const std::string &type,
                                int count) {

--- a/third_party/ascend/unittest/Conversion/General/TritonToGraph/graph-optimize-radix-topk-threshold.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToGraph/graph-optimize-radix-topk-threshold.mlir
@@ -1,0 +1,57 @@
+// RUN: triton-opt %s -graph-optimize='compile-on-910-95=true' --verify-each | FileCheck %s
+// RUN: triton-opt %s -graph-optimize='compile-on-910-95=false' --verify-each | FileCheck %s --check-prefix=OTHER
+//
+// Reduced from one byte-selection round of _radix_topk_threshold, BLOCK_R=8192.
+// Preserve its u32 key extraction, zero parking and bin-zero correction.
+// All four radix rounds use this structure. This is not an end-to-end kernel.
+//
+// CHECK-LABEL: tt.func @radix_topk_threshold_round(
+// CHECK: arith.constant dense<-1> : tensor<8192xi32>
+// CHECK: arith.shrui {{.*}} : tensor<8192xi32>
+// CHECK-NOT: tt.reduce
+// CHECK: tt.histogram
+// CHECK-NOT: tt.reduce
+// CHECK-NOT: arith.subi
+// CHECK: tt.return
+// OTHER-LABEL: tt.func @radix_topk_threshold_round(
+// OTHER: arith.shrui {{.*}} : tensor<8192xi32>
+// OTHER: tt.histogram
+// OTHER: tt.reduce
+// OTHER: arith.subi
+tt.func @radix_topk_threshold_round(%keys: tensor<8192xi64>, %live: tensor<8192xi1>) -> tensor<256xi32> {
+  %u32mask = arith.constant dense<4294967295> : tensor<8192xi64>
+  %shift = arith.constant dense<24> : tensor<8192xi64>
+  %byte_mask = arith.constant dense<255> : tensor<8192xi64>
+  %zero = arith.constant dense<0> : tensor<8192xi32>
+  %true = arith.constant dense<true> : tensor<8192xi1>
+  %zero_bins = arith.constant dense<0> : tensor<256xi32>
+  %bounded = arith.andi %keys, %u32mask : tensor<8192xi64>
+  %shifted = arith.shrui %bounded, %shift : tensor<8192xi64>
+  %byte = arith.andi %shifted, %byte_mask : tensor<8192xi64>
+  %indices = arith.trunci %byte : tensor<8192xi64> to tensor<8192xi32>
+  %parked = arith.select %live, %indices, %zero : tensor<8192xi1>, tensor<8192xi32>
+  %hist = tt.histogram %parked : tensor<8192xi32> -> tensor<256xi32>
+  %invalid = arith.xori %live, %true : tensor<8192xi1>
+  %counts = arith.extui %invalid : tensor<8192xi1> to tensor<8192xi32>
+  %count = "tt.reduce"(%counts) ({
+  ^bb0(%a: i32, %b: i32):
+    %sum = arith.addi %a, %b : i32
+    tt.reduce.return %sum : i32
+  }) {axis = 0 : i32} : (tensor<8192xi32>) -> i32
+  %splat = tt.splat %count : i32 -> tensor<256xi32>
+  %bins = tt.make_range {start = 0 : i32, end = 256 : i32} : tensor<256xi32>
+  %iszero = arith.cmpi eq, %bins, %zero_bins : tensor<256xi32>
+  %correction = arith.select %iszero, %splat, %zero_bins : tensor<256xi1>, tensor<256xi32>
+  %result = arith.subi %hist, %correction : tensor<256xi32>
+  tt.return %result : tensor<256xi32>
+}
+
+// CHECK-LABEL: tt.func @keep_signed_shift(
+// CHECK: arith.shrsi {{.*}} : tensor<8192xi64>
+// OTHER-LABEL: tt.func @keep_signed_shift(
+// OTHER: arith.shrsi {{.*}} : tensor<8192xi64>
+tt.func @keep_signed_shift(%keys: tensor<8192xi64>) -> tensor<8192xi64> {
+  %shift = arith.constant dense<24> : tensor<8192xi64>
+  %result = arith.shrsi %keys, %shift : tensor<8192xi64>
+  tt.return %result : tensor<8192xi64>
+}

--- a/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
@@ -540,7 +540,7 @@ def _run_make_ttir_with_recorded_graph_options(compiler, monkeypatch, options):
         compiler,
         "ascend",
         SimpleNamespace(passes=SimpleNamespace(ttir=SimpleNamespace(
-            add_graph_optimize=lambda _pm, **kwargs: graph_calls.append(kwargs)))),
+            add_graph_optimize=lambda _pm, **kwargs: (events.append("graph_optimize"), graph_calls.append(kwargs))))),
     )
 
     assert compiler.make_ttir(module, {}, options) is module
@@ -551,6 +551,7 @@ def test_make_ttir_passes_canonical_compile_mode_to_graph_optimize(compiler_modu
     options = SimpleNamespace(
         enable_graph_optimize=True,
         target_arch="Ascend910B1",
+        compile_on_910_95=False,
         compile_mode="simt_only",
         debug=False,
     )
@@ -560,8 +561,17 @@ def test_make_ttir_passes_canonical_compile_mode_to_graph_optimize(compiler_modu
     assert graph_calls == [{
         "ub_capacity_bytes": 96 * 1024,
         "compile_mode": "simt_only",
+        "compile_on_910_95": False,
     }]
     assert events[-1] == "run_row"
+    assert events.index(("loop_unroll", (), {})) < events.index("graph_optimize")
+
+
+def test_make_ttir_disables_graph_pipeline(compiler_module, monkeypatch):
+    options = SimpleNamespace(enable_graph_optimize=False, debug=False)
+    events, graph_calls = _run_make_ttir_with_recorded_graph_options(compiler_module, monkeypatch, options)
+    assert "graph_optimize" not in events
+    assert graph_calls == []
 
 
 @pytest.mark.skip(reason="The case is not supported on A5, skipping for now. Will be fixed in future.")

--- a/third_party/ascend/unittest/pytest_ut/test_histogram_parking.py
+++ b/third_party/ascend/unittest/pytest_ut/test_histogram_parking.py
@@ -1,0 +1,52 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Fold parked bin-zero counts without losing genuine zeros or other users."""
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _parking(X, M, O, N: tl.constexpr, BINS: tl.constexpr, PARK: tl.constexpr, WRONG_MASK: tl.constexpr,
+             KEEP_RAW: tl.constexpr):
+    i = tl.arange(0, N)
+    mask = tl.load(M + i) != 0
+    x = tl.load(X + i)
+    hist = tl.histogram(tl.where(mask, x, PARK), BINS)
+    counted_mask = mask if not WRONG_MASK else (i % 3 == 0)
+    count = tl.sum((~counted_mask).to(tl.int32), 0)
+    bins = tl.arange(0, BINS)
+    corrected = hist - tl.where(bins == 0, count, 0)
+    tl.store(O + bins, corrected)
+    tl.store(O + BINS + bins, hist if KEEP_RAW else corrected)
+
+
+def _check_parking(size, bins, park, wrong_mask, mask_kind, keep_raw=False):
+    torch.manual_seed(37)
+    x = torch.randint(-8, bins + 8, (size, ), dtype=torch.int32)
+    x[::7] = 0
+    mask = torch.randint(0, 2, (size, ), dtype=torch.int32)
+    if mask_kind != "random":
+        mask.fill_(int(mask_kind == "all"))
+    device_x, device_mask = x.npu(), mask.npu()
+    output = torch.empty((2, bins), dtype=torch.int32, device=device_x.device)
+    _parking[(1, )](device_x, device_mask, output, size, bins, park, wrong_mask, keep_raw, enable_graph_optimize=True)
+    parked = torch.where(mask.bool(), x, park)
+    hist = torch.bincount(parked[(parked >= 0) & (parked < bins)].long(), minlength=bins)
+    count_mask = torch.arange(size) % 3 == 0 if wrong_mask else mask.bool()
+    expected = hist.clone()
+    expected[0] -= (~count_mask).sum()
+    second = hist if keep_raw else expected
+    torch.testing.assert_close(output.cpu().long(), torch.stack((expected, second)), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("size", [256, 8192])
+@pytest.mark.parametrize("bins", [16, 256])
+@pytest.mark.parametrize("park,wrong_mask", [(0, False), (1, False), (0, True)])
+@pytest.mark.parametrize("mask_kind", ["random", "none", "all"])
+def test_histogram_parking(size, bins, park, wrong_mask, mask_kind):
+    _check_parking(size, bins, park, wrong_mask, mask_kind)
+
+
+def test_histogram_parking_other_users():
+    _check_parking(8192, 256, 0, False, "random", keep_raw=True)

--- a/third_party/ascend/unittest/pytest_ut/test_unsigned_tensor_narrowing.py
+++ b/third_party/ascend/unittest/pytest_ut/test_unsigned_tensor_narrowing.py
@@ -1,0 +1,37 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Unsigned narrowing must preserve upper-bit checks and signed shifts."""
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _narrow_bits(X, T, O, N: tl.constexpr, SHIFT: tl.constexpr):
+    i = tl.arange(0, N)
+    x = tl.load(X + i)
+    t = tl.load(T)
+    u = x & 0xffffffff
+    key = tl.where(x < 0, (~u) & 0xffffffff, u | 0x80000000)
+    tl.store(O + i, key >> SHIFT)
+    tl.store(O + N + i, (key >> SHIFT) == t)
+    # This shift must NOT be changed to unsigned, nor narrowed before shifting.
+    tl.store(O + 2 * N + i, x >> SHIFT)
+    tl.store(O + 3 * N + i, x)
+
+
+@pytest.mark.parametrize("shift", [0, 8, 24, 31])
+@pytest.mark.parametrize("threshold", [-1, 0, 255, 0x1000000ff])
+def test_unsigned_tensor_narrowing(shift, threshold):
+    values = torch.tensor([
+        -(1 << 63), -0x100000001, -1, 0, 1, 255, 0x7fffffff, 0x80000000, 0xffffffff, 0x100000000, 0x1000000ff,
+        (1 << 63) - 1, -255, 0x123456789abcdef, -0x123456789abcdef, 42
+    ], dtype=torch.int64, device="npu")
+    target = torch.tensor([threshold], dtype=torch.int64, device=values.device)
+    output = torch.empty((4, 16), dtype=torch.int64, device=values.device)
+    _narrow_bits[(1, )](values, target, output, 16, shift, enable_graph_optimize=True)
+    x = values.cpu()
+    u = x & 0xffffffff
+    key = torch.where(x < 0, (~u) & 0xffffffff, u | 0x80000000)
+    expected = torch.stack((key >> shift, ((key >> shift) == threshold).long(), x >> shift, x))
+    torch.testing.assert_close(output.cpu(), expected, rtol=0, atol=0)


### PR DESCRIPTION
# Radix Top-K：两个图优化规则

两个规则为 `NarrowUnsignedTensor` 和 `FoldHistogramParking`。它们现在直接集成在
TA 的 `GraphOptimizePass` 中，不再是两个独立 pass；不修改原始 Triton 算子算法。

## 1. Motivation / Initiative：优化动机

`_radix_topk_threshold` 逐字节缩小 Top-K 阈值范围，每轮包含 key 提取、histogram 和选桶。
其中有两类可由编译器消除的开销：

| 规则 | 原始问题 | 优化目标 |
| --- | --- | --- |
| `NarrowUnsignedTensor` | key 的有效范围只有32位，但部分 tensor 位运算使用64位，增加中间数据量和 UB 压力 | 在可证明等价时，用32位 tensor 完成计算，使大 tile 更容易编译并执行 |
| `FoldHistogramParking` | 无效元素被置为0参与 histogram，再通过 `sum(!mask)` 从第0桶扣除假计数 | 不让无效元素参与计数，消除额外归约和补偿减法 |

## 2. Solution：实现方案

### 2.1 NarrowUnsignedTensor：安全收窄位宽

示例：

```text
优化前：i64 tensor → & 0xffffffff → >> 24 → & 255 → 转 i32
优化后：提取低32位 → i32 tensor 位运算 → i32 bucket
```

依据常量掩码、扩展操作和数据流证明值位于无符号32位范围，再改写支持的
and/or/xor、select、右移和相等比较。必要时在结果处恢复原来的64位类型，保持接口不变。

正确性约束：不能证明范围时不改写；未知范围的有符号右移保持原样；与64位标量阈值比较时，
保留阈值高位合法性检查，不能直接截断阈值。

### 2.2 FoldHistogramParking：消除假零计数

```text
优化前：histogram(where(mask, bucket, 0))
        - where(bin_id == 0, sum(!mask), 0)

优化后：histogram(where(mask, bucket, -1))
```

Ascend 模板忽略负数和超出桶范围的输入，因此 `-1` 不会被计数；真实 bucket=0 的元素仍然保留。
在匹配的 radix 轮次中，补偿用的归约和减法成为死代码，可被清除。

正确性约束：仅在 `compile_on_910_95` 下启用；要求一维 i32、无显式 histogram mask、
原 histogram 只有一个使用者，且扣除计数与输入使用同一个 mask。
错误 mask、非零停车值、有其他 histogram 使用者等情况不匹配，避免改变语义。

### 2.3 集成位置

```text
现有 TTIR pipeline
  → loop unroll
  → GraphOptimizePass
      → 两个规则的 greedy rewrite
      → 建图与分析
      → 原有 layout / memory 图优化
```

前置重写在建图前完成，后续分析看到简化后的 IR，不复用已经失效的分析结果。
通过现有 `enable_graph_optimize` 开关控制，不再保留独立 `TensorValueOptimizationPass`。

实现位置（相对于 triton-ascend）：

- `third_party/ascend/lib/TritonToGraph/Rules/NarrowUnsignedTensor.h`
- `third_party/ascend/lib/TritonToGraph/Rules/FoldHistogramParking.h`
- `third_party/ascend/lib/TritonToGraph/GraphOptimizationPass.cpp`

## 3. Test Result：测试结果

环境：TD Ascend950DT、物理卡3，`/home/kaixin2` / Conda `kaixin2`。
使用现有 `build_bishengir.sh` 和 `build_triton.sh` 重建，新缓存复测；
`TRITON_DEBUG=0`、`TRITON_DISABLE_LINE_INFO=1`。

测试原始 `_radix_topk_threshold`，**仅 threshold，不包含 pack 或完整算子端到端耗时**。
shape 为65536行×8192列，TopK=512、BLOCK_R=8192、256 buckets。

| 验证项 | 结果 |
| --- | --- |
| 合并到现有 pipeline 后的三次实测 | 7.333889 / 7.330401 / 7.329090 ms |
| 中位耗时 | **7.330401 ms**，守住7.5 ms目标 |
| 重构前独立 pass 版本 | 7.343421 ms；两次独立测试，不据此声称重构本身提速 |
| 全量精度 | 65536行与 CPU 参考结果完全一致 |
| 边界精度 | 64行边界数据通过 |
| 相关 Python 回归 | 81通过、30项原有跳过，非完整 Ascend CI |
| MLIR/FileCheck | 两条 RUN 均通过：A5消零、非A5保留补偿，以及有符号右移保护 |

MLIR 守护用例：
`third_party/ascend/unittest/Conversion/General/TritonToGraph/graph-optimize-radix-topk-threshold.mlir`。
它提炼一个 radix 轮次的关键结构，守护编译结果，不用于测量性能。

**归因边界：** 7.330 ms 使用了 NPUIR `c16c1071c` 的小桶 histogram 专用模板，
是当前 TA+NPUIR 组合的实测结果，不是两个 TA 规则各自的独立加速比。




# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
