### PR TITLE
[CustomOp] Emit and validate rank-specific flatten declarations

### DIFF
--- a/third_party/ascend/language/cann/extension/custom_op.py
+++ b/third_party/ascend/language/cann/extension/custom_op.py
@@ -312,6 +312,43 @@ def _add_optional_iterator_types_attr(op, builder, attrs):
     attrs[name] = builder.get_iterator_types_attr([iterator_type.value for iterator_type in getattr(op, name)])
 
 
+def _add_optional_flatten_symbols_attr(op, builder, attrs):
+    # `flatten_symbols` maps a collapsed rank to the symbol implementing the op
+    # at that rank, e.g. {1: "custom_add_1d"}. It is emitted as the paired
+    # `flatten_ranks` / `flatten_symbols` attributes `hivm-flatten-ops` reads:
+    # once the operands are collapsed to `flatten_ranks[i]` the op calls
+    # `flatten_symbols[i]` instead of `symbol`. A rank without an entry is
+    # never produced, so the op keeps its rank and its original `symbol`.
+    # Declaring the table promises equivalent implementations for every
+    # supported reassociation and layout. The compiler only flattens ops whose
+    # iterator types are all parallel; rank alone cannot encode axis semantics.
+    name = 'flatten_symbols'
+    if not hasattr(op, name):
+        return
+
+    table = getattr(op, name)
+    if not isinstance(table, dict):
+        raise TypeError(f"'{name}' should be a dict mapping a collapsed rank to a symbol.")
+    if not table:
+        raise ValueError(f"'{name}' should be non-empty.")
+    # Validate the entire declaration before constructing or publishing attrs.
+    # In particular, do not coerce 1.5 / '1' to rank 1, or None to a symbol.
+    for rank, symbol in table.items():
+        if isinstance(rank, bool) or not isinstance(rank, int):
+            raise TypeError(f"'{name}' ranks should be integers, excluding bool.")
+        if not 1 <= rank <= (1 << 63) - 1:
+            raise ValueError(f"'{name}' ranks should be positive signed 64-bit integers.")
+        if not isinstance(symbol, str):
+            raise TypeError(f"'{name}' symbols should be strings.")
+        if not symbol:
+            raise ValueError(f"'{name}' symbols should be non-empty.")
+    ranks = sorted(table)
+    ranks_attr = builder.get_i64_array_attr(ranks)
+    symbols_attr = builder.get_array_attr([builder.get_string_attr(table[rank]) for rank in ranks])
+    attrs['flatten_ranks'] = ranks_attr
+    attrs[name] = symbols_attr
+
+
 def _add_sync_event_slots_attr(op, builder, attrs):
     if not hasattr(op, 'sync_event_slots'):
         return
@@ -345,6 +382,7 @@ def _make_attrs(op, builder, is_macro):
 
     _add_optional_indexing_map_attr(op, builder, attrs)
     _add_optional_iterator_types_attr(op, builder, attrs)
+    _add_optional_flatten_symbols_attr(op, builder, attrs)
 
     _add_optional_extra_buffer_attr(op, builder, attrs)
 

--- a/third_party/ascend/unittest/pytest_ut/test_custom.py
+++ b/third_party/ascend/unittest/pytest_ut/test_custom.py
@@ -11,6 +11,8 @@ from triton._C.libtriton.ascend import ir as ascend_ir
 from triton.backends.ascend.compiler import NPUOptions, ttir_to_linalg
 import pytest
 
+pytestmark = pytest.mark.backend("none")
+
 
 def compile_kernel(kernel, signature, constants):
     """Helper to compile a kernel function to MLIR in linalg dialect."""
@@ -19,7 +21,7 @@ def compile_kernel(kernel, signature, constants):
     ir.load_dialects(context)
     ascend_ir.load_dialects(context)
     try:
-        options = NPUOptions()
+        options = NPUOptions(arch="Ascend910B1")
         ttir = ast_to_ttir(kernel, src, context, options, {}, {})
         metadata = {
             **options.__dict__,
@@ -163,6 +165,36 @@ def kernel_extra_buf_wide(x_ptr, out_ptr, n, BLOCK: tl.constexpr):
     tl.store(out_ptr + i, r, mask=i < n)
 
 
+@al.register_custom_op
+class my_custom_op_flatten:
+    """Custom op declaring the implementations hivm-flatten-ops may collapse to."""
+
+    core = al.CORE.VECTOR
+    pipe = al.PIPE.PIPE_V
+    mode = al.MODE.SIMD
+    symbol = "my_flatten_func_3d"
+    bitcode = os.path.abspath(__file__)
+    iterator_types = [
+        al.IteratorType.Parallel,
+        al.IteratorType.Parallel,
+        al.IteratorType.Parallel,
+    ]
+    # Declared out of order on purpose: the pair must come out sorted by rank.
+    flatten_symbols = {2: "my_flatten_func_2d", 1: "my_flatten_func_1d"}
+
+    def __init__(self, x, out=None):
+        pass
+
+
+@triton.jit
+def kernel_flatten(x_ptr, out_ptr, n, BLOCK: tl.constexpr):
+    i = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    x = tl.reshape(tl.load(x_ptr + i, mask=i < n), (4, 4, BLOCK // 16))
+    y = tl.reshape(tl.load(out_ptr + i, mask=i < n), (4, 4, BLOCK // 16))
+    r = al.custom("my_custom_op_flatten", x, out=y)
+    tl.store(out_ptr + i, tl.reshape(r, (BLOCK, )), mask=i < n)
+
+
 # ============== Pytest tests ==============
 
 
@@ -285,6 +317,37 @@ def test_custom_op_without_extra_buffers_has_no_extra_buffer_attrs():
         assert "extra_buffers_sizes" not in line
 
 
+def test_custom_op_flatten_symbols():
+    """flatten_symbols is emitted as the paired flatten_ranks / flatten_symbols attrs."""
+    mlir = compile_kernel(
+        kernel_flatten,
+        {"x_ptr": "*fp32", "out_ptr": "*fp32", "n": "i32"},
+        {"BLOCK": 256},
+    )
+    assert mlir and len(mlir) > 0
+    lines = _custom_lines(mlir, "my_custom_op_flatten")
+    assert lines, "expected at least one hivm.hir.custom line for my_custom_op_flatten"
+    line = lines[0]
+    # Ranks are sorted and paired with their symbol, whatever the dict order was.
+    assert "flatten_ranks = [1, 2]" in line
+    assert 'flatten_symbols = ["my_flatten_func_1d", "my_flatten_func_2d"]' in line
+    # The original symbol is untouched; the pass switches it after collapsing.
+    assert 'symbol = "my_flatten_func_3d"' in line
+    # The declaration describes a real rank-3 SIMD op before bufferization.
+    assert "tensor<4x4x16xf32>" in line
+    assert "#hivm.vf_mode<SIMD>" in line
+
+
+def test_custom_op_without_flatten_symbols_has_no_flatten_attrs():
+    """Ops that do not declare flatten_symbols should not emit the flatten attributes."""
+    mlir = compile_kernel(my_kernel, {"x_ptr": "*fp32", "y_ptr": "*fp32", "out_ptr": "*fp32", "n": "i32"},
+                          {"BLOCK": 256})
+    assert mlir
+    for line in _custom_lines(mlir, "my_custom_op"):
+        assert "flatten_ranks" not in line
+        assert "flatten_symbols" not in line
+
+
 # ============== Main for manual testing ==============
 
 if __name__ == "__main__":
@@ -293,6 +356,8 @@ if __name__ == "__main__":
     test_custom_op_extra_buffers_integer_variants()
     test_custom_op_extra_buffers_mixed_scalar_types()
     test_custom_op_extra_buffers_single_buffer()
+    test_custom_op_flatten_symbols()
+    test_custom_op_without_flatten_symbols_has_no_flatten_attrs()
     mlir = compile_kernel(my_kernel, {"x_ptr": "*fp32", "y_ptr": "*fp32", "out_ptr": "*fp32", "n": "i32"},
                           {"BLOCK": 256})
     print(f"✅ Generated MLIR ({len(mlir)} chars):\n")

--- a/third_party/ascend/unittest/pytest_ut/test_custom_flatten_declaration.py
+++ b/third_party/ascend/unittest/pytest_ut/test_custom_flatten_declaration.py
@@ -1,0 +1,86 @@
+"""Validate declarations before any builder call or attribute mutation."""
+from types import SimpleNamespace
+
+import pytest
+
+from triton._C.libtriton import ir
+from triton._C.libtriton.ascend import ir as ascend_ir
+from triton.language.extra.cann.extension.custom_op import _add_optional_flatten_symbols_attr
+
+pytestmark = pytest.mark.backend("none")
+
+
+class RejectBuilderCalls:
+
+    def __getattr__(self, name):
+        raise AssertionError(f"Invalid declaration reached builder.{name}")
+
+
+@pytest.mark.parametrize("table,error", [
+    (None, TypeError),
+    ([], TypeError),
+    ([(1, "f")], TypeError),
+    ({}, ValueError),
+    ({True: "f"}, TypeError),
+    ({False: "f"}, TypeError),
+    ({1.5: "f"}, TypeError),
+    ({1.0: "f"}, TypeError),
+    ({"1": "f"}, TypeError),
+    ({1: "first", "1": "second"}, TypeError),
+    ({1.1: "first", 1.9: "second"}, TypeError),
+    ({0: "f"}, ValueError),
+    ({-1: "f"}, ValueError),
+    ({1 << 63: "f"}, ValueError),
+    ({1: None}, TypeError),
+    ({1: 7}, TypeError),
+    ({1: []}, TypeError),
+    ({1: ""}, ValueError),
+    ({1: "valid", 2: None}, TypeError),
+])
+def test_invalid_flatten_declaration_is_atomic(table, error):
+    attrs = {"preserved": object()}
+    before = dict(attrs)
+    with pytest.raises(error, match="flatten_symbols"):
+        _add_optional_flatten_symbols_attr(SimpleNamespace(flatten_symbols=table), RejectBuilderCalls(), attrs)
+    assert attrs == before
+
+
+def test_absent_flatten_declaration_does_not_use_builder():
+    attrs = {"preserved": object()}
+    before = dict(attrs)
+    _add_optional_flatten_symbols_attr(SimpleNamespace(), RejectBuilderCalls(), attrs)
+    assert attrs == before
+
+
+def _print_module_attrs(builder, attrs):
+    module = builder.create_module()
+    for name, attr in attrs.items():
+        module.set_attr(name, attr)
+    return str(module)
+
+
+def test_flatten_declaration_with_real_builder():
+    context = ir.context()
+    ir.load_dialects(context)
+    ascend_ir.load_dialects(context)
+    builder = ascend_ir.ascendnpu_ir_builder(context, "Ascend910B1")
+    attrs = {}
+    table = {2: "second", 1: "first"}
+    _add_optional_flatten_symbols_attr(SimpleNamespace(flatten_symbols=table), builder, attrs)
+    text = _print_module_attrs(builder, attrs)
+    assert "flatten_ranks = [1, 2]" in text
+    assert 'flatten_symbols = ["first", "second"]' in text
+    assert list(table.items()) == [(2, "second"), (1, "first")]
+
+
+def test_flatten_symbol_escaping_with_real_builder():
+    context = ir.context()
+    ir.load_dialects(context)
+    ascend_ir.load_dialects(context)
+    builder = ascend_ir.ascendnpu_ir_builder(context, "Ascend910B1")
+    attrs = {}
+    symbol = 'quoted"symbol\\suffix'
+    _add_optional_flatten_symbols_attr(SimpleNamespace(flatten_symbols={1: symbol}), builder, attrs)
+    text = _print_module_attrs(builder, attrs)
+    # Inspect the real MLIR printer's quote and backslash escaping.
+    assert r'flatten_symbols = ["quoted\22symbol\\suffix"]' in text


### PR DESCRIPTION
## Summary

CustomOp implementations can provide functions for flattened ranks, but the frontend must validate and preserve that declaration in HIVM. This change validates the rank-to-symbol mapping, emits paired `flatten_ranks` and `flatten_symbols` attributes in deterministic rank order, and adds declaration and real-builder tests, including optimized Python execution.

The work is associated with [AscendNPU-IR issue #258](https://gitcode.com/Ascend/AscendNPU-IR/issues/258) and [design PR #360](https://gitcode.com/Ascend/EcoDevHub/merge_requests/360). The actual flattening transformation depends on [the compiler implementation](https://gitcode.com/Ascend/AscendNPU-IR/merge_requests/3347); frontend declaration tests can run independently.

## Review scope and dependencies

The [single commit `26f3e09ae`](https://github.com/xchencehn/triton-ascend/commit/26f3e09ae96413c9531e91754a858126c6ef1a7a) changes 144 non-comment source lines relative to `fe60c1e36`. This is a draft for early review. Before requesting merge, the branch will be rebased onto the current main branch and the resulting diff and required tests will be checked again.

## Validation

The retained commit was built using the repository's Ascend build entry point. Declaration and real-builder tests passed in both ordinary Python and `python -O`, with 29 tests passing in each mode. These results correspond to base `fe60c1e36`; the current upstream head is `6e15848cf`. No claim is made that the newer upstream integration has been rebuilt. The complete Triton-to-NPU comparison against PyTorch remains separate work.

## New contributor declaration

- [x] This change implements functional behavior and is not a trivial edit.
- [x] The description explains the problem and the resulting behavior.
- [ ] The required pre-commit checks have been run for the final rebased commit.
- [x] Tests have been added under the Ascend Python unit tests.
- [x] No lit tests have been added.
