### PR TITLE
[ssbuffer](fix) do not erase live ops or stale manager entries

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h
+++ b/third_party/ascend/include/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.h
@@ -52,6 +52,8 @@ public:
   void updateBlockIdWithInner(Operation *parentOp, int targetId);
   void updateBlockId(Operation *op, int blockId);
 
+  void forgetOp(Operation *op);
+
   bool shouldInheritFromParent(Block *block, CoreType requiredCoreType) const;
   llvm::LogicalResult inheritFromParent(Block *block);
 

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ComputeBlockIdManager.cpp
@@ -143,6 +143,27 @@ void ComputeBlockIdManager::updateBlockId(Operation *op, int blockId) {
   blockIdToOps[blockId].push_back(op);
 }
 
+void ComputeBlockIdManager::forgetOp(Operation *op) {
+  if (!op) {
+    return;
+  }
+
+  auto it = opToBlockId.find(op);
+  if (it == opToBlockId.end()) {
+    return; // never recorded, nothing to drop
+  }
+
+  const int blockId = it->second;
+  if (auto vecIt = blockIdToOps.find(blockId); vecIt != blockIdToOps.end()) {
+    auto &vec = vecIt->second;
+    auto found = llvm::find(vec, op);
+    if (found != vec.end()) {
+      vec.erase(found);
+    }
+  }
+  opToBlockId.erase(it);
+}
+
 llvm::ArrayRef<Operation *>
 ComputeBlockIdManager::getOpsRefByBlockId(int blockId) const {
   if (blockId == -1) {

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/RefineArgsBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/RefineArgsBlockId.cpp
@@ -29,6 +29,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Debug.h"
 
@@ -40,23 +41,34 @@ static constexpr const char *DEBUG_TYPE = "refine-args-block-id";
 
 using namespace mlir::triton;
 
-static void eraseOpsWithUnusedUsers(Operation *op, Block *loopBlock) {
-  llvm::SetVector<Operation *> toErase;
-  llvm::SetVector<Operation *> visited;
-  SmallVector<Operation *> worklist;
+static void eraseOpsWithUnusedUsers(Operation *op, Block *loopBlock,
+                                    CVPipeline::ComputeBlockIdManager &bm) {
+  llvm::SetVector<Operation *> worklist;
 
-  worklist.push_back(op);
+  worklist.insert(op);
 
   while (!worklist.empty()) {
     Operation *cur = worklist.pop_back_val();
+    // Stay inside the loop body the caller handed us.
+    if (cur->getBlock() != loopBlock) {
+      continue;
+    }
+    // No users left and no side effects to lose: the only condition under which
+    // erasing is legal.
+    if (!isOpTriviallyDead(cur)) {
+      continue;
+    }
+    // Operands have to be collected before erase(): afterwards `cur` is gone.
+    SmallVector<Operation *> producers;
     for (Value operand : cur->getOperands()) {
       if (Operation *defOp = operand.getDefiningOp()) {
-        if (defOp->getResult(0).getNumUses() == 1) {
-          worklist.push_back(defOp);
-        }
+        producers.push_back(defOp);
       }
     }
+    bm.forgetOp(cur);
     cur->erase();
+    // Re-examine the producers now that their uses have actually been dropped.
+    worklist.insert(producers.begin(), producers.end());
   }
 }
 
@@ -247,7 +259,7 @@ static void processOneLoop(Operation *loopOp,
     yieldOp.setOperand(i, mapping.lookup(yieldDefOp->getResult(0)));
 
     // Erase original yieldDefOp and its upstream ops that have no more users
-    eraseOpsWithUnusedUsers(yieldDefOp, loopBlock);
+    eraseOpsWithUnusedUsers(yieldDefOp, loopBlock, bm);
     LOG_DEBUG("Successfully moved iter_arg " << i << " from block "
                                              << updateBlockId << " to block "
                                              << firstUserBlockId << "\n");


### PR DESCRIPTION
eraseOpsWithUnusedUsers removed the yield's defining op unconditionally, on the assumption that rewiring the yield onto the clone had dropped its last use. A loop-carried value is regularly consumed inside the body as well, so the assumption does not hold and the remaining consumers were left with dangling operands. It also counted uses on getResult(0) rather than on the result that was actually the operand, which reports a multi-result op as dead while other results are live.

ComputeBlockIdManager caches raw Operation pointers in blockIdToOps and opToBlockId and had no way to invalidate them, so erased operations stayed in the maps. cloneDepSubgraph and willCreateCycle dereference that vector through getOpsByBlockId, and the manager is constructed once per module, so an erase performed for one main loop corrupts the next. Add forgetOp and withdraw an operation before erasing it.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `the defect is a use-after-free, not a difference in emitted IR. With the bug present the pass dereferences freed memory, which surfaces as a crash whose symptom depends on the allocator rather than as a stable diagnostic; with it fixed, the IR produced for any input that previously survived is byte-identical. There is therefore nothing for FileCheck to assert on. Built and exercised on a flash-attention kernel that goes through the dynamic CV pipeline; generated code is unchanged for inputs that previously compiled, and a case that previously aborted inside RefineArgsBlockIdPass now completes`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
