### PR TITLE
[TritonMemoryAccess](fix) avoid reusing loop init values for masks

### DIFF
--- a/third_party/ascend/lib/TritonMemoryAccess/MaskAnalysis.cpp
+++ b/third_party/ascend/lib/TritonMemoryAccess/MaskAnalysis.cpp
@@ -96,17 +96,9 @@ LogicalResult MaskState::parse(Value operand, const Location &loc,
     return parseIntScalar(operand, loc, builder);
   }
 
-  if (auto blockArgument = dyn_cast<BlockArgument>(operand)) {
-    auto parentOp = blockArgument.getOwner()->getParentOp();
-    if (auto loopOp = dyn_cast<LoopLikeOpInterface>(parentOp)) {
-      OpOperand *initArgOperand = loopOp.getTiedLoopInit(blockArgument);
-      if (initArgOperand) {
-        Value initArg = initArgOperand->get();
-        return parse(initArg, loc, builder);
-      }
-    }
-  }
-
+  // A tensor loop argument represents the current iteration, not its init.
+  // Leave invariant argument elimination to canonicalization; an argument with
+  // no defining operation must fail analysis and use the existing fallback.
   auto definingOp = operand.getDefiningOp();
   if (!definingOp)
     return failure();

--- a/third_party/ascend/unittest/Conversion/General/TritonToLinalg/loop_carried_select.mlir
+++ b/third_party/ascend/unittest/Conversion/General/TritonToLinalg/loop_carried_select.mlir
@@ -1,0 +1,108 @@
+// RUN: triton-opt --triton-to-linalg --split-input-file %s | FileCheck %s --check-prefixes=CHECK,CANON
+// RUN: triton-opt --canonicalize --triton-to-linalg --split-input-file %s | FileCheck %s --check-prefix=CANON
+
+// A changing tensor must keep the current iteration's predicate, rather than
+// deriving a slice length from the initial range.
+// CHECK-LABEL: func.func @changing_for
+// CHECK: scf.for {{.*}} iter_args(%[[OFFSETS:[a-zA-Z0-9_]+]] =
+// CHECK: %[[MASK:.*]] = linalg.generic {{.*}} ins(%[[OFFSETS]],
+// CHECK: arith.cmpi slt,
+// CHECK: linalg.generic {{.*}} ins(%[[MASK]],
+// CHECK: arith.select {{.*}} : i32
+func.func @changing_for(%n: i32, %steps: index, %yes: tensor<32xi32>, %no: tensor<32xi32>) -> tensor<32xi32> {
+  %zero = arith.constant 0 : index
+  %one = arith.constant 1 : index
+  %stride = arith.constant dense<32> : tensor<32xi32>
+  %range = tt.make_range {start = 0 : i32, end = 32 : i32} : tensor<32xi32>
+  %limit = tt.splat %n : i32 -> tensor<32xi32>
+  %result:2 = scf.for %i = %zero to %steps step %one iter_args(%offsets = %range, %acc = %no) -> (tensor<32xi32>, tensor<32xi32>) {
+    %mask = arith.cmpi slt, %offsets, %limit : tensor<32xi32>
+    %selected = arith.select %mask, %yes, %acc : tensor<32xi1>, tensor<32xi32>
+    %next = arith.addi %offsets, %stride : tensor<32xi32>
+    scf.yield %next, %selected : tensor<32xi32>, tensor<32xi32>
+  }
+  return %result#1 : tensor<32xi32>
+}
+
+// -----
+
+// Canonicalization removes the unchanged carrier before select analysis, so
+// the rectangular optimization needs no invariance analysis in MaskState.
+// TritonToLinalg also canonicalizes internally; both RUN lines retain this path.
+// CANON-LABEL: func.func @invariant_for
+// CANON-NOT: arith.select
+// CANON: tensor.extract_slice
+// CANON: tensor.insert_slice
+// CANON-NOT: arith.select
+// CANON: return
+func.func @invariant_for(%n: i32, %steps: index, %yes: tensor<32xi32>, %no: tensor<32xi32>) -> tensor<32xi32> {
+  %zero = arith.constant 0 : index
+  %one = arith.constant 1 : index
+  %range = tt.make_range {start = 0 : i32, end = 32 : i32} : tensor<32xi32>
+  %limit = tt.splat %n : i32 -> tensor<32xi32>
+  %result:2 = scf.for %i = %zero to %steps step %one iter_args(%offsets = %range, %acc = %no) -> (tensor<32xi32>, tensor<32xi32>) {
+    %mask = arith.cmpi slt, %offsets, %limit : tensor<32xi32>
+    %selected = arith.select %mask, %yes, %acc : tensor<32xi1>, tensor<32xi32>
+    scf.yield %offsets, %selected : tensor<32xi32>, tensor<32xi32>
+  }
+  return %result#1 : tensor<32xi32>
+}
+
+// -----
+
+// The inner carrier is unchanged, but its init is a changing outer carrier.
+// CHECK-LABEL: func.func @nested_for
+// CHECK: scf.for
+// CHECK: scf.for
+// CHECK: arith.cmpi slt,
+// CHECK: arith.select {{.*}} : i32
+func.func @nested_for(%n: i32, %steps: index, %yes: tensor<32xi32>, %no: tensor<32xi32>) -> tensor<32xi32> {
+  %zero = arith.constant 0 : index
+  %one = arith.constant 1 : index
+  %stride = arith.constant dense<32> : tensor<32xi32>
+  %range = tt.make_range {start = 0 : i32, end = 32 : i32} : tensor<32xi32>
+  %limit = tt.splat %n : i32 -> tensor<32xi32>
+  %result:2 = scf.for %i = %zero to %steps step %one iter_args(%offsets = %range, %acc = %no) -> (tensor<32xi32>, tensor<32xi32>) {
+    %inner:2 = scf.for %j = %zero to %steps step %one iter_args(%lanes = %offsets, %value = %acc) -> (tensor<32xi32>, tensor<32xi32>) {
+      %mask = arith.cmpi slt, %lanes, %limit : tensor<32xi32>
+      %selected = arith.select %mask, %yes, %value : tensor<32xi1>, tensor<32xi32>
+      scf.yield %lanes, %selected : tensor<32xi32>, tensor<32xi32>
+    }
+    %next = arith.addi %offsets, %stride : tensor<32xi32>
+    scf.yield %next, %inner#1 : tensor<32xi32>, tensor<32xi32>
+  }
+  return %result#1 : tensor<32xi32>
+}
+
+// -----
+
+// A while before-region argument also changes on the backedge. The forwarded
+// after-region argument is not directly tied to the loop init either.
+// CHECK-LABEL: func.func @changing_while
+// CHECK: scf.while
+// CHECK: arith.cmpi slt,
+// CHECK: arith.select {{.*}} : i32
+// CHECK: scf.condition
+// CHECK: arith.cmpi slt,
+// CHECK: arith.select {{.*}} : i32
+func.func @changing_while(%n: i32, %steps: i32, %yes: tensor<32xi32>, %no: tensor<32xi32>) -> tensor<32xi32> {
+  %zero = arith.constant 0 : i32
+  %one = arith.constant 1 : i32
+  %stride = arith.constant dense<32> : tensor<32xi32>
+  %range = tt.make_range {start = 0 : i32, end = 32 : i32} : tensor<32xi32>
+  %limit = tt.splat %n : i32 -> tensor<32xi32>
+  %result:3 = scf.while (%i = %zero, %offsets = %range, %acc = %no) : (i32, tensor<32xi32>, tensor<32xi32>) -> (i32, tensor<32xi32>, tensor<32xi32>) {
+    %mask = arith.cmpi slt, %offsets, %limit : tensor<32xi32>
+    %selected = arith.select %mask, %yes, %acc : tensor<32xi1>, tensor<32xi32>
+    %next = arith.addi %offsets, %stride : tensor<32xi32>
+    %continue = arith.cmpi slt, %i, %steps : i32
+    scf.condition(%continue) %i, %next, %selected : i32, tensor<32xi32>, tensor<32xi32>
+  } do {
+  ^bb0(%i: i32, %offsets: tensor<32xi32>, %acc: tensor<32xi32>):
+    %mask = arith.cmpi slt, %offsets, %limit : tensor<32xi32>
+    %selected = arith.select %mask, %acc, %no : tensor<32xi1>, tensor<32xi32>
+    %next = arith.addi %i, %one : i32
+    scf.yield %next, %offsets, %selected : i32, tensor<32xi32>, tensor<32xi32>
+  }
+  return %result#2 : tensor<32xi32>
+}

--- a/third_party/ascend/unittest/pytest_ut/test_loop_carried_mask.py
+++ b/third_party/ascend/unittest/pytest_ut/test_loop_carried_mask.py
@@ -1,0 +1,137 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _loop_carried_mask_kernel(src, dst, n, steps, BLOCK: tl.constexpr, MASK_USE: tl.constexpr,
+                              CARRY_INDEX: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    offsets = lanes
+    src_ptrs = src + lanes
+    dst_ptrs = dst + lanes
+    for iteration in range(steps):
+        if CARRY_INDEX:
+            mask = offsets < n
+        else:
+            # Equivalent scalar-index control; both variants advance pointers.
+            mask = iteration * BLOCK + lanes < n
+        if MASK_USE == "load":
+            values = tl.load(src_ptrs, mask=mask, other=-1)
+            tl.store(dst_ptrs, values)
+        elif MASK_USE == "store":
+            values = tl.load(src_ptrs)
+            tl.store(dst_ptrs, values, mask=mask)
+        else:
+            values = tl.load(src_ptrs)
+            tl.store(dst_ptrs, tl.where(mask, values, -1))
+        offsets += BLOCK
+        src_ptrs += BLOCK
+        dst_ptrs += BLOCK
+
+
+@pytest.mark.parametrize("mask_use", ["load", "store", "select"])
+@pytest.mark.parametrize("carry_index", [False, True], ids=["scalar_index", "tensor_index"])
+def test_loop_carried_mask(mask_use, carry_index):
+    """A full tile, a 3-lane tail and an empty tile need different masks."""
+    block, n, steps = 32, 35, 3
+    # Back the entire traversal, including masked-off lanes, with real storage.
+    # Incorrect masks then cause deterministic value errors, not allocator OOB.
+    source_cpu = torch.arange(1, steps * block + 1, dtype=torch.int32)
+    output_cpu = torch.full_like(source_cpu, -2)
+    source, output = source_cpu.npu(), output_cpu.npu()
+
+    _loop_carried_mask_kernel[(1, )](
+        source,
+        output,
+        n,
+        steps,
+        BLOCK=block,
+        MASK_USE=mask_use,
+        CARRY_INDEX=carry_index,
+        enable_auto_bind_sub_block=False,
+    )
+
+    expected = source_cpu.clone()
+    expected[n:] = -2 if mask_use == "store" else -1
+    torch.testing.assert_close(output.cpu(), expected, rtol=0, atol=0)
+
+
+@triton.jit
+def _masked_access(src, dst, mask, MASK_USE: tl.constexpr):
+    if MASK_USE == "load":
+        tl.store(dst, tl.load(src, mask=mask, other=-1))
+    elif MASK_USE == "store":
+        tl.store(dst, tl.load(src), mask=mask)
+    elif MASK_USE == "atomic_add":
+        tl.atomic_add(dst, tl.load(src), mask=mask)
+    else:
+        tl.store(dst, tl.where(mask, tl.load(src), -1))
+
+
+@triton.jit
+def _changing_predicate_kernel(src, dst, steps, BLOCK: tl.constexpr, MASK_USE: tl.constexpr, WHILE_LOOP: tl.constexpr):
+    lanes = tl.arange(0, BLOCK)
+    mask = lanes < 3
+    if WHILE_LOOP:
+        iteration = 0
+        while iteration < steps:
+            offsets = iteration * BLOCK + lanes
+            _masked_access(src + offsets, dst + offsets, mask, MASK_USE)
+            mask = ~mask
+            iteration += 1
+    else:
+        for iteration in range(steps):
+            offsets = iteration * BLOCK + lanes
+            _masked_access(src + offsets, dst + offsets, mask, MASK_USE)
+            mask = ~mask
+
+
+@pytest.mark.parametrize("mask_use", ["load", "store", "select", "atomic_add"])
+@pytest.mark.parametrize("while_loop", [False, True], ids=["for", "while"])
+def test_changing_loop_predicate(mask_use, while_loop):
+    """The predicate itself changes; scalarizing pointer offsets cannot fix it."""
+    block, steps = 32, 3
+    source_cpu = torch.arange(1, steps * block + 1, dtype=torch.int32)
+    source = source_cpu.npu()
+    output = torch.full_like(source, -2)
+    _changing_predicate_kernel[(1, )](
+        source,
+        output,
+        steps,
+        BLOCK=block,
+        MASK_USE=mask_use,
+        WHILE_LOOP=while_loop,
+        enable_auto_bind_sub_block=False,
+        compile_mode="simd",
+    )
+    active = torch.arange(block) < 3
+    mask = torch.stack([active, ~active, active]).flatten()
+    if mask_use == "atomic_add":
+        expected = torch.where(mask, source_cpu - 2, -2)
+    else:
+        other = -2 if mask_use == "store" else -1
+        expected = torch.where(mask, source_cpu, other)
+    torch.testing.assert_close(output.cpu(), expected, rtol=0, atol=0)


### PR DESCRIPTION
Loop-carried tensors can change across iterations. Analyzing their initial values produces incorrect mask bounds for loads, stores and selects.

Stop tracing tensor loop arguments to their initial values and use the existing fallback when analysis fails.

Add MLIR and pytest regressions for loop-carried indices and changing predicates.