### PR TITLE
[ssbuffer](fix) Earlier store avoid cc overflow

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeCubeBlock.cpp
@@ -52,7 +52,6 @@ static const llvm::DenseSet<llvm::StringRef> kDisableMergeCubeKernel = {
     "pcb06_tc02_c2v2v2c_chain",
     "flex_attention_backward_dq_kernel",
     "parallel_deltaformer_bwd_kernel_qk",
-    "_parallel_hstu_attn_bwd",
     "chunk_kda_bwd_kernel_intra",
     "chunk_gated_delta_rule_fwd_kernel_h_blockdim64",
 };

--- a/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PlanComputeBlock/ReorderOpsByBlockId.cpp
@@ -24,6 +24,7 @@
 #include <string_view>
 #include <utility>
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
@@ -346,23 +347,91 @@ GroupAdjacencyGraph::computeTopologicalOrder() {
 }
 
 static bool isStoreLikeWithRegion(Operation *op) {
-  if (isa<hivm::StoreOp, bufferization::MaterializeInDestinationOp>(op)) {
-    return true;
-  }
   auto ret = op->walk([&](Operation *subOp) {
     if (isa<hivm::StoreOp, bufferization::MaterializeInDestinationOp>(subOp)) {
       return WalkResult::interrupt();
     }
     return WalkResult::advance();
   });
-  return ret == WalkResult::interrupt();
+  return ret.wasInterrupted();
+}
+
+static SmallVector<Operation *>
+orderInOneCBlock(ArrayRef<Operation *> opsInSameBlock,
+                 const MemoryDependenceGraph &memGraph) {
+  // reorder in one compute block following rules:
+  // 1. vecoter block should sink storeLike Op. (only Vector)
+  // 2. Other
+  SmallVector<Operation *> originOrder(opsInSameBlock.begin(),
+                                       opsInSameBlock.end());
+  if (llvm::any_of(opsInSameBlock, [&](Operation *op) {
+        return CVPipeline::getCoreTypeOfSimpleOpOrCf(op) !=
+               CVPipeline::VECTOR_ONLY;
+      })) {
+    // If this is one CUBE block, storeLike Ops no need to sink down.
+    // Considering
+    //  1. CUBE block's store is always use FIXPIPE
+    //  2. C->V always just next to matmul.
+    // So there are no conflict between store and  inter transfer
+    return originOrder;
+  }
+
+  if (llvm::all_of(opsInSameBlock,
+                   [&](Operation *op) { return !isStoreLikeWithRegion(op); })) {
+    // If there are no store-like op, early return.
+    return originOrder;
+  }
+  Block *block = opsInSameBlock.front()->getBlock();
+  BlockOpGraph graph{opsInSameBlock, block, memGraph};
+
+  // Kahn's topological sort. Track in-degree per op and seed the ready set
+  // with all ops that have no predecessors.
+  DenseMap<Operation *, unsigned> inDeg;
+  SmallVector<Operation *> ready;
+  for (Operation *op : opsInSameBlock) {
+    inDeg[op] = graph.preds.at(op).size();
+    if (inDeg[op] == 0) {
+      ready.push_back(op);
+    }
+  }
+
+  // Tie-breaker among ready (in-degree 0) ops:
+  // 1. Non-store-like ops come first (sink store-like ops to the end).
+  // 2. The op with a smaller opIndex wins (preserve original program order).
+  auto comesBefore = [&](Operation *a, Operation *b) {
+    bool aStore = isStoreLikeWithRegion(a);
+    bool bStore = isStoreLikeWithRegion(b);
+    if (aStore != bStore) {
+      return !aStore;
+    }
+    return graph.opIndex.at(a) < graph.opIndex.at(b);
+  };
+
+  SmallVector<Operation *> ordered;
+  ordered.reserve(opsInSameBlock.size());
+  while (!ready.empty()) {
+    // Pick the best candidate under the tie-breaking rules.
+    auto bestIt = std::min_element(ready.begin(), ready.end(), comesBefore);
+    Operation *cur = *bestIt;
+    ready.erase(bestIt);
+
+    ordered.push_back(cur);
+
+    // Release successors; any that drop to in-degree 0 become ready.
+    for (Operation *succ : graph.succs.at(cur)) {
+      if (--inDeg[succ] == 0) {
+        ready.push_back(succ);
+      }
+    }
+  }
+
+  return ordered;
 }
 
 // Stable sort ops based on their group orders
-static llvm::FailureOr<SmallVector<Operation *>>
-buildReorderedOps(const BlockOpGraph &graph,
-                  const DenseMap<Operation *, int> &opBlockId,
-                  ComputeBlockIdManager &bm) {
+static llvm::FailureOr<SmallVector<Operation *>> buildReorderedOps(
+    const BlockOpGraph &graph, const DenseMap<Operation *, int> &opBlockId,
+    ComputeBlockIdManager &bm, const MemoryDependenceGraph &memGraph) {
   SmallVector<Operation *> reordered;
   GroupAdjacencyGraph adjacencyGraph{graph, opBlockId, bm};
   auto groupOrderResult = adjacencyGraph.computeTopologicalOrder();
@@ -371,19 +440,16 @@ buildReorderedOps(const BlockOpGraph &graph,
   }
 
   for (int const blockId : groupOrderResult.value()) {
-    SmallVector<Operation *> storeOps;
+    SmallVector<Operation *>
+        originOrderOp; // collect ops following program order.
     for (Operation *op : graph.ops) {
       if (opBlockId.at(op) == blockId) {
-        if (isStoreLikeWithRegion(op)) {
-          storeOps.push_back(op);
-          continue;
-        }
-        reordered.push_back(op);
+        originOrderOp.push_back(op);
       }
     }
-    for (auto op : storeOps) {
-      reordered.push_back(op);
-    }
+    SmallVector<Operation *> orderedInOneCBlock =
+        orderInOneCBlock(originOrderOp, memGraph);
+    reordered.append(orderedInOneCBlock);
   }
   return reordered;
 }
@@ -420,7 +486,7 @@ reorderOpsInBlock(Block &block, const MemoryDependenceGraph &memGraph,
     LOG_DEBUG("  Op: " << *op << ", opBlockId = " << opBlockId[op] << "\n");
   }
 
-  const auto reorderedRes = buildReorderedOps(graph, opBlockId, bm);
+  const auto reorderedRes = buildReorderedOps(graph, opBlockId, bm, memGraph);
   if (failed(reorderedRes)) {
     return failure();
   }

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_reorder_ops_by_block_id.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/PlanComputeBlock/test_reorder_ops_by_block_id.mlir
@@ -1,0 +1,102 @@
+// RUN: triton-opt --reorder-ops-by-block-id %s | FileCheck %s
+
+// Tests for orderInOneCBlock in ReorderOpsByBlockIdPass.
+//
+// The pass reorders operations within a compute block using a Kahn's
+// topological sort with a tie-breaker that sinks store-like ops
+// (materialize_in_destination / hivm.hir.store) to the end of VECTOR_ONLY
+// blocks, while respecting SSA and memory dependencies.
+// CUBE blocks (any block containing a non-VECTOR_ONLY op) preserve the
+// original program order.
+
+module {
+  // ============================================================================
+  // 1. cube_block_store_not_last
+  //
+  // A CUBE block where bufferization.materialize_in_destination is NOT the
+  // last op. In CUBE blocks, orderInOneCBlock preserves the original program
+  // order (store-like ops are NOT sunk).
+  //
+  // Program order:  materialize, matmul
+  // Expected:       materialize, matmul  (unchanged)
+  // ============================================================================
+  // CHECK-LABEL: func.func @cube_block_store_not_last(
+  // CHECK: bufferization.materialize_in_destination {{.*}} ssbuffer.core_type = "CUBE"
+  // CHECK: linalg.matmul {{.*}} ssbuffer.core_type = "CUBE"
+  func.func @cube_block_store_not_last(
+      %arg0: memref<64x64xf16>,
+      %in1: tensor<64x64xf16>,
+      %A: tensor<64x64xf16>,
+      %B: tensor<64x64xf16>,
+      %init: tensor<64x64xf16>) {
+    bufferization.materialize_in_destination %in1 in writable %arg0 {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"} : (tensor<64x64xf16>, memref<64x64xf16>) -> ()
+    %mm = linalg.matmul {ssbuffer.block_id = 2 : i32, ssbuffer.core_type = "CUBE"}
+      ins(%A, %B : tensor<64x64xf16>, tensor<64x64xf16>)
+      outs(%init : tensor<64x64xf16>) -> tensor<64x64xf16>
+    return
+  }
+
+  // ============================================================================
+  // 2. vector_materialize_in_middle
+  //
+  // A VECTOR_ONLY block where bufferization.materialize_in_destination sits
+  // between two independent VECTOR compute ops. After reorder, the store
+  // sinks past the independent compute op to the end.
+  //
+  // Program order:  addf, materialize(addf), mulf
+  // Expected:       addf, mulf, materialize
+  // ============================================================================
+  // CHECK-LABEL: func.func @vector_materialize_in_middle(
+  // CHECK: arith.addf {{.*}} ssbuffer.core_type = "VECTOR"
+  // CHECK: arith.mulf {{.*}} ssbuffer.core_type = "VECTOR"
+  // CHECK: bufferization.materialize_in_destination {{.*}} ssbuffer.core_type = "VECTOR"
+  func.func @vector_materialize_in_middle(
+      %arg0: memref<64xf32>,
+      %in1: tensor<64xf32>,
+      %in2: tensor<64xf32>) -> (tensor<64xf32>, tensor<64xf32>) {
+    %a = arith.addf %in1, %in1 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+    bufferization.materialize_in_destination %a in writable %arg0 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64xf32>, memref<64xf32>) -> ()
+    %b = arith.mulf %in2, %in2 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+    return %a, %b : tensor<64xf32>, tensor<64xf32>
+  }
+
+  // ============================================================================
+  // 3. vector_store_inside_scf_if_sinks
+  //
+  // bufferization.materialize_in_destination is wrapped inside an scf.if.
+  // The scf.if carries ssbuffer.block_id and ssbuffer.core_type so it is in
+  // the same VECTOR_ONLY compute block. The scf.if returns a value used by
+  // another VECTOR compute op. Since the scf.if contains a store-like op,
+  // isStoreLikeWithRegion(scf.if) == true, so the scf.if itself is treated
+  // as store-like and sinks past independent VECTOR ops, while respecting
+  // the SSA dependency from the consuming compute op.
+  //
+  // Program order:  scf.if(+store), independent_mulf, use_addf(if_result)
+  // Expected:       independent_mulf, scf.if, use_addf
+  //                  (scf.if sinks past mulf but not past use_addf which
+  //                   depends on it)
+  // ============================================================================
+  // CHECK-LABEL: func.func @vector_store_inside_scf_if_sinks(
+  // CHECK: arith.mulf {{.*}} ssbuffer.core_type = "VECTOR"
+  // CHECK: scf.if
+  // CHECK: } {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"}
+  // CHECK: arith.addf {{.*}} ssbuffer.core_type = "VECTOR"
+  func.func @vector_store_inside_scf_if_sinks(
+      %cond: i1,
+      %arg0: memref<64xf32>,
+      %in: tensor<64xf32>,
+      %in2: tensor<64xf32>) -> (tensor<64xf32>, tensor<64xf32>) {
+    %result = "scf.if"(%cond) ({
+      %val = arith.addf %in, %in {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+      bufferization.materialize_in_destination %val in writable %arg0 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64xf32>, memref<64xf32>) -> ()
+      "scf.yield"(%val) : (tensor<64xf32>) -> ()
+    }, {
+      %val2 = arith.mulf %in, %in {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+      bufferization.materialize_in_destination %val2 in writable %arg0 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (tensor<64xf32>, memref<64xf32>) -> ()
+      "scf.yield"(%val2) : (tensor<64xf32>) -> ()
+    }) {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : (i1) -> tensor<64xf32>
+    %independent = arith.mulf %in2, %in2 {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+    %use = arith.addf %result, %result {ssbuffer.block_id = 1 : i32, ssbuffer.core_type = "VECTOR"} : tensor<64xf32>
+    return %independent, %use : tensor<64xf32>, tensor<64xf32>
+  }
+}


### PR DESCRIPTION
# Summary

This PR fixes a CC overflow issue caused by reordering store-like operations.

Previously, store-like operations were always moved to the end of a compute block during block reordering. However, this reordering is unnecessary for CUBE blocks and may lead to CC overflow.

# Changes
- Introduces separate ordering logic for operations within a compute block.
- Keeps the original operation order for CUBE blocks.
- Continues to sink store-like operations to the end for VECTOR blocks.
- Removes `_parallel_hstu_attn_bwd` from the MergeCubeBlock disable list.

This avoids unnecessary store reordering in CUBE blocks while preserving the existing ordering optimization for VECTOR blocks.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
