### PR TITLE
[ssbuffer](fix) tag-driven outer-scope transfer-chain classification …

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.h
+++ b/third_party/ascend/include/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.h
@@ -40,13 +40,16 @@ struct BufferAllocPair {
   Operation *markOp = nullptr;
 };
 
-/// Transfer operation chain for sender or receiver side
+/// Transfer chain for one side. Tag+dataflow classification:
+/// - writes a group buffer: sender
+/// - first value-read of a group buffer: receiver head
 struct TransferOpChain {
   Operation *waitOp = nullptr;
-  Operation *transferOp =
-      nullptr; // fixpipe / hir.copy / memory_space_cast / convert_layout
+  Operation *transferOp = nullptr;
+  // Group-buffer operand of transferOp; remapped to the spare buffer on wrap
+  Value bufferOperand;
   Operation *toTensorOp =
-      nullptr; // bufferization.to_tensor (memory_space_cast scenario only)
+      nullptr; // memref→tensor boundary op terminating the receiver chain
   Operation *setOp = nullptr;
 };
 

--- a/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/AllocMultiCache/AddMultiBufferOuterScope.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #include "ascend/include/DynamicCVPipeline/Common/BufferCountManager.h"
 #include "ascend/include/DynamicCVPipeline/Common/FlagIdManager.h"
@@ -64,9 +65,36 @@ static int getTransferId(Operation *op) {
   return -1;
 }
 
-// --- Address space helpers ---
+// --- main_loop attribute helpers ---
 
-static bool isInVectorScope(Operation *op) {
+/// Walk up from `op` (exclusive) and return the first ancestor satisfying
+/// `pred`; nullptr if none.
+static Operation *findAncestorOp(Operation *op,
+                                 llvm::function_ref<bool(Operation *)> pred) {
+  for (Operation *cur = op->getParentOp(); cur; cur = cur->getParentOp())
+    if (pred(cur))
+      return cur;
+  return nullptr;
+}
+
+/// Nearest ancestor carrying the main_loop attribute, if any.
+static Operation *findMainLoopOp(Operation *op) {
+  return findAncestorOp(
+      op, [](Operation *cur) { return CVPipeline::isMainLoopOp(cur); });
+}
+
+/// True if the sync op is nested inside a main_loop op (ForOp/WhileOp).
+static bool parentOpHasMainLoopAttr(Operation *syncOp) {
+  if (!syncOp) {
+    return false;
+  }
+  return findMainLoopOp(syncOp) != nullptr;
+}
+
+// --- Tag-driven transfer op classification helpers ---
+
+/// True if op is inside a VECTOR scope; for direction derivation only
+static bool isInsideVectorScope(Operation *op) {
   auto scopeOp = op->getParentOfType<scope::ScopeOp>();
   if (!scopeOp) {
     return false;
@@ -76,15 +104,56 @@ static bool isInVectorScope(Operation *op) {
   return false;
 }
 
-// --- main_loop attribute helpers ---
-
-/// Check if a sync op's direct parent is a main_loop op (forOp / whileOp
-/// carrying the ssbuffer.main_loop attribute)
-static bool parentOpHasMainLoopAttr(Operation *syncOp) {
-  if (!syncOp) {
+/// True if op declares MemoryEffects Write on buffer
+static bool hasWriteEffectOn(Operation *op, Value buffer) {
+  auto iface = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!iface) {
     return false;
   }
-  return CVPipeline::isMainLoopOp(syncOp->getParentOp());
+  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>> effects;
+  iface.getEffects(effects);
+  return llvm::any_of(effects, [&](const auto &effect) {
+    return isa<MemoryEffects::Write>(effect.getEffect()) &&
+           effect.getValue() == buffer;
+  });
+}
+
+/// Walk single-use memref chain from receiverOp to the first op producing a
+/// tensor. Returns nullptr when:
+/// - head result is not a memref
+/// - chain forks (multi-use), leaves the block, or hits an op that does not
+///   produce exactly one result
+static Operation *findChainTensorTerminal(Operation *receiverOp) {
+  if (receiverOp->getNumResults() != 1) {
+    return nullptr;
+  }
+  Value cur = receiverOp->getResult(0);
+  Block *block = receiverOp->getBlock();
+  // Terminates: SSA def-use is acyclic; same-block users appear strictly
+  // after their def, so the walk never revisits a value.
+  while (cur && isa<MemRefType>(cur.getType())) {
+    if (!cur.hasOneUse()) {
+      return nullptr; // forked chain: ambiguous
+    }
+    Operation *user = *cur.getUsers().begin();
+    if (user->getBlock() != block || user->getNumResults() != 1) {
+      return nullptr;
+    }
+    Value result = user->getResult(0);
+    if (isa<RankedTensorType>(result.getType())) {
+      return user;
+    }
+    cur = result;
+  }
+  return nullptr;
+}
+
+/// First block_id found in a block's ops, if any
+static std::optional<int> getFirstBlockId(Block *block) {
+  for (Operation &op : *block)
+    if (auto id = CVPipeline::getOpBlockId(&op))
+      return id;
+  return std::nullopt;
 }
 
 // --- Operation search helpers ---
@@ -132,20 +201,6 @@ static Operation *findSyncOpWithFlag(Block *block, Operation *start, int flag,
         return op;
       }
     } while (it != block->begin());
-  }
-  return nullptr;
-}
-
-/// Find the to_tensor op after a given op in the same block
-static Operation *findToTensorAfter(Block *block, Operation *start) {
-  if (!block) {
-    return nullptr;
-  }
-  auto it = start->getIterator();
-  for (auto e = block->end(); it != e; ++it) {
-    if (isa<bufferization::ToTensorOp>(&*it)) {
-      return &*it;
-    }
   }
   return nullptr;
 }
@@ -199,32 +254,24 @@ static int collectBufferAllocs(const SmallVector<Operation *> &ops,
     return nullptr;
   };
 
-  // Identify sender's cross-core buffer from transferOp's outs operand
-  if (info.senderChain.transferOp) {
-    Operation *transferOp = info.senderChain.transferOp;
-    // fixpipe / hir.copy: cross-core buffer is the last operand (outs)
-    Value crossCoreBuf =
-        transferOp->getOperand(transferOp->getNumOperands() - 1);
-    if (auto *defOp = crossCoreBuf.getDefiningOp()) {
+  // Cross-core buffer = alloc defining the recorded buffer operand
+  if (info.senderChain.transferOp && info.senderChain.bufferOperand) {
+    if (auto *defOp = info.senderChain.bufferOperand.getDefiningOp()) {
       if (isa<memref::AllocOp>(defOp)) {
         info.senderBuf.allocOp = defOp;
         info.senderBuf.markOp = findMarkForAlloc(defOp);
-        LDBG("Sender cross-core buffer: alloc from transferOp outs.");
+        LDBG("Sender cross-core buffer: alloc from transferOp buffer operand.");
       }
     }
   }
 
-  // Identify receiver's cross-core buffer from transferOp's input operand
-  if (info.receiverChain.transferOp) {
-    Operation *transferOp = info.receiverChain.transferOp;
-    // memref.memory_space_cast / hivm.convert_layout: cross-core buffer is
-    // the first operand
-    Value crossCoreBuf = transferOp->getOperand(0);
-    if (auto *defOp = crossCoreBuf.getDefiningOp()) {
+  if (info.receiverChain.transferOp && info.receiverChain.bufferOperand) {
+    if (auto *defOp = info.receiverChain.bufferOperand.getDefiningOp()) {
       if (isa<memref::AllocOp>(defOp)) {
         info.receiverBuf.allocOp = defOp;
         info.receiverBuf.markOp = findMarkForAlloc(defOp);
-        LDBG("Receiver cross-core buffer: alloc from transferOp input.");
+        LDBG("Receiver cross-core buffer: alloc from transferOp buffer "
+             "operand.");
       }
     }
   }
@@ -370,52 +417,77 @@ static int collectExtraSync(const SmallVector<Operation *> &ops,
   return 0;
 }
 
-/// Collect transfer chain ops (parent has main_loop)
+/// Collect in-loop sender/receiver chains. Tag+dataflow rules:
+/// - group buffer: alloc carrying the transfer_id
+/// - sender: writes a group buffer (Write effect or result-less)
+/// - receiver head: first op reading a group buffer as a value
+/// - no op-type matching; receiver trailing ops found at wrap time
 static int collectTransferChains(const SmallVector<Operation *> &ops,
                                  int originalFlag, TransferChainInfo &info) {
+  // Group buffers: allocs carrying this transfer_id, one per core (sender and
+  // receiver sides each own one physical buffer)
+  SmallVector<Value> groupBuffers;
+  for (Operation *op : ops) {
+    if (auto allocOp = dyn_cast<memref::AllocOp>(op)) {
+      groupBuffers.push_back(allocOp.getResult());
+    }
+  }
+  auto isGroupBuffer = [&](Value v) {
+    return llvm::is_contained(groupBuffers, v);
+  };
+
   for (Operation *op : ops) {
     if ((isa<hivm::SyncBlockSetOp>(op) || isa<hivm::SyncBlockWaitOp>(op)) ||
         !op->getBlock()) {
+      continue;
+    }
+    // Buffers and annotations are data, not transfer behavior
+    if (isa<memref::AllocOp>(op) || isa<annotation::MarkOp>(op)) {
       continue;
     }
     if (!parentOpHasMainLoopAttr(op)) {
       continue;
     }
 
+    // First operand backed by a group buffer
+    Value bufferOperand;
+    for (Value operand : op->getOperands()) {
+      if (isGroupBuffer(operand)) {
+        bufferOperand = operand;
+        break;
+      }
+    }
+    if (!bufferOperand) {
+      continue;
+    }
+
     Block *block = op->getBlock();
 
-    if (isa<hivm::FixpipeOp>(op)) {
+    if (op->getNumResults() == 0 || hasWriteEffectOn(op, bufferOperand)) {
+      // Writes the cross-core buffer → sender
+      if (info.sender.transferOp) {
+        continue;
+      }
       info.sender.transferOp = op;
+      info.sender.bufferOperand = bufferOperand;
       info.sender.waitOp =
           findSyncOpWithFlag(block, op, originalFlag, false, true);
       info.sender.setOp =
           findSyncOpWithFlag(block, op, originalFlag, true, false);
-      LDBG("Sender chain (CUBE): fixpipe, flag=" << originalFlag << ".");
-    } else if (isa<hivm::CopyOp>(op)) {
-      info.sender.transferOp = op;
-      info.sender.waitOp =
-          findSyncOpWithFlag(block, op, originalFlag, false, true);
-      info.sender.setOp =
-          findSyncOpWithFlag(block, op, originalFlag, true, false);
-      LDBG("Sender chain (VECTOR): hir.copy, flag=" << originalFlag << ".");
-    } else if (isa<memref::MemorySpaceCastOp>(op) && isInVectorScope(op)) {
+      LDBG("Sender chain (tag-driven): " << op->getName()
+                                         << ", flag=" << originalFlag << ".");
+    } else if (!info.receiver.transferOp && op->getNumResults() > 0) {
+      // Reads the cross-core buffer as a value → receiver head
       info.receiver.transferOp = op;
+      info.receiver.bufferOperand = bufferOperand;
       info.receiver.waitOp =
           findSyncOpWithFlag(block, op, originalFlag, false, true);
       info.receiver.setOp =
           findSyncOpWithFlag(block, op, originalFlag, true, false);
-      info.receiver.toTensorOp = findToTensorAfter(block, op);
-      LDBG("Receiver chain (VECTOR): memory_space_cast, flag=" << originalFlag
-                                                               << ".");
-    } else if (isa<hivm::ConvertLayoutOp>(op)) {
-      info.receiver.transferOp = op;
-      info.receiver.waitOp =
-          findSyncOpWithFlag(block, op, originalFlag, false, true);
-      info.receiver.setOp =
-          findSyncOpWithFlag(block, op, originalFlag, true, false);
-      info.receiver.toTensorOp = findToTensorAfter(block, op);
-      LDBG("Receiver chain (CUBE): convert_layout, flag=" << originalFlag
-                                                          << ".");
+      info.receiver.toTensorOp = findChainTensorTerminal(op);
+      LDBG("Receiver chain (tag-driven): "
+           << op->getName() << ", flag=" << originalFlag << ", toTensorOp="
+           << (info.receiver.toTensorOp ? "found" : "none") << ".");
     }
   }
 
@@ -464,13 +536,28 @@ static int buildTransferGroupData(int tid, const SmallVector<Operation *> &ops,
   info.senderChain = chainInfo.sender;
   info.receiverChain = chainInfo.receiver;
 
-  // 4. Determine direction
+  // 3.5 Chain completeness: each side needs both its wait and set syncs.
+  // Wrapping half a handshake (producer alternates flags while the consumer
+  // does not) deadlocks; drop the group's chains entirely so the transfer
+  // stays single-buffered instead.
+  auto chainComplete = [](const TransferOpChain &chain) {
+    return !chain.transferOp || (chain.waitOp && chain.setOp);
+  };
+  if (!chainComplete(info.senderChain) || !chainComplete(info.receiverChain)) {
+    LDBG("Group tid=" << tid
+                      << " has an incomplete chain (wait/set missing), keeping"
+                      << " it single-buffered.");
+    info.senderChain = TransferOpChain();
+    info.receiverChain = TransferOpChain();
+  }
+
+  // 4. Direction from the executing core's scope:
+  // - sender in VECTOR scope: V→C; in CUBE scope: C→V
+  // - no sender: derive from receiver scope instead
   if (info.senderChain.transferOp) {
-    if (isa<hivm::FixpipeOp>(info.senderChain.transferOp)) {
-      info.isCtoV = true;
-    } else if (isa<hivm::CopyOp>(info.senderChain.transferOp)) {
-      info.isCtoV = false;
-    }
+    info.isCtoV = !isInsideVectorScope(info.senderChain.transferOp);
+  } else if (info.receiverChain.transferOp) {
+    info.isCtoV = isInsideVectorScope(info.receiverChain.transferOp);
   }
 
   // 5. Collect buffer alloc/mark pairs from transfer ops
@@ -751,13 +838,35 @@ static int setSsbufferTags(Operation *op, OpBuilder &builder, int blockId,
   return 0;
 }
 
-/// Ensure a WhileOp has an i32 iteration counter loop-carried variable.
-/// Returns the counter Value; polling condition is (counter % 2) == 0.
-/// Reuses an existing counter (e.g. one injected by InnerScope, detected via
-/// ssbuffer.iterCounter); injects a new one only when absent.
+/// Ensure a WhileOp has an i32 iteration counter (polling: counter % 2 == 0).
+/// - reuse an existing one (InnerScope-injected, kIterCounter on the while)
+/// - normalize its body-end update: move to body head, re-tag first block id
 static Value ensureWhileOpHasCounter(scf::WhileOp whileOp) {
   if (whileOp->hasAttr(CVPipeline::kIterCounter)) {
     Block &after = whileOp.getAfter().front();
+    SmallVector<Operation *> updates;
+    for (Operation &op : after)
+      if (op.hasAttr(CVPipeline::kIterCounter))
+        updates.push_back(&op);
+    for (Operation *addi : updates) {
+      Operation *firstOp = &after.front();
+      if (addi == firstOp || addi == firstOp->getNextNode())
+        continue; // already at head
+      std::optional<int> firstId = getFirstBlockId(&after);
+      if (!firstId)
+        continue;
+      addi->moveBefore(&after, after.begin());
+      for (Value operand : addi->getOperands())
+        if (Operation *defOp = operand.getDefiningOp())
+          if (defOp->getBlock() == &after)
+            defOp->moveBefore(addi);
+      OpBuilder tagBuilder(whileOp.getContext());
+      IntegerAttr blockIdAttr = tagBuilder.getI32IntegerAttr(*firstId);
+      addi->setAttr(CVPipeline::kBlockId, blockIdAttr);
+      for (Value operand : addi->getOperands())
+        if (Operation *defOp = operand.getDefiningOp())
+          defOp->setAttr(CVPipeline::kBlockId, blockIdAttr);
+    }
     return after.getArgument(after.getNumArguments() - 1);
   }
 
@@ -775,6 +884,8 @@ static Value ensureWhileOpHasCounter(scf::WhileOp whileOp) {
   newResultTypes.push_back(i32Type);
 
   Value counterIterArg;
+  Operation *counterOne = nullptr;
+  Operation *counterAdd = nullptr;
 
   // Rebuild via the Builder callback API (matching InnerScope's
   // setupWhileIterArgCounter)
@@ -802,6 +913,12 @@ static Value ensureWhileOpHasCounter(scf::WhileOp whileOp) {
         Block *oldAfter = oldWhile.getAfterBody();
         unsigned n = oldAfter->getNumArguments();
         counterIterArg = iterArgs[n];
+        // Counter update at body start; prepareLoopPolling builds the
+        // polling chain around it (c2+remsi before, c0+cmpi after).
+        counterOne = ab.create<arith::ConstantIntOp>(al, 1, kBits32);
+        counterAdd = ab.create<arith::AddIOp>(al, counterIterArg,
+                                              counterOne->getResult(0));
+        Value nextCounter = counterAdd->getResult(0);
         IRMapping map;
         for (unsigned i = 0; i < n; ++i)
           map.map(oldAfter->getArgument(i), iterArgs[i]);
@@ -810,8 +927,6 @@ static Value ensureWhileOpHasCounter(scf::WhileOp whileOp) {
           ab.clone(op, map);
 
         auto oldYield = cast<scf::YieldOp>(oldAfter->getTerminator());
-        Value one = ab.create<arith::ConstantIntOp>(al, 1, 32);
-        Value nextCounter = ab.create<arith::AddIOp>(al, counterIterArg, one);
         SmallVector<Value> yOps;
         for (Value v : oldYield.getOperands())
           yOps.push_back(map.lookupOrDefault(v));
@@ -823,6 +938,18 @@ static Value ensureWhileOpHasCounter(scf::WhileOp whileOp) {
   for (auto attr : oldWhile->getAttrs())
     newWhile->setAttr(attr.getName(), attr.getValue());
   newWhile->setAttr(CVPipeline::kIterCounter, builder.getUnitAttr());
+
+  // Tag counter-update ops with the first body block_id (CloneOps
+  // contiguity, mirrors InnerScope); they carry no id yet, so the scan
+  // picks the first old-body op's id.
+  Block &afterBody = newWhile.getAfter().front();
+  if (std::optional<int> firstBlockId = getFirstBlockId(&afterBody);
+      firstBlockId && counterOne && counterAdd) {
+    IntegerAttr blockIdAttr = builder.getI32IntegerAttr(*firstBlockId);
+    counterOne->setAttr(CVPipeline::kBlockId, blockIdAttr);
+    counterAdd->setAttr(CVPipeline::kBlockId, blockIdAttr);
+    counterAdd->setAttr(CVPipeline::kIterCounter, builder.getUnitAttr());
+  }
 
   // Replace results (exclude counter result)
   for (unsigned i = 0, e = oldWhile.getNumResults(); i < e; ++i)
@@ -910,9 +1037,11 @@ static Operation *wrapSyncOpWithScfIf(
   return ifOp.getOperation();
 }
 
-/// Wrap a transfer op (with external uses) in scf.if with yield
+/// Wrap transfer op (with external uses) in scf.if with yield:
+/// - then: clone with the original buffer operand
+/// - else: clone with bufferOperand remapped to the spare buffer
 static Operation *wrapTransferOpWithScfIfYield(Operation *transferOp,
-                                               Value cond, Value inputBuffer,
+                                               Value cond, Value bufferOperand,
                                                Value outputBuffer, int bid,
                                                int tid, bool isProducer,
                                                OpBuilder &builder) {
@@ -923,16 +1052,11 @@ static Operation *wrapTransferOpWithScfIfYield(Operation *transferOp,
   auto ifOp = builder.create<scf::IfOp>(loc, transferOp->getResultTypes(), cond,
                                         true /* withElseRegion */);
 
-  // then branch: use inputBuffer
+  // then branch: keep the original buffer operand
   Operation *thenCloned = nullptr;
   {
     auto thenBuilder = ifOp.getThenBodyBuilder();
-    IRMapping inputMap;
-    if (transferOp->getNumOperands() > 0) {
-      inputMap.map(transferOp->getOperand(transferOp->getNumOperands() - 1),
-                   inputBuffer);
-    }
-    thenCloned = thenBuilder.clone(*transferOp, inputMap);
+    thenCloned = thenBuilder.clone(*transferOp);
     thenBuilder.create<scf::YieldOp>(loc, thenCloned->getResults());
   }
 
@@ -941,9 +1065,8 @@ static Operation *wrapTransferOpWithScfIfYield(Operation *transferOp,
   {
     auto elseBuilder = ifOp.getElseBodyBuilder();
     IRMapping outputMap;
-    if (transferOp->getNumOperands() > 0) {
-      outputMap.map(transferOp->getOperand(transferOp->getNumOperands() - 1),
-                    outputBuffer);
+    if (bufferOperand) {
+      outputMap.map(bufferOperand, outputBuffer);
     }
     elseCloned = elseBuilder.clone(*transferOp, outputMap);
     elseBuilder.create<scf::YieldOp>(loc, elseCloned->getResults());
@@ -976,7 +1099,7 @@ static Operation *wrapTransferOpWithScfIfYield(Operation *transferOp,
 
 /// Wrap a transfer op (no external uses) in scf.if without yield
 static Operation *wrapTransferOpWithScfIfSimple(Operation *transferOp,
-                                                Value cond, Value inputBuffer,
+                                                Value cond, Value bufferOperand,
                                                 Value outputBuffer, int bid,
                                                 int tid, bool isProducer,
                                                 OpBuilder &builder) {
@@ -987,7 +1110,7 @@ static Operation *wrapTransferOpWithScfIfSimple(Operation *transferOp,
   auto ifOp = builder.create<scf::IfOp>(loc, TypeRange{}, cond,
                                         true /* withElseRegion */);
 
-  // then branch: clone directly
+  // then branch: clone directly (keeps the original buffer operand)
   Operation *thenCloned = nullptr;
   {
     auto thenBuilder = ifOp.getThenBodyBuilder();
@@ -999,9 +1122,8 @@ static Operation *wrapTransferOpWithScfIfSimple(Operation *transferOp,
   {
     auto elseBuilder = ifOp.getElseBodyBuilder();
     IRMapping outputMap;
-    if (transferOp->getNumOperands() > 0) {
-      outputMap.map(transferOp->getOperand(transferOp->getNumOperands() - 1),
-                    outputBuffer);
+    if (bufferOperand) {
+      outputMap.map(bufferOperand, outputBuffer);
     }
     elseCloned = elseBuilder.clone(*transferOp, outputMap);
   }
@@ -1025,11 +1147,11 @@ static Operation *wrapTransferOpWithScfIfSimple(Operation *transferOp,
   return ifOp.getOperation();
 }
 
-/// Wrap a receiver transfer chain (transferOp + trailing memspace_cast +
-/// to_tensor) in scf.if so that the if returns tensor type directly.
+/// Wrap receiver chain (head + trailing ops + tensor boundary) in scf.if
+/// returning tensor
 static Operation *wrapReceiverChainWithScfIf(Operation *transferOp,
                                              Operation *toTensorOp, Value cond,
-                                             Value inputBuffer,
+                                             Value bufferOperand,
                                              Value outputBuffer, int bid,
                                              int tid, OpBuilder &builder) {
   OpBuilder::InsertionGuard guard(builder);
@@ -1061,21 +1183,17 @@ static Operation *wrapReceiverChainWithScfIf(Operation *transferOp,
   auto ifOp = builder.create<scf::IfOp>(loc, tensorType, cond,
                                         true /* withElseRegion */);
 
-  // then branch: use inputBuffer → clone chain + to_tensor
+  // then branch: keep the original buffer operand → clone chain + boundary
   {
     auto thenBuilder = ifOp.getThenBodyBuilder();
-    IRMapping inputMap;
-    if (transferOp->getNumOperands() > 0)
-      inputMap.map(transferOp->getOperand(transferOp->getNumOperands() - 1),
-                   inputBuffer);
-    Operation *clonedTransfer = thenBuilder.clone(*transferOp, inputMap);
+    IRMapping thenMapper;
+    Operation *clonedTransfer = thenBuilder.clone(*transferOp, thenMapper);
     // Strip crossDeps from the cloned transferOp: clone() inherits attrs
     // from the original (which may carry [tid, 0] from upstream tagging),
     // but consumer role is owned by the ifOp wrapper below. Inner clone
     // must stay clean.
     clonedTransfer->removeAttr(mlir::CVPipeline::kCrossCoreDeps);
     Value chainResult = clonedTransfer->getResult(0);
-    auto thenMapper = inputMap;
     thenMapper.map(transferOp->getResult(0), chainResult);
     for (Operation *op : trailingOps) {
       Operation *cloned = thenBuilder.clone(*op, thenMapper);
@@ -1087,13 +1205,13 @@ static Operation *wrapReceiverChainWithScfIf(Operation *transferOp,
     thenBuilder.create<scf::YieldOp>(loc, clonedToTensor->getResult(0));
   }
 
-  // else branch: use outputBuffer → clone chain + to_tensor
+  // else branch: use outputBuffer → clone chain + boundary
   {
     auto elseBuilder = ifOp.getElseBodyBuilder();
     IRMapping outputMap;
-    if (transferOp->getNumOperands() > 0)
-      outputMap.map(transferOp->getOperand(transferOp->getNumOperands() - 1),
-                    outputBuffer);
+    if (bufferOperand) {
+      outputMap.map(bufferOperand, outputBuffer);
+    }
     Operation *clonedTransfer = elseBuilder.clone(*transferOp, outputMap);
     clonedTransfer->removeAttr(mlir::CVPipeline::kCrossCoreDeps);
     Value chainResult = clonedTransfer->getResult(0);
@@ -1128,12 +1246,11 @@ static Operation *wrapReceiverChainWithScfIf(Operation *transferOp,
 }
 
 /// Process polling for a sender or receiver transfer chain
-static int processTransferChain(TransferOpChain &chain, Value cond,
-                                Value inputBuffer, Value outputBuffer,
-                                int outputFlag, bool isProducer,
-                                OpBuilder &builder) {
+static LogicalResult processTransferChain(TransferOpChain &chain, Value cond,
+                                          Value outputBuffer, int outputFlag,
+                                          bool isProducer, OpBuilder &builder) {
   if (!chain.waitOp) {
-    return -1;
+    return failure();
   }
 
   Location loc = chain.waitOp->getLoc();
@@ -1150,20 +1267,18 @@ static int processTransferChain(TransferOpChain &chain, Value cond,
             .getOperation();
       });
 
-  // 2. Wrap transferOp in polling if (then=use inputBuffer, else=use
-  // outputBuffer)
+  // 2. Wrap transferOp in polling if (then=original buffer, else=outputBuffer)
   if (chain.transferOp) {
     int bid = getBlockId(chain.transferOp);
     int tid = getTransferId(chain.transferOp);
 
-    // For receiver chains with toTensorOp, wrap the full chain
-    // (transferOp → memspace_cast → to_tensor) so the scf.if returns tensor.
+    // Receiver with boundary op: wrap the whole chain so scf.if yields tensor
     if (!isProducer && chain.toTensorOp) {
       LDBG("transferOp: " << chain.transferOp->getName()
                           << " (receiver, wrapping to_tensor).");
       chain.transferOp = wrapReceiverChainWithScfIf(
-          chain.transferOp, chain.toTensorOp, cond, inputBuffer, outputBuffer,
-          bid, tid, builder);
+          chain.transferOp, chain.toTensorOp, cond, chain.bufferOperand,
+          outputBuffer, bid, tid, builder);
       chain.toTensorOp = nullptr;
     } else {
       bool hasExternalUses = !chain.transferOp->getResults().empty() &&
@@ -1175,11 +1290,11 @@ static int processTransferChain(TransferOpChain &chain, Value cond,
       chain.transferOp =
           hasExternalUses
               ? wrapTransferOpWithScfIfYield(chain.transferOp, cond,
-                                             inputBuffer, outputBuffer, bid,
-                                             tid, isProducer, builder)
+                                             chain.bufferOperand, outputBuffer,
+                                             bid, tid, isProducer, builder)
               : wrapTransferOpWithScfIfSimple(chain.transferOp, cond,
-                                              inputBuffer, outputBuffer, bid,
-                                              tid, isProducer, builder);
+                                              chain.bufferOperand, outputBuffer,
+                                              bid, tid, isProducer, builder);
     }
   }
 
@@ -1196,7 +1311,7 @@ static int processTransferChain(TransferOpChain &chain, Value cond,
               .getOperation();
         });
   }
-  return 0;
+  return success();
 }
 
 /// Create polling condition and builder for a loop op (ForOp or WhileOp).
@@ -1215,70 +1330,164 @@ static Value prepareLoopPolling(Operation *loopOp, Operation *waitOp,
   }
 
   if (auto whileOp = dyn_cast<scf::WhileOp>(loopOp)) {
-    // Counter was already injected in preprocessing. Polling condition:
-    // (counter % 2) == 0
+    // Guard: only main_loop whiles carry an injected counter; a plain
+    // while here has none to poll on — fall back.
+    if (!whileOp->hasAttr(CVPipeline::kIterCounter))
+      return Value();
+    // Polling cond: (counter % 2) == 0. The counter update sits at the
+    // body head (created / normalized by ensure), so the chain is built
+    // around it: c2+remsi before, c0+cmpi after.
     Block &after = whileOp.getAfter().front();
     Value counter = after.getArgument(after.getNumArguments() - 1);
-    builderOut.setInsertionPoint(after.getTerminator());
+    // Locate the counter update (top-level only; nested loops own theirs).
+    Operation *lastCounterUpdate = nullptr;
+    for (Operation &op : after)
+      if (op.hasAttr(CVPipeline::kIterCounter))
+        lastCounterUpdate = &op;
+    bool counterAtHead =
+        lastCounterUpdate && (lastCounterUpdate == &after.front() ||
+                              lastCounterUpdate == after.front().getNextNode());
+    // Insert at body start to dominate the wrapping scf.ifs.
+    builderOut.setInsertionPointToStart(&after);
+    // Tag the cond ops with the first body block_id (CloneOps contiguity).
+    std::optional<int> pollBlockId = getFirstBlockId(&after);
+    if (!pollBlockId)
+      pollBlockId = bid;
     OpBuilder condBuilder(builderOut);
-    Value c2 =
-        condBuilder.create<arith::ConstantIntOp>(whileOp.getLoc(), 2, 32);
-    Value rem =
-        condBuilder.create<arith::RemSIOp>(whileOp.getLoc(), counter, c2);
-    Value c0 =
-        condBuilder.create<arith::ConstantIntOp>(whileOp.getLoc(), 0, 32);
-    return condBuilder.create<arith::CmpIOp>(whileOp.getLoc(),
-                                             arith::CmpIPredicate::eq, rem, c0);
+    Operation *c2Op =
+        condBuilder.create<arith::ConstantIntOp>(whileOp.getLoc(), 2, kBits32);
+    setSsbufferTags(c2Op, condBuilder, *pollBlockId, tid);
+    Operation *remOp = condBuilder.create<arith::RemSIOp>(
+        whileOp.getLoc(), counter, c2Op->getResult(0));
+    setSsbufferTags(remOp, condBuilder, *pollBlockId, tid);
+    // Put c0+cmpi right after the counter update:
+    // - +1 lands between remsi and cmpi (validated backend ordering)
+    // - otherwise chain stays contiguous at body start: the cond must
+    //   dominate the wrapping scf.ifs
+    if (counterAtHead)
+      condBuilder.setInsertionPointAfter(lastCounterUpdate);
+    Operation *c0Op =
+        condBuilder.create<arith::ConstantIntOp>(whileOp.getLoc(), 0, kBits32);
+    setSsbufferTags(c0Op, condBuilder, *pollBlockId, tid);
+    Operation *condOp = condBuilder.create<arith::CmpIOp>(
+        whileOp.getLoc(), arith::CmpIPredicate::eq, remOp->getResult(0),
+        c0Op->getResult(0));
+    setSsbufferTags(condOp, condBuilder, *pollBlockId, tid);
+    return condOp->getResult(0);
   }
 
-  llvm_unreachable("unexpected loop op type");
+  // Unexpected loop type: caller falls back with ERRCODE_IGNORED.
+  return Value();
 }
 
 /// Add polling control flow for all transfer groups
-static int addPollingControlFlow(DenseMap<int, TransferGroupInfo> &groups) {
-  for (auto &p : groups) {
-    TransferGroupInfo &g = p.second;
+/// Get or create the polling condition shared by all groups rotating buffers
+/// on one loop. The parity value ((iter%2)==0) is identical for every group,
+/// so one scalar condition chain per loop suffices; anchorWait (the earliest
+/// wait in the loop) guarantees the cond dominates every group's scf.if.
+static Value getOrCreateLoopCond(Operation *loopOp, Operation *anchorWait,
+                                 DenseMap<Operation *, Value> &condCache) {
+  auto it = condCache.find(loopOp);
+  if (it != condCache.end()) {
+    return it->second;
+  }
+  OpBuilder builder(loopOp->getContext());
+  Value cond = prepareLoopPolling(loopOp, anchorWait, builder);
+  if (cond) {
+    condCache[loopOp] = cond;
+    LDBG("Shared polling cond created for loop, tagged by anchor wait.");
+  }
+  return cond;
+}
 
+/// Nearest ForOp/WhileOp ancestor of a sync op (sync may sit in scf.if).
+/// A While nested in a For resolves to the While, not the For.
+static Operation *resolveLoopOp(Operation *op) {
+  return findAncestorOp(op, [](Operation *cur) {
+    return isa<scf::ForOp>(cur) || isa<scf::WhileOp>(cur);
+  });
+}
+
+static LogicalResult
+addPollingControlFlow(DenseMap<int, TransferGroupInfo> &groups, int &errCode) {
+  // Anchor per loop: the earliest wait across all groups — the shared cond
+  // must dominate every group's scf.if wrappers.
+  DenseMap<Operation *, Operation *> loopAnchor;
+  for (auto &[tid, group] : groups) {
+    auto track = [&](Operation *waitOp) {
+      if (!waitOp) {
+        return;
+      }
+      Operation *loop = resolveLoopOp(waitOp);
+      Operation *anchor = loopAnchor.lookup(loop);
+      if (!anchor || (waitOp->getBlock() == anchor->getBlock() &&
+                      waitOp->isBeforeInBlock(anchor))) {
+        loopAnchor[loop] = waitOp;
+      }
+    };
+    track(group.senderChain.waitOp);
+    track(group.receiverChain.waitOp);
+  }
+
+  DenseMap<Operation *, Value> condCache;
+  for (auto &[tid, group] : groups) {
     // Get sender's loop op (ForOp or WhileOp)
-    Operation *senderWaitParent = g.senderChain.waitOp->getParentOp();
+    Operation *senderWaitParent = resolveLoopOp(group.senderChain.waitOp);
 
-    // Prepare polling condition and builder for sender loop
+    // Shared polling condition for the sender loop
     OpBuilder senderBuilder(senderWaitParent->getContext());
-    Value senderCond = prepareLoopPolling(senderWaitParent,
-                                          g.senderChain.waitOp, senderBuilder);
+    Value senderCond = getOrCreateLoopCond(
+        senderWaitParent, loopAnchor[senderWaitParent], condCache);
+    if (!senderCond) {
+      LDBG("FALLBACK: unexpected sender loop op, tid="
+           << tid << ", op=" << *senderWaitParent
+           << ", rc=" << CVPipeline::ERRCODE_IGNORED << ".");
+      errCode = CVPipeline::ERRCODE_IGNORED;
+      return failure();
+    }
 
     // Process sender chain (isProducer=true)
-    if (processTransferChain(g.senderChain, senderCond, g.senderInputBuffer,
-                             g.senderOutputBuffer, g.outputFlag, true,
-                             senderBuilder) != 0) {
-      return -1;
+    if (failed(processTransferChain(group.senderChain, senderCond,
+                                    group.senderOutputBuffer, group.outputFlag,
+                                    true, senderBuilder))) {
+      errCode = CVPipeline::ERRCODE_FAILED;
+      return failure();
     }
 
     // Process receiver chain (may use different loop op) (isProducer=false)
-    if (g.receiverChain.waitOp) {
-      Operation *receiverWaitParent = g.receiverChain.waitOp->getParentOp();
+    if (group.receiverChain.waitOp) {
+      Operation *receiverWaitParent = resolveLoopOp(group.receiverChain.waitOp);
 
       if (receiverWaitParent == senderWaitParent) {
         // Use the same cond and builder
-        if (processTransferChain(g.receiverChain, senderCond,
-                                 g.receiverInputBuffer, g.receiverOutputBuffer,
-                                 g.outputFlag, false, senderBuilder) != 0) {
-          return -1;
+        if (failed(processTransferChain(
+                group.receiverChain, senderCond, group.receiverOutputBuffer,
+                group.outputFlag, false, senderBuilder))) {
+          errCode = CVPipeline::ERRCODE_FAILED;
+          return failure();
         }
       } else {
-        // Receiver uses a different loop op, prepare new cond and builder
+        // Receiver uses a different loop op, share its cond too
         OpBuilder receiverBuilder(receiverWaitParent->getContext());
-        Value receiverCond = prepareLoopPolling(
-            receiverWaitParent, g.receiverChain.waitOp, receiverBuilder);
-        if (processTransferChain(g.receiverChain, receiverCond,
-                                 g.receiverInputBuffer, g.receiverOutputBuffer,
-                                 g.outputFlag, false, receiverBuilder) != 0) {
-          return -1;
+        Value receiverCond = getOrCreateLoopCond(
+            receiverWaitParent, loopAnchor[receiverWaitParent], condCache);
+        if (!receiverCond) {
+          LDBG("FALLBACK: unexpected receiver loop op, tid="
+               << tid << ", op=" << *receiverWaitParent
+               << ", rc=" << CVPipeline::ERRCODE_IGNORED << ".");
+          errCode = CVPipeline::ERRCODE_IGNORED;
+          return failure();
+        }
+        if (failed(processTransferChain(
+                group.receiverChain, receiverCond, group.receiverOutputBuffer,
+                group.outputFlag, false, receiverBuilder))) {
+          errCode = CVPipeline::ERRCODE_FAILED;
+          return failure();
         }
       }
     }
   }
-  return 0;
+  return success();
 }
 
 // ============================================================================
@@ -1418,10 +1627,11 @@ void AddMultiBufferOuterScopePass::runOnOperation() {
     LDBG("[Step 2/3] Done.");
 
     LDBG("[Step 3/3] Start: polling control flow.");
-    if (addPollingControlFlow(groups)) {
+    int pollingRc = CVPipeline::ERRCODE_FAILED;
+    if (failed(addPollingControlFlow(groups, pollingRc))) {
       LDBG("FALLBACK: Step 3/3 failed, polling control flow failed, rc="
-           << CVPipeline::ERRCODE_FAILED << ".");
-      CVPipeline::setFallbackAttr(module, CVPipeline::ERRCODE_FAILED);
+           << pollingRc << ".");
+      CVPipeline::setFallbackAttr(module, pollingRc);
       return;
     }
     LDBG("[Step 3/3] Done.");

--- a/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable/PreCheckDisablePreload.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable/PreCheckDisablePreload.cpp
@@ -37,15 +37,9 @@ using namespace triton;
 
 // Functions that should use at most double buffering.
 static const llvm::SmallVector<llvm::StringRef> kBlacklistFuncNames = {
-    "sdf02_tc01_c2v_war",
-    "sdf02_tc02_c2v_war",
     "_attn_fwd",
     "kernel_sdpa_fwd",
     "kernel_sdpa_bwd_q",
-    "pcb08_tc01_kernel",
-    "pcb08_tc02_kernel",
-    "pcb09_tc01_kernel",
-    "pcb09_tc02_kernel",
     "_swa_paged_decode_kernel",
     "_mqa_logits_kernel",
     "parallel_path_fwd_kernel",
@@ -53,11 +47,8 @@ static const llvm::SmallVector<llvm::StringRef> kBlacklistFuncNames = {
     "chunk_fwd_kernel_h",
     "_jagged_dense_flash_attention_bwd_dk_kernel",
     "_gqa_sparse_decode_kernel",
-    "pcb14_tc01_while_matmul_scalar",
-    "pcb14_tc02_while_matmul_scalar",
     "paged_decode_fd_reduce_kernel",
-    "paged_decode_fd_kernel",
-    "flash_fwd_kernel"};
+    "paged_decode_fd_kernel"};
 
 static constexpr const char *DEBUG_TYPE = "pre-check-disable-preload";
 #define DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Outer-scope-whileop.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Outer-scope-whileop.mlir
@@ -1,19 +1,47 @@
 // RUN: triton-opt --add_multi_buffer_outer_scope %s | FileCheck %s
 
-// Test: C→V transfer with scf.while (main_loop) in single-buffer mode.
-// Pass must not crash; IR structure (whileOp, main_loop, TCB marks) preserved.
-//   We pin the inter-core buffer count to 1 via the module-level
-//   `ssbuffer.inter_core_buf_count` attribute so the default of 2 doesn't
-//   trigger the double-buffer polling branch (scf.if dispatch), which is
-//   not supported for scf.while main loops here.
+// Test: C→V transfer with scf.while (main_loop) in double-buffer mode.
+// - pin inter_core_buf_count=2: polling branch (scf.if dispatch) now
+//   supported for scf.while, as the polling condition is inserted at
+//   while-body start (dominance fix); supersedes the pin-to-1 workaround
+// - wrong insertion order still rejected by verifier
+//   (operand-defined-after-use)
+// - CHECK locks double-buffer output: two mutually-exclusive transfer
+//   groups (even/odd flags) + double-buffer selection
 
 // CHECK-LABEL: func.func @tc_while_ctov_sender
-// CHECK: scf.while
-// CHECK: ssbuffer.main_loop
 // CHECK: tightly_coupled_buffer
+// while gets injected counter iter_arg
+// CHECK: scf.while {{.*}} : (i32, i32) -> (i32, i32)
+// polling condition computed at body start
+// CHECK: arith.remsi
+// CHECK: arith.cmpi eq
+// two mutually-exclusive transfer groups: even flag=3 / odd flag=8
+// CHECK: scf.if
+// CHECK: sync_block_wait {{.*}} flag = 3
+// CHECK: } else {
+// CHECK: sync_block_wait {{.*}} flag = 8
+// CHECK: ssbuffer.cross_buffer
+// double-buffer selection
+// CHECK: memref.memory_space_cast
+// CHECK: } else {
+// CHECK: memref.memory_space_cast
+// CHECK: sync_block_set {{.*}} flag = 3
+// CHECK: } else {
+// CHECK: sync_block_set {{.*}} flag = 8
+// CHECK: ssbuffer.iterCounter
+// CHECK: ssbuffer.main_loop
+// cross-core initial signals for both flags + CUBE-side waits
+// CHECK: sync_block_set {{.*}} flag = 3
+// CHECK: sync_block_set {{.*}} flag = 8
+// CHECK: sync_block_wait {{.*}} flag = 3
+// CHECK: sync_block_wait {{.*}} flag = 8
+// CUBE side: fixpipe double-buffer selection
+// CHECK: hivm.hir.fixpipe
+// CHECK: } else {
+// CHECK: hivm.hir.fixpipe
 
-module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">,
-                   ssbuffer.inter_core_buf_count = 1 : i32} {
+module attributes {hacc.target = #hacc.target<"Ascend950PR_9579">, ssbuffer.inter_core_buf_count = 2 : i32} {
 func.func @tc_while_ctov_sender() {
   %c0_i32 = arith.constant 0 : i32
   %c100_i32 = arith.constant 100 : i32
@@ -56,9 +84,36 @@ func.func @tc_while_ctov_sender() {
 
 
 // Test: Both sender and receiver use scf.while with main_loop
+// - both whiles get counter injection + two mutually-exclusive groups
+
 // CHECK-LABEL: func.func @tc_while_both_sides
-// CHECK: scf.while
-// CHECK: ssbuffer.main_loop
+// CHECK: tightly_coupled_buffer
+// VECTOR while: counter injection + two mutually-exclusive groups (flag 6/7)
+// CHECK: scf.while {{.*}} : (i32, i32) -> (i32, i32)
+// CHECK: arith.remsi
+// CHECK: arith.cmpi eq
+// CHECK: scf.if
+// CHECK: sync_block_wait {{.*}} flag = 6
+// CHECK: } else {
+// CHECK: sync_block_wait {{.*}} flag = 7
+// CHECK: ssbuffer.cross_buffer
+// CHECK: memref.memory_space_cast
+// CHECK: } else {
+// CHECK: memref.memory_space_cast
+// CHECK: sync_block_set {{.*}} flag = 6
+// CHECK: } else {
+// CHECK: sync_block_set {{.*}} flag = 7
+// CHECK: ssbuffer.iterCounter
+// CHECK: sync_block_set {{.*}} flag = 6
+// CHECK: sync_block_set {{.*}} flag = 7
+// CHECK: sync_block_wait {{.*}} flag = 6
+// CHECK: sync_block_wait {{.*}} flag = 7
+// CUBE while: same counter injection + fixpipe double-buffer selection
+// CHECK: scf.while {{.*}} : (i32, i32) -> (i32, i32)
+// CHECK: hivm.hir.fixpipe
+// CHECK: } else {
+// CHECK: hivm.hir.fixpipe
+// CHECK: ssbuffer.iterCounter
 
 func.func @tc_while_both_sides() {
   %c0_i32 = arith.constant 0 : i32


### PR DESCRIPTION
…with WhileOp polling support

- Classify transfer chains by ssbuffer.transfer_id tag + dataflow instead of op-type patterns: group buffers share a transfer_id, sender = buffer writer (write effect or resultless DMA), receiver head = first value operand reader, direction derived from sender scope tcore_type; TransferOpChain carries bufferOperand instead of assuming the last operand
- Replace findToTensorAfter with findChainTensorTerminal (walks memref chain to the first RankedTensorType producer)
- WhileOp outer-scope polling: emit cond at body start for dominance, hoist counter increment to first use, re-tag hoisted ops, resolve nearest enclosing loop through scf.if wrappers, share one polling condition per loop
- Drop wait/set-only transfer groups to avoid half-handshake deadlock
- Unblacklist sdf02/pcb08/pcb09/pcb14 kernels in PreCheckDisablePreload

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
