### PR TITLE
[ssbuffer](feat) Enable 4 items in 3-preload blacklist

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable/PreCheckDisablePreload.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable/PreCheckDisablePreload.cpp
@@ -48,14 +48,10 @@ static const llvm::SmallVector<llvm::StringRef> kBlacklistFuncNames = {
     "pcb09_tc02_kernel",
     "_swa_paged_decode_kernel",
     "_mqa_logits_kernel",
-    "parallel_path_fwd_kernel",
-    "chunk_bwd_kernel_dv_local",
     "chunk_fwd_kernel_h",
     "_jagged_dense_flash_attention_bwd_dk_kernel",
-    "_gqa_sparse_decode_kernel",
     "pcb14_tc01_while_matmul_scalar",
     "pcb14_tc02_while_matmul_scalar",
-    "paged_decode_fd_reduce_kernel",
     "paged_decode_fd_kernel",
     "flash_fwd_kernel"};
 


### PR DESCRIPTION
this pr enables 3-preload on kernels below:
"parallel_path_fwd_kernel"
    "chunk_bwd_kernel_dv_local"
    "_gqa_sparse_decode_kernel"
    "paged_decode_fd_reduce_kernel"
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
