### PR TITLE
[simt_costmodel](fix) re-enable AutoBlockify for all-SIMD routes

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -187,12 +187,11 @@ def _apply_cpp_simd_simt_decision(metadata, effective: str, superblock_factor: i
         # stages add mixed-runtime flags even though no SIMT scope exists.
         metadata["compile_mode"] = "simd"
         metadata["parallel_mode"] = "simd"
-        # SIMT AutoBlockify V1 uses the SIMT block/thread execution contract.
-        # It may be present on the analysis copy so StagePartitioner can see
-        # its scheduling loop, but an all-SIMD executable must launch the
-        # original logical grid and must not request the NPUIR V1 pass.
-        metadata["auto_blockify_v1_enabled"] = False
-        metadata["auto_blockify_v1_runtime_cap"] = False
+        # All-SIMD can still execute AutoBlockify V1 as a logical-program loop.
+        # Keep the policy resolved before the cost model instead of disabling it.
+        v1_materializable = bool(metadata.get("route_transform_v1_materializable", False))
+        metadata["auto_blockify_v1_enabled"] = v1_materializable
+        metadata["auto_blockify_v1_runtime_cap"] = v1_materializable
     elif effective == "mixed_simd_simt":
         metadata["auto_simt_requested_kind"] = effective
         # Mixed execution still needs V1 at factor one: its persistent
@@ -222,7 +221,8 @@ def _selected_npuir_superblock_factor(metadata, opt) -> int:
     unconditionally made an old/default F1 value shadow explicit F2/F4.
     """
     effective = metadata.get("auto_simt_effective_kind")
-    if effective == "mixed_simd_simt" or (effective is None and metadata.get("compile_mode") == "simd_simt"):
+    if (effective in ("all_simd", "mixed_simd_simt")
+            or (effective is None and metadata.get("compile_mode") == "simd_simt")):
         # The process-wide factor owns the surrounding SIMD/AIC scheduling
         # graph and must stay F1. The selected F2/F4 value is carried on the
         # scope itself and restored only in its outlined SIMT module.
@@ -578,11 +578,10 @@ def ttir_to_linalg(mod, metadata, opt, *, named_ops=False):
     ttir_code = str(mod)
     auto_map_parallel_blocks_enabled = _is_auto_map_parallel_blocks_enabled()
     if metadata.get("auto_simt_effective_kind") == "all_simd":
-        # Preserve the decision-owned disable from
-        # _apply_cpp_simd_simt_decision. Re-running the option policy here
-        # would re-enable the whole-kernel V1 transform on an all-SIMD binary.
-        metadata["auto_blockify_v1_enabled"] = False
-        metadata["auto_blockify_v1_runtime_cap"] = False
+        # All-SIMD also runs NPUIR AutoBlockify when the shared policy allows it.
+        # Preserve the values set by _apply_cpp_simd_simt_decision; do not
+        # re-enable or force-disable here.
+        metadata["auto_blockify_v1_runtime_cap"] = bool(metadata.get("auto_blockify_v1_enabled", False))
     elif metadata.get("auto_simt_effective_kind") == "mixed_simd_simt":
         # Preserve the mixed SuperBlock contract established above.  NPUIR V1
         # creates the persistent logical-program loop even for F1; the
@@ -1230,13 +1229,19 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
                 _compile_option_list += \
                     [f"--link-aicore-bitcode={bitcode}"]
 
-        npuir_v1_mixed_enabled = (metadata.get("auto_blockify_v1_enabled", False)
-                                  and not metadata.get("ta_auto_blockify_v1_materialized", False)
-                                  and metadata.get("parallel_mode") == "mix_simd_simt")
-        if npuir_v1_mixed_enabled:
+        # Honor the linalg-level blacklist (e.g. hivm.sync_block_lock) as well:
+        # the launcher disables the grid cap for blacklisted kernels, so
+        # requesting the NPUIR persistent loop without that cap would deadlock.
+        npuir_v1_enabled = (metadata.get("auto_blockify_v1_enabled", False)
+                            and not metadata.get("ta_auto_blockify_v1_materialized", False)
+                            and not metadata.get("has_auto_blockify_blacklist_op", False))
+        if npuir_v1_enabled:
             _compile_option_list += ["--enable-auto-blockify-loop"]
-            selected_factor = _selected_npuir_superblock_factor(metadata, opt)
-            _compile_option_list += [f"--super-block-factor={selected_factor}"]
+            # Only mixed/local-scope routes carry a SuperBlock factor; all-SIMD
+            # and ordinary SIMD keep the historical F1 autoblockify behavior.
+            if metadata.get("parallel_mode") == "mix_simd_simt":
+                selected_factor = _selected_npuir_superblock_factor(metadata, opt)
+                _compile_option_list += [f"--super-block-factor={selected_factor}"]
             metadata["auto_blockify_v1_runtime_cap"] = True
         elif not metadata.get("ta_auto_blockify_v1_materialized", False):
             metadata["auto_blockify_v1_runtime_cap"] = False
@@ -1507,15 +1512,19 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
             _compile_option_list += \
                 [f"--disable-size-align-for-cast={disable_size_align_for_cast}"]
 
-        npuir_v1_mixed_enabled = (metadata.get("auto_blockify_v1_enabled", False)
-                                  and not metadata.get("ta_auto_blockify_v1_materialized", False)
-                                  and metadata.get("parallel_mode") == "mix_simd_simt")
-        if npuir_v1_mixed_enabled:
-            selected_factor = _selected_npuir_superblock_factor(metadata, opt)
-            _compile_option_list += [
-                "--enable-auto-blockify-loop",
-                f"--super-block-factor={selected_factor}",
-            ]
+        # Honor the linalg-level blacklist (e.g. hivm.sync_block_lock) as well:
+        # the launcher disables the grid cap for blacklisted kernels, so
+        # requesting the NPUIR persistent loop without that cap would deadlock.
+        npuir_v1_enabled = (metadata.get("auto_blockify_v1_enabled", False)
+                            and not metadata.get("ta_auto_blockify_v1_materialized", False)
+                            and not metadata.get("has_auto_blockify_blacklist_op", False))
+        if npuir_v1_enabled:
+            _compile_option_list += ["--enable-auto-blockify-loop"]
+            # Only mixed/local-scope routes carry a SuperBlock factor; all-SIMD
+            # and ordinary SIMD keep the historical F1 autoblockify behavior.
+            if metadata.get("parallel_mode") == "mix_simd_simt":
+                selected_factor = _selected_npuir_superblock_factor(metadata, opt)
+                _compile_option_list += [f"--super-block-factor={selected_factor}"]
             metadata["auto_blockify_v1_runtime_cap"] = True
         elif not metadata.get("ta_auto_blockify_v1_materialized", False):
             metadata["auto_blockify_v1_runtime_cap"] = False


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - [ ] `/test` for `lit` tests
    - [ ] `/unittest` for C++ tests
    - [ ] `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it restores the pre-6e29d8e
         AutoBlockify V1 flag policy while keeping the existing linalg-level
         blacklist contract; the existing costmodel compiler contract tests
         are unaffected and stay green.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

## Why

The 6e29d8e refactor made `--enable-auto-blockify-loop` conditional on
`parallel_mode == mix_simd_simt` and also force-disabled V1 for `all_simd`.
This prevents all-SIMD and ordinary SIMD kernels from using AutoBlockify even
when the shared policy allows it, while the current cost model scores
`all_simd` from a post-AutoBlockify analysis view.

## What

- Keep the resolved V1 policy for `all_simd` instead of force-disabling it.
- Stop gating the NPUIR `--enable-auto-blockify-loop` flag on `parallel_mode`,
  restoring the pre-6e29d8e behavior for every route.
- Honor the linalg-level blacklist (`has_auto_blockify_blacklist_op`) in both
  bin paths.  `DiscreteMaskAccessConversion` inserts `hivm.sync_block_lock`
  when it cannot prove program-id non-overlap (e.g. discrete masked stores
  over dynamic indices), and the launcher then deliberately disables the
  launch-grid cap:
  `enable_auto_map_parallel_blocks = auto_blockify_v1_runtime_cap && !has_auto_blockify_blacklist_op`.
  Requesting the NPUIR persistent loop without that cap deadlocks, so the
  compiler must exclude these kernels exactly like the legacy path does
  (`_is_auto_map_parallel_blocks_enabled() && !has_auto_blockify_blacklist_op`).
- Only mixed/local-scope routes carry `--super-block-factor`; `all_simd`
  remains F1, matching the historical SIMD behavior.

Only `third_party/ascend/backend/compiler.py` is touched (+36/-27).

## Tests

No new UT is included in this PR.  On the branch, the existing costmodel
contract test was run and stays green:

```text
python third_party/ascend/unittest/costmodel_ut/test_compiler_costmodel_contract.py \
  CompilerCostmodelContractTest.test_all_simd_decision_replaces_route_request_with_backend_mode
-> OK
```

On an Ascend A3 test machine, for a kernel that hits the linalg blacklist
(`test_triton_unified_attn[...]` with dynamic-index masked stores):

- base (no flag requested): passes;
- this change without the blacklist check (previous revision): fails with NPU
  aicore timeout, because the pass is requested while the launcher disables
  the grid cap;
- this revision: the blacklisted kernel does not request the pass, while
  non-blacklisted kernels still get the global V1 behavior.

CI integration tests are re-run by this push.
