### PR TITLE
feat(ascend): forward enable_hivm_batch_matmul when compiler supports it

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -57,7 +57,6 @@ from triton.backends.ascend.utils import (
     _is_ascend_sanitizer_enabled,
     _is_debug_line_info_disabled,
     _is_auto_map_parallel_blocks_enabled,
-    _npu_compiler_supports_option,
     _get_auto_blockify_blacklist_reasons,
     _warn_auto_blockify_disabled,
     _remove_deprecated_npu_options,
@@ -74,6 +73,35 @@ from triton.backends.compiler import (
     GPUTarget,
 )
 from triton.runtime.cache import get_dump_manager
+
+
+@functools.lru_cache(None)
+def _npu_compiler_supports_option(option: str) -> bool:
+    """Return True if ``bishengir-compile --help`` advertises ``option``.
+
+    Optional flags must not be passed to an older toolchain that does not
+    know them -- the compile would fail on an unrecognized argument. Probe
+    once per process (cached) so a kernel that asks for a new flag still
+    builds against a compiler that has not landed it yet.
+
+    Kept in this module (not utils) so source-loaded compiler tests that stub
+    ``triton.backends.ascend.utils`` do not need a matching export.
+    """
+    bishengir_path, _ = _get_npucompiler_path()
+    if not bishengir_path:
+        return False
+    try:
+        result = subprocess.run(
+            [bishengir_path, "--help"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return option in (result.stdout or "")
 
 
 # TODO: materialize the concrete min shape

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -57,6 +57,7 @@ from triton.backends.ascend.utils import (
     _is_ascend_sanitizer_enabled,
     _is_debug_line_info_disabled,
     _is_auto_map_parallel_blocks_enabled,
+    _npu_compiler_supports_option,
     _get_auto_blockify_blacklist_reasons,
     _warn_auto_blockify_disabled,
     _remove_deprecated_npu_options,
@@ -725,6 +726,10 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
                 "--enable-hfusion-compile=true",
                 "--enable-triton-kernel-compile=true",
             ]
+            # Probe --help: an older bishengir-compile rejects unknown flags.
+            if (metadata.get("enable_hivm_batch_matmul")
+                    and _npu_compiler_supports_option("--enable-hivm-batch-matmul")):
+                _compile_option_list += ["--enable-hivm-batch-matmul"]
         bisheng_options = metadata["bisheng_options"]
         if bisheng_options is not None:
             _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
@@ -935,6 +940,10 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
                 bishengir_hivm_opt,
                 "--enable-triton-kernel-compile=true",
             ]
+            # Probe --help: an older bishengir-compile rejects unknown flags.
+            if (metadata.get("enable_hivm_batch_matmul")
+                    and _npu_compiler_supports_option("--enable-hivm-batch-matmul")):
+                _compile_option_list += ["--enable-hivm-batch-matmul"]
 
         _compile_option_list += ["--mlir-print-ir-after-failure"]
         _compile_option_list += ["--mlir-print-stacktrace-on-diagnostic"]
@@ -1068,6 +1077,10 @@ class NPUOptions:
     enable_auto_bind_sub_block: bool = None
     disable_tightly_coupled_buffer_reuse: bool = False
     enable_hivm_auto_cv_balance: bool = None
+    # Lower a rank-3 tl.dot as one batched mmad macro rather than a loop
+    # over the batch. Off unless a kernel asks for it; only forwarded when
+    # bishengir-compile advertises --enable-hivm-batch-matmul.
+    enable_hivm_batch_matmul: bool = False
     sync_solver: bool = None
     unit_flag: bool = None
     enable_flatten: bool = None

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -766,32 +766,6 @@ def _check_bishengir_able_save_ir() -> bool:
         return False
 
 
-@functools.lru_cache(None)
-def _npu_compiler_supports_option(option: str) -> bool:
-    """Return True if ``bishengir-compile --help`` advertises ``option``.
-
-    Optional flags must not be passed to an older toolchain that does not
-    know them -- the compile would fail on an unrecognized argument. Probe
-    once per process (cached) so a kernel that asks for a new flag still
-    builds against a compiler that has not landed it yet.
-    """
-    bishengir_path, _ = _get_npucompiler_path()
-    if not _is_valid_bishengir_path(bishengir_path):
-        return False
-    try:
-        result = subprocess.run(
-            [bishengir_path, "--help"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            timeout=10,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return False
-    return option in (result.stdout or "")
-
-
 def get_ascend_arch_from_env():
     _warn_deprecated_ascend_env_var("TRITON_ASCEND_ARCH")
     return ""

--- a/third_party/ascend/backend/utils.py
+++ b/third_party/ascend/backend/utils.py
@@ -766,6 +766,32 @@ def _check_bishengir_able_save_ir() -> bool:
         return False
 
 
+@functools.lru_cache(None)
+def _npu_compiler_supports_option(option: str) -> bool:
+    """Return True if ``bishengir-compile --help`` advertises ``option``.
+
+    Optional flags must not be passed to an older toolchain that does not
+    know them -- the compile would fail on an unrecognized argument. Probe
+    once per process (cached) so a kernel that asks for a new flag still
+    builds against a compiler that has not landed it yet.
+    """
+    bishengir_path, _ = _get_npucompiler_path()
+    if not _is_valid_bishengir_path(bishengir_path):
+        return False
+    try:
+        result = subprocess.run(
+            [bishengir_path, "--help"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return option in (result.stdout or "")
+
+
 def get_ascend_arch_from_env():
     _warn_deprecated_ascend_env_var("TRITON_ASCEND_ARCH")
     return ""


### PR DESCRIPTION
Motivation: torch_npu BMM templates set enable_hivm_batch_matmul so bishengir-compile can keep a rank-3 tl.dot as one BatchMmadL1 macro. Without a matching NPUOptions field and CLI forwarding, the hint is silently dropped and older toolchains that reject unknown flags cannot be mixed with kernels that ask for the option.

Design: add enable_hivm_batch_matmul (default False) and only append --enable-hivm-batch-matmul after probing bishengir-compile --help via a cached _npu_compiler_supports_option helper. Both the 910_95 and A2/A3 compile paths probe before forwarding, so a compiler without the flag still builds successfully and falls back to the loop-tiled path.

Risks: None. The option defaults off; kernels that do not request it keep prior behaviour. Probe failure returns False and skips the flag.

Assisted-by: AI

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
