### PR TITLE
[autotune](fix) delete code related to simt_stack_Limit

### DIFF
--- a/third_party/ascend/backend/runtime/autotuner.py
+++ b/third_party/ascend/backend/runtime/autotuner.py
@@ -79,11 +79,6 @@ _DEFAULT_HINT_NUM_STAGES = [1, 2]
 _DEFAULT_COMPILE_MODE = "simd_simt_template"
 
 
-def _inject_default_simt_stack_limit(options: Dict[str, object], stack_limit: int) -> None:
-    if options.get("compile_mode") == "simt_only" and options.get("simt_stack_limit") is None:
-        options["simt_stack_limit"] = stack_limit
-
-
 def _format_autotune_timing(timing) -> str:
     """Format the timing returned by the active autotune benchmarker."""
     if isinstance(timing, (tuple, list)):
@@ -339,7 +334,6 @@ class AutoTilingTuner(Autotuner):
         else:
             self.user_configs = configs
         self.is_simt_mode = False
-        self.simt_stack_limit = 8192
         self.user_specified_warps = None
         self.user_specified_num_stages = None
         self.user_specified_multibuffer = None
@@ -2113,7 +2107,6 @@ class AutoTilingTuner(Autotuner):
         self._inject_grid_num_tiles(kwargs)
         key = self.generate_key_and_configs(*args, **kwargs)
         cache_miss = key not in self.cache
-        _inject_default_simt_stack_limit(kwargs, self.simt_stack_limit)
         did_benchmark = False
         disk_cache_hit = False
         single_config_cache_pending = False
@@ -2158,7 +2151,6 @@ class AutoTilingTuner(Autotuner):
         ub_cfg = dict(getattr(config, "ubtune_cfg", {}))
         final_kwargs = dict(config.all_kwargs(), **kwargs)
         final_kwargs.update(ub_cfg)
-        _inject_default_simt_stack_limit(final_kwargs, self.simt_stack_limit)
         if config.pre_hook is not None:
             config.pre_hook({**self.nargs, **final_kwargs})
         try:
@@ -2224,7 +2216,6 @@ class AutoTilingTuner(Autotuner):
             ub_cfg = dict(getattr(config, "ubtune_cfg", {}))
             if ub_cfg:
                 current.update(ub_cfg)
-            _inject_default_simt_stack_limit(current, self.simt_stack_limit)
 
             # Match the first call made by _batch_bench. Heuristics.run sees
             # grid and warmup before forwarding the remaining arguments to
@@ -2452,7 +2443,6 @@ class AutoTilingTuner(Autotuner):
         ub_cfg = dict(getattr(config, "ubtune_cfg", {}))
         if ub_cfg:
             current.update(ub_cfg)
-        _inject_default_simt_stack_limit(current, self.simt_stack_limit)
         full_nargs = {**self.nargs, **current}
 
         def kernel_call(warmup):
@@ -2493,7 +2483,6 @@ class AutoTilingTuner(Autotuner):
 
         def warmup_config(config):
             compile_options = dict(config.all_kwargs(), **kwargs)
-            _inject_default_simt_stack_limit(compile_options, self.simt_stack_limit)
             return self.fn.warmup(*args, **compile_options)
 
         if self.compile_parallel:

--- a/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
+++ b/third_party/ascend/unittest/autotune_ut/test_autotune_param_valid.py
@@ -69,7 +69,6 @@ def _load_autotuner_methods(*method_names):
         "VectorAxes": _load_vector_axes_module().VectorAxes,
         "_InternalNPUOptionInt": ascend_autotuner._InternalNPUOptionInt,
         "_DEFAULT_COMPILE_MODE": ascend_autotuner._DEFAULT_COMPILE_MODE,
-        "_inject_default_simt_stack_limit": ascend_autotuner._inject_default_simt_stack_limit,
     }
     exec(compile(extracted_module, str(AUTOTUNER_PATH), "exec"), namespace)
     return namespace
@@ -1666,7 +1665,7 @@ def test_make_kernel_call_extracts_name_from_jit_run():
         tl.store(x_ptr + offsets, x, mask=mask)
 
     fake_self = SimpleNamespace(fn=test_kernel_jit, pre_hook=lambda full_nargs: None,
-                                post_hook=lambda full_nargs, exception=None: None, nargs={}, simt_stack_limit=8192)
+                                post_hook=lambda full_nargs, exception=None: None, nargs={})
     fake_config = SimpleNamespace(kwargs={"BLOCK_SIZE": 32}, all_kwargs=lambda: {"BLOCK_SIZE": 32}, pre_hook=None)
 
     x = torch.zeros(128, dtype=torch.float32, device="npu")
@@ -1692,7 +1691,7 @@ def test_make_kernel_call_extracts_name_from_libentry_tuple():
         tl.store(x_ptr + offsets, x, mask=mask)
 
     fake_self = SimpleNamespace(fn=test_kernel_libentry, pre_hook=lambda full_nargs: None,
-                                post_hook=lambda full_nargs, exception=None: None, nargs={}, simt_stack_limit=8192)
+                                post_hook=lambda full_nargs, exception=None: None, nargs={})
     fake_config = SimpleNamespace(kwargs={"BLOCK_SIZE": 32}, all_kwargs=lambda: {"BLOCK_SIZE": 32}, pre_hook=None)
 
     x = torch.zeros(128, dtype=torch.float32, device="npu")

--- a/third_party/ascend/unittest/autotune_ut/test_compile_failure_cache.py
+++ b/third_party/ascend/unittest/autotune_ut/test_compile_failure_cache.py
@@ -44,7 +44,6 @@ def _compile_key_kernel(
 def _make_compile_key_tuner(monkeypatch, wrapped_fn):
     tuner = object.__new__(AutoTilingTuner)
     tuner.fn = wrapped_fn
-    tuner.simt_stack_limit = 8192
     tuner.compile_parallel = False
     tuner.user_defined_pre_hook = False
 

--- a/third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py
+++ b/third_party/ascend/unittest/autotune_ut/test_do_bench_compat.py
@@ -55,7 +55,6 @@ def _make_run_tuner(configs):
     tuner.arg_names = []
     tuner.cache = {}
     tuner.is_simt_mode = False
-    tuner.simt_stack_limit = 8192
     tuner.generate_key_and_configs = generate_key_and_configs
     tuner.prune_configs = lambda kwargs: configs
     tuner.enable_ubtuner = False
@@ -342,7 +341,6 @@ def test_run_caches_single_config_and_skips_gc(monkeypatch):
     assert tuner.run() == "kernel-result"
     assert len(prune_calls) == 1
     assert len(tuner.run_kwargs) == 2
-    assert tuner.run_kwargs[-1]["simt_stack_limit"] == 8192
     assert gc_calls == []
     assert profile_calls == []
 


### PR DESCRIPTION
The requirement is to hide the simt_stack_limit option in the SIMT-only scenario from users, and the value of this option should only be determined by the data read from the acl_default.json file. 
Therefore, the code in autotune that manually assigns a value to simt_stack_limit has been removed, and compile.py will now assign the value to simt_stack_limit(The relevant logic already exists)
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
