### PR TITLE
[sim_costmodel](fix) Model route-specific scan capabilities and safe fallback

### DIFF
--- a/third_party/ascend/costmodel/include/AscendModel/Analysis/SimtAnchorAnalysis.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Analysis/SimtAnchorAnalysis.h
@@ -41,6 +41,26 @@ struct CandidateLowerability {
   bool mixed = true;
 };
 
+/// Backend lowering capabilities consumed by anchor analysis.  Keeping these
+/// facts explicit avoids encoding target names in individual pattern matchers
+/// and makes capability changes independently testable.
+struct SimtLoweringCapabilities {
+  bool supportsLocalSimtScopes = false;
+  bool supportsPlainCumsumSIMD = true;
+  /// Plain cumsum is legal when the whole kernel is compiled in simt_only
+  /// mode.  This is deliberately distinct from support inside a local SIMT
+  /// scope: the two routes use different downstream lowering pipelines.
+  bool supportsPlainCumsumSIMTOnly = false;
+  /// Whether tt.scan can be materialized inside a mixed-mode local SIMT
+  /// scope.  Keep this false until the local-scope pipeline lowers vcumsum;
+  /// the surrounding mixed kernel can still execute cumsum on the SIMD side.
+  bool supportsPlainCumsumInLocalSIMTScope = false;
+};
+
+SimtLoweringCapabilities
+querySimtLoweringCapabilities(llvm::StringRef actualTarget,
+                              bool compileOn91095);
+
 /// Structural facts for a blockwise triangular recurrence such as solve_tril.
 /// These are extracted from TTIR and deliberately avoid workload/function
 /// names.  The dense dot tail is outside the SIMT anchor and must remain on the
@@ -112,6 +132,11 @@ bool isLoadedIndexDependentMemoryOp(Operation *op);
 
 /// Build the non-overlapping shared plan in pre-order.
 SimtAnchorPlan buildMixedSimtAnchorPlan(ModuleOp module, bool compileOn91095);
+
+/// Capability-driven entry point used by the production selector.
+SimtAnchorPlan
+buildMixedSimtAnchorPlan(ModuleOp module,
+                         const SimtLoweringCapabilities &capabilities);
 
 } // namespace ascend
 } // namespace mlir

--- a/third_party/ascend/costmodel/include/AscendModel/RouteModel/StageCostModels.h
+++ b/third_party/ascend/costmodel/include/AscendModel/RouteModel/StageCostModels.h
@@ -85,6 +85,15 @@ struct LogicalStage {
   /// materialize only anchors owned by Stages that the solver selected as
   /// SIMT; consuming every materializable anchor would violate the route.
   std::vector<unsigned> simtAnchorIndices;
+  /// Conjunction of all owned anchors' pure-SIMD lowering capabilities.
+  bool allAnchorsSimdLowerable = true;
+  /// Exact operations materialized inside the local SIMT scope.  This may be
+  /// much smaller than `operations` for a hybrid Stage (for example one
+  /// tt.scan inside a loop-carried Stage that also owns several tt.dot ops).
+  std::vector<Operation *> localSimtOperations;
+  /// Per-Stage-iteration workload of localSimtOperations.  Local mixed costing
+  /// uses this for SIMT and charges the residual workload with the SIMD model.
+  StageWorkload localSimtWorkload;
   bool simdLegal = false;
   bool simtLegal = false;
   /// True when this Stage has exact operation ownership/live-in/live-out and

--- a/third_party/ascend/costmodel/include/AscendModel/RouteModel/StageRouteCostModel.h
+++ b/third_party/ascend/costmodel/include/AscendModel/RouteModel/StageRouteCostModel.h
@@ -1,8 +1,9 @@
 //===- StageRouteCostModel.h - Logical-stage route model -------*- C++ -*-===//
 //
-// A kernel is represented as serial algorithm stages.  Every Stage is
-// implemented entirely by SIMD or entirely by SIMT.  A mixed kernel is a
-// route containing both modes; there is deliberately no mixed Stage.
+// A kernel is represented as serial algorithm stages.  Whole-kernel
+// implementations use one mode per Stage.  A local-scope implementation may
+// execute an exact anchored subrange in SIMT while retaining the residual Stage
+// workload in SIMD; this mirrors scope materialization for hybrid IR.
 //
 //===----------------------------------------------------------------------===//
 
@@ -139,6 +140,9 @@ struct LogicalStageCost {
   int64_t iterationCount = 1;
   StageModelFeatures features;
   StageWorkload workload;
+  /// Work executed by an anchored local SIMT scope.  The residual
+  /// (workload-localSimtWorkload) remains SIMD in a mixed implementation.
+  StageWorkload localSimtWorkload;
   int64_t ownedOperationCount = 0;
   /// Unique source locations of the TTIR operations owned by this Stage.
   /// These are calibration provenance only: they let a debug-line-enabled

--- a/third_party/ascend/costmodel/include/AscendModel/Support/CostModelError.h
+++ b/third_party/ascend/costmodel/include/AscendModel/Support/CostModelError.h
@@ -1,0 +1,37 @@
+//===- CostModelError.h - Typed cost-model failures ------------*- C++ -*-===//
+
+#ifndef ASCENDMODEL_SUPPORT_COSTMODELERROR_H
+#define ASCENDMODEL_SUPPORT_COSTMODELERROR_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
+#include <system_error>
+
+namespace mlir::ascend {
+
+/// An input kernel that is valid TTIR but is outside the model/materializer
+/// contract.  The selector may recover from this by using backend_default.
+class UnsupportedCostModelIR final
+    : public llvm::ErrorInfo<UnsupportedCostModelIR> {
+public:
+  static inline char ID = 0;
+
+  explicit UnsupportedCostModelIR(std::string message)
+      : message(std::move(message)) {}
+
+  void log(llvm::raw_ostream &os) const override { os << message; }
+  std::error_code convertToErrorCode() const override {
+    return std::make_error_code(std::errc::not_supported);
+  }
+  llvm::StringRef getMessage() const { return message; }
+
+private:
+  std::string message;
+};
+
+} // namespace mlir::ascend
+
+#endif // ASCENDMODEL_SUPPORT_COSTMODELERROR_H

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/SimtAnchorAnalysis.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/SimtAnchorAnalysis.cpp
@@ -42,6 +42,17 @@ static std::string getScalarTypeName(Type type) {
   return "unknown";
 }
 
+/// True for scalar or tensor-of-pointer state.  A scope.scope region may
+/// capture such values but must not return them: TritonToUnstructure cannot
+/// reconstruct the offset information for a returned pointer.
+static bool isPointerLikeType(Type type) {
+  std::string text;
+  llvm::raw_string_ostream stream(text);
+  stream << type;
+  stream.flush();
+  return llvm::StringRef(text).contains("!tt.ptr");
+}
+
 struct PlainCumsumLegality {
   int64_t axisExtent;
   std::string elementType;
@@ -460,8 +471,9 @@ collectTriangularSolveScopeOperations(Operation *anchor,
   return result;
 }
 
-static std::optional<SimtAnchorDescriptor> analyzeAnchor(Operation *op,
-                                                         bool compileOn91095) {
+static std::optional<SimtAnchorDescriptor>
+analyzeAnchor(Operation *op,
+              const SimtLoweringCapabilities &capabilities) {
   if (!op)
     return std::nullopt;
   SimtAnchorDescriptor descriptor;
@@ -501,8 +513,20 @@ static std::optional<SimtAnchorDescriptor> analyzeAnchor(Operation *op,
     if (!facts)
       return std::nullopt;
     descriptor.kind = SimtAnchorKind::PlainOneDimensionalCumsum;
-    if (facts->axisExtent <= 0 || !isSupportedCumsumType(facts->elementType))
-      descriptor.lowerability.mixed = false;
+    descriptor.lowerability.allSimd = capabilities.supportsPlainCumsumSIMD;
+    descriptor.lowerability.allSimtOnly =
+        capabilities.supportsPlainCumsumSIMTOnly;
+    const bool supportedShapeAndType =
+        facts->axisExtent > 0 && isSupportedCumsumType(facts->elementType);
+    descriptor.lowerability.allSimd &= supportedShapeAndType;
+    descriptor.lowerability.allSimtOnly &= supportedShapeAndType;
+    // A mixed route does not require every recognized anchor to become a
+    // local SIMT scope.  Cumsum can remain in the residual SIMD portion while
+    // independent, genuinely materializable anchors use local SIMT scopes.
+    descriptor.lowerability.mixed =
+        supportedShapeAndType &&
+        (capabilities.supportsPlainCumsumSIMD ||
+         capabilities.supportsPlainCumsumInLocalSIMTScope);
   } else if (name == "tt.atomic_rmw" || name == "tt.atomic_cas") {
     descriptor.kind = SimtAnchorKind::TensorAtomic;
     auto result = op->getNumResults() > 0
@@ -536,7 +560,11 @@ static std::optional<SimtAnchorDescriptor> analyzeAnchor(Operation *op,
     return std::nullopt;
   }
 
-  descriptor.materializable = compileOn91095 && descriptor.lowerability.mixed;
+  descriptor.materializable = capabilities.supportsLocalSimtScopes &&
+                              descriptor.lowerability.mixed;
+  if (descriptor.kind == SimtAnchorKind::PlainOneDimensionalCumsum)
+    descriptor.materializable &=
+        capabilities.supportsPlainCumsumInLocalSIMTScope;
   return descriptor;
 }
 
@@ -645,15 +673,33 @@ bool mlir::ascend::isLoadedIndexDependentMemoryOp(Operation *op) {
          hasTensorPointerOperand(op) && pointerDependsOnLoadedIndex(op);
 }
 
-SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(ModuleOp module,
-                                                      bool compileOn91095) {
+SimtLoweringCapabilities mlir::ascend::querySimtLoweringCapabilities(
+    llvm::StringRef /*actualTarget*/, bool compileOn91095) {
+  SimtLoweringCapabilities capabilities;
+  // The integration layer is the authority for local-scope support.  Target
+  // spelling is retained for diagnostics/future capability-table expansion;
+  // individual anchor matchers no longer branch on a product-name boolean.
+  capabilities.supportsLocalSimtScopes = compileOn91095;
+  // tt.scan is supported by the normal SIMD pipeline and by the whole-kernel
+  // simt_only pipeline on 91095.  The local-SIMT-scope pipeline is a third,
+  // narrower capability: its current external compiler cannot legalize the
+  // resulting hivm.hir.vcumsum, so cumsum must stay on the SIMD side of a
+  // mixed route instead of being outlined.
+  capabilities.supportsPlainCumsumSIMD = true;
+  capabilities.supportsPlainCumsumSIMTOnly = compileOn91095;
+  capabilities.supportsPlainCumsumInLocalSIMTScope = false;
+  return capabilities;
+}
+
+SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(
+    ModuleOp module, const SimtLoweringCapabilities &capabilities) {
   SimtAnchorPlan plan;
   llvm::DenseSet<Operation *> operationsInPlannedScope;
   module.walk<WalkOrder::PreOrder>([&](Operation *op) {
     if (operationsInPlannedScope.contains(op))
       return WalkResult::skip();
     std::optional<SimtAnchorDescriptor> descriptor =
-        analyzeAnchor(op, compileOn91095);
+        analyzeAnchor(op, capabilities);
     if (!descriptor)
       return WalkResult::advance();
 
@@ -684,4 +730,10 @@ SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(ModuleOp module,
   }
   plan.kernelLowerability.mixed = anyMixed && !mixedBlocked;
   return plan;
+}
+
+SimtAnchorPlan mlir::ascend::buildMixedSimtAnchorPlan(ModuleOp module,
+                                                      bool compileOn91095) {
+  return buildMixedSimtAnchorPlan(
+      module, querySimtLoweringCapabilities("", compileOn91095));
 }

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
@@ -368,6 +368,7 @@ static void attachExactAnchorOwnership(StagePartition &partition,
       if (anchor.materializable && stageOwnsAnchor(stage, anchor)) {
         stage.simtAnchorIndices.push_back(
             static_cast<unsigned>(indexedAnchor.index()));
+        stage.allAnchorsSimdLowerable &= anchor.lowerability.allSimd;
         Operation *insertionPoint = anchor.scopeOperations.size() > 1
                                         ? anchor.scopeInsertionPoint
                                         : anchor.operation;
@@ -673,6 +674,7 @@ static void deriveLocalSimtScopeTraffic(StagePartition &partition,
     stage.localSimtScopeCount = 0;
     stage.scopeInputTensorBytes = 0;
     stage.scopeOutputTensorBytes = 0;
+    stage.localSimtOperations.clear();
     auto merged = mergeSimtStageAnchors(anchorPlan, stage.simtAnchorIndices);
     if (!merged)
       continue;
@@ -684,6 +686,7 @@ static void deriveLocalSimtScopeTraffic(StagePartition &partition,
         llvm::append_range(roots, anchor.scopeOperations);
       else
         roots.push_back(anchor.operation);
+      stage.localSimtOperations.assign(roots.begin(), roots.end());
 
       llvm::DenseSet<Operation *> inside;
       for (Operation *root : roots) {

--- a/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Analysis/StagePartitioner.cpp
@@ -1146,13 +1146,14 @@ llvm::Error StageKindClassifier::analyze(StagePartition &partition,
     if (stage.costModelKind == StageCostModelKind::AutoBlockifyDispatch ||
         stage.costModelKind == StageCostModelKind::AutoBlockifyLoop)
       continue;
-    if (facts.hasDot && (facts.hasReduction || facts.hasIndirectMemory ||
-                         facts.hasLoopCarriedDataDependency))
-      return llvm::createStringError(
-          std::errc::invalid_argument,
-          "requires_split: Stage '%s' owns incompatible dominant structures",
-          stage.id.c_str());
-
+    // A Stage mixing tt.dot with another dominant structure (reduction,
+    // indirect memory, loop-carried recurrence) cannot always be split: the
+    // dot may sit inside the serial chain itself (e.g. a chunked-scan state
+    // update whose per-iteration body contains dots), so the partitioner has
+    // no boundary at which to separate it. Model such hybrid Stages with the
+    // dominant structure's kind instead of failing: workload accounting
+    // charges the dot on the same critical path, and the SIMT profile's
+    // scalar-FMA dot rate keeps a hybrid Stage honestly expensive in SIMT.
     auto derive = [&]() {
       if (facts.hasLoopCarriedDataDependency)
         return StageCostModelKind::LoopCarriedRecurrence;

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/SimdSimtCostModel.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AscendModel/RouteModel/SimdSimtCostModel.h"
+#include "AscendModel/Support/CostModelError.h"
 #include "AscendModel/Analysis/SimtAnchorAnalysis.h"
 #include "AscendModel/Analysis/StagePartitioner.h"
 #include "AscendModel/Profile/MicrobenchmarkProfile.h"
@@ -796,8 +797,7 @@ estimateSimdSimtCandidatesImpl(const SimdSimtFeatureSummary &features,
       static_cast<unsigned>(report.allSimtOnlyCandidateLegal) +
       static_cast<unsigned>(report.mixedCandidateLegal);
   if (legalCandidateCount == 0)
-    return llvm::createStringError(
-        std::errc::not_supported,
+    return llvm::make_error<UnsupportedCostModelIR>(
         "Stage Route Model found no materializable candidate");
   report.decision =
       chooseBest(report.candidateCosts, report.allSimdCandidateLegal,
@@ -810,8 +810,9 @@ llvm::Expected<SimdSimtCostReport> mlir::ascend::analyzeSimdSimtCandidates(
   if (!module)
     return llvm::createStringError(std::errc::invalid_argument,
                                    "cannot analyze a null ModuleOp");
-  SimtAnchorPlan anchorPlan =
-      buildMixedSimtAnchorPlan(module, options.compileOn91095);
+  SimtAnchorPlan anchorPlan = buildMixedSimtAnchorPlan(
+      module, querySimtLoweringCapabilities(options.actualTarget,
+                                            options.compileOn91095));
   return analyzeSimdSimtCandidates(module, anchorPlan, options);
 }
 

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageCostModels.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageCostModels.cpp
@@ -141,6 +141,55 @@ static StageResourceCycles mapWorkload(const LogicalStage &stage,
   return materializeControlFlow(stage, mode, resources, profile.controlFlow);
 }
 
+static StageWorkload subtractWorkload(const StageWorkload &total,
+                                      const StageWorkload &local) {
+  StageWorkload residual = total;
+  auto subtract = [](double lhs, double rhs) {
+    return std::max(0.0, lhs - rhs);
+  };
+  residual.scalarOperations =
+      subtract(total.scalarOperations, local.scalarOperations);
+  residual.loadBytes = subtract(total.loadBytes, local.loadBytes);
+  residual.storeBytes = subtract(total.storeBytes, local.storeBytes);
+  residual.loadWarpInstructions =
+      subtract(total.loadWarpInstructions, local.loadWarpInstructions);
+  residual.storeWarpInstructions =
+      subtract(total.storeWarpInstructions, local.storeWarpInstructions);
+  residual.predicateElements =
+      subtract(total.predicateElements, local.predicateElements);
+  residual.shuffleLaneSteps =
+      subtract(total.shuffleLaneSteps, local.shuffleLaneSteps);
+  residual.dotFlops = subtract(total.dotFlops, local.dotFlops);
+  residual.issueElements = subtract(total.issueElements, local.issueElements);
+  residual.estimatedSpillTransactions = subtract(
+      total.estimatedSpillTransactions, local.estimatedSpillTransactions);
+  for (const auto &[name, elements] : local.operationElements) {
+    auto it = residual.operationElements.find(name);
+    if (it != residual.operationElements.end())
+      it->second = subtract(it->second, elements);
+  }
+  return residual;
+}
+
+static void addResources(StageResourceCycles &into,
+                         const StageResourceCycles &from) {
+  into.setup += from.setup;
+  into.scalar += from.scalar;
+  into.load += from.load;
+  into.store += from.store;
+  into.compute += from.compute;
+  into.predicate += from.predicate;
+  into.shuffle += from.shuffle;
+  into.dot += from.dot;
+  into.loopControl += from.loopControl;
+  into.branchControl += from.branchControl;
+  into.divergence += from.divergence;
+  into.synchronization += from.synchronization;
+  into.spill += from.spill;
+  into.issue += from.issue;
+  into.criticalPath += from.criticalPath;
+}
+
 static double applySuperBlock(const LogicalStage &stage,
                               const StageResourceCycles &resources,
                               const StageImplementation &implementation,
@@ -456,6 +505,7 @@ StageCostEvaluator::evaluate(const StagePartition &partition,
     logicalCost.iterationCount = stage.iterationCount;
     logicalCost.features = stage.features;
     logicalCost.workload = stage.workload;
+    logicalCost.localSimtWorkload = stage.localSimtWorkload;
     logicalCost.ownedOperationCount =
         static_cast<int64_t>(stage.operations.size());
     logicalCost.sourceLocations = collectSourceLocations(stage);
@@ -488,16 +538,49 @@ StageCostEvaluator::evaluate(const StagePartition &partition,
         return llvm::createStringError(std::errc::invalid_argument,
                                        "Stage '%s' has an illegal candidate",
                                        stage.id.c_str());
-      StageResourceCycles resources = mapWorkload(
-          stage,
-          implementation.mode == StageMode::SIMD ? profile.simd : profile.simt,
-          implementation.mode);
+      StageResourceCycles resources;
+      double baseCycles = 0.0;
+      if (implementation.localScope &&
+          stage.localSimtWorkload.issueElements > 0.0) {
+        LogicalStage residualStage = stage;
+        residualStage.workload =
+            subtractWorkload(stage.workload, stage.localSimtWorkload);
+        StageResourceCycles residual =
+            mapWorkload(residualStage, profile.simd, StageMode::SIMD);
+        const double residualCycles =
+            estimateStage(residualStage, profile, StageMode::SIMD, residual);
+
+        LogicalStage localStage = stage;
+        localStage.costModelKind = stage.features.hasPrefixScan
+                                       ? StageCostModelKind::PrefixScan
+                                       : stage.costModelKind;
+        localStage.scheduleKind = StageScheduleKind::StraightLine;
+        localStage.workload = stage.localSimtWorkload;
+        localStage.workload.paysKernelSetup = false;
+        localStage.features = StageModelFeatures{};
+        localStage.features.hasPrefixScan = stage.features.hasPrefixScan;
+        localStage.features.hasReduction = !stage.features.hasPrefixScan &&
+                                           stage.features.hasReduction;
+        StageResourceCycles local =
+            mapWorkload(localStage, profile.simt, StageMode::SIMT);
+        const double localCycles =
+            estimateStage(localStage, profile, StageMode::SIMT, local);
+        resources = residual;
+        addResources(resources, local);
+        baseCycles = residualCycles + localCycles;
+      } else {
+        resources = mapWorkload(
+            stage, implementation.mode == StageMode::SIMD ? profile.simd
+                                                           : profile.simt,
+            implementation.mode);
+        baseCycles =
+            estimateStage(stage, profile, implementation.mode, resources);
+      }
       StageImplementationCost cost;
       cost.implementation = implementation;
       cost.resources = resources;
-      cost.totalCycles = applySuperBlock(
-          stage, resources, implementation, profile,
-          estimateStage(stage, profile, implementation.mode, resources));
+      cost.totalCycles =
+          applySuperBlock(stage, resources, implementation, profile, baseCycles);
       if (!cost.isValid())
         return llvm::createStringError(std::errc::invalid_argument,
                                        "Stage '%s' produced an invalid cost",

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageCostModels.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageCostModels.cpp
@@ -136,8 +136,12 @@ static StageResourceCycles mapWorkload(const LogicalStage &stage,
                              resources.predicate + resources.shuffle +
                              resources.dot;
   else if (stage.features.hasReduction)
+    // A reduction whose accumulation is a tt.dot (hybrid dot+reduction
+    // Stage) must charge the dot on the accumulation chain; pure
+    // reductions keep dot == 0 and are unaffected.
     resources.criticalPath =
-        resources.compute + resources.predicate + resources.shuffle;
+        resources.compute + resources.predicate + resources.shuffle +
+        resources.dot;
   return materializeControlFlow(stage, mode, resources, profile.controlFlow);
 }
 

--- a/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageRouteCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/RouteModel/StageRouteCostModel.cpp
@@ -268,6 +268,7 @@ llvm::json::Object LogicalStageCost::toJSON() const {
   result["iteration_count"] = iterationCount;
   result["features"] = features.toJSON();
   result["workload"] = workload.toJSON();
+  result["local_simt_workload"] = localSimtWorkload.toJSON();
   result["owned_operation_count"] = ownedOperationCount;
   llvm::json::Array locations;
   for (const std::string &location : sourceLocations)

--- a/third_party/ascend/costmodel/lib/AscendModel/Transforms/SelectSimdSimtCostModel.cpp
+++ b/third_party/ascend/costmodel/lib/AscendModel/Transforms/SelectSimdSimtCostModel.cpp
@@ -9,6 +9,7 @@
 
 #include "AscendModel/Analysis/SimtAnchorAnalysis.h"
 #include "AscendModel/RouteModel/SimdSimtCostModel.h"
+#include "AscendModel/Support/CostModelError.h"
 #include "AscendModel/Transforms/Passes.h"
 #include "AscendModel/Transforms/SimtSelection.h"
 
@@ -65,6 +66,60 @@ static bool containsExplicitVectorScope(ModuleOp module) {
     return WalkResult::advance();
   });
   return found;
+}
+
+static bool isBackendIntrinsicSimtScan(Operation *op) {
+  if (op->getName().getStringRef() != "tt.scan" ||
+      op->getNumOperands() == 0 || op->getNumRegions() == 0 ||
+      op->getRegion(0).empty())
+    return false;
+
+  auto axisAttr = op->getAttrOfType<IntegerAttr>("axis");
+  auto srcTy = dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+  if (!axisAttr || !srcTy || !srcTy.hasRank())
+    return false;
+  int64_t axis = axisAttr.getInt();
+  ArrayRef<int64_t> shape = srcTy.getShape();
+  if (axis < 0 || axis >= static_cast<int64_t>(shape.size()))
+    return false;
+  for (int64_t dim = 0; dim < static_cast<int64_t>(shape.size()); ++dim) {
+    if (dim != axis && shape[dim] != 1)
+      return false;
+  }
+
+  Operation *combineOp = nullptr;
+  for (Operation &bodyOp : op->getRegion(0).front().without_terminator()) {
+    llvm::StringRef name = bodyOp.getName().getStringRef();
+    if (name == "tt.scan.return")
+      continue;
+    if (name == "arith.extf" || name == "arith.truncf" ||
+        name == "arith.bitcast")
+      continue;
+    if (combineOp)
+      return false;
+    combineOp = &bodyOp;
+  }
+  if (!combineOp)
+    return false;
+  llvm::StringRef combineName = combineOp->getName().getStringRef();
+  return combineName == "arith.addf" || combineName == "arith.addi";
+}
+
+static bool requiresBackendIntrinsicSimtRouting(ModuleOp module,
+                                                bool compileOn91095) {
+  if (!compileOn91095)
+    return false;
+  bool required = false;
+  module.walk([&](Operation *op) {
+    llvm::StringRef name = op->getName().getStringRef();
+    if (name == "tt.gather" || name == "tt.histogram" ||
+        isBackendIntrinsicSimtScan(op)) {
+      required = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return required;
 }
 
 static void clearPreviousSelection(ModuleOp module) {
@@ -181,21 +236,70 @@ struct SelectSimdSimtCostModelPass
         if (auto count = object->getInteger("physical_vector_core_count_hint"))
           options.physicalVectorCoreCountHint = std::max<int64_t>(0, *count);
 
-    SimtAnchorPlan anchorPlan =
-        buildMixedSimtAnchorPlan(module, options.compileOn91095);
+    const SimtLoweringCapabilities capabilities =
+        querySimtLoweringCapabilities(options.actualTarget,
+                                      options.compileOn91095);
+    SimtAnchorPlan anchorPlan = buildMixedSimtAnchorPlan(module, capabilities);
     SimtAnchorPlan analysisAnchorPlan =
-        buildMixedSimtAnchorPlan(analysisModule, options.compileOn91095);
+        buildMixedSimtAnchorPlan(analysisModule, capabilities);
     auto reportOr =
         analyzeSimdSimtCandidates(analysisModule, analysisAnchorPlan, options);
     if (!reportOr) {
-      module.emitError("C++ SIMD/SIMT cost model failed: ")
-          << llvm::toString(reportOr.takeError());
-      signalPassFailure();
+      std::string reason;
+      bool recoverable = false;
+      llvm::Error unhandled = llvm::handleErrors(
+          reportOr.takeError(), [&](const UnsupportedCostModelIR &error) {
+            reason = error.getMessage().str();
+            recoverable = true;
+          });
+      if (unhandled) {
+        reason = llvm::toString(std::move(unhandled));
+        module.emitError("C++ SIMD/SIMT cost model internal failure: ")
+            << reason;
+        signalPassFailure();
+        return;
+      }
+      assert(recoverable && "typed costmodel error was not handled");
+      // Unsupported but valid TTIR is recoverable.  Internal partition/profile
+      // invariants are deliberately not swallowed by this path.
+      module.emitWarning("C++ SIMD/SIMT cost model fell back to "
+                         "backend_default: ")
+          << reason;
+      Builder builder(module.getContext());
+      module->setAttr(kEffectiveExecutionAttr,
+                      builder.getStringAttr(kBackendDefault));
+      module->setAttr(kSelectionSourceAttr,
+                      builder.getStringAttr("backend_default"));
+      llvm::json::Object reportJSON;
+      reportJSON["mode"] = mode.getValue();
+      reportJSON["recommended_decision_kind"] = kBackendDefault.str();
+      reportJSON["effective_decision_kind"] = kBackendDefault.str();
+      reportJSON["selection_source"] = "backend_default";
+      reportJSON["application_reason"] = reason;
+      reportJSON["action_supported"] = false;
+      std::string json =
+          llvm::formatv("{0}", llvm::json::Value(std::move(reportJSON))).str();
+      module->setAttr(kReportJSONAttr, builder.getStringAttr(json));
+      if (failed(appendJSONLine(reportFile.getValue(), json)))
+        module.emitWarning("failed to append C++ SIMD/SIMT report to ")
+            << reportFile.getValue();
       return;
     }
     SimdSimtCostReport report = std::move(*reportOr);
 
-    std::string recommended = stringifySimdSimtCandidate(report.decision).str();
+    std::string costOnlyRecommended =
+        stringifySimdSimtCandidate(report.decision).str();
+    std::string recommended = costOnlyRecommended;
+    // "all_simd" means that the Route Model does not need to materialize a
+    // local SIMT scope.  It must not disable backend-intrinsic SIMT lowering
+    // for operations such as tt.scan, whose strict SIMD lowering is not a
+    // valid executable candidate.  Preserve the proven backend route in this
+    // case instead of applying a semantically different all-SIMD contract.
+    const bool preserveBackendIntrinsicRoute =
+        autoMode && recommended == kAllSimd &&
+        requiresBackendIntrinsicSimtRouting(module, options.compileOn91095);
+    if (preserveBackendIntrinsicRoute)
+      recommended = kBackendDefault.str();
     std::string effective = kBackendDefault.str();
     std::string selectionSource = "backend_default";
     std::string applicationReason;
@@ -208,7 +312,7 @@ struct SelectSimdSimtCostModelPass
     else if (report.decision == SimdSimtCandidateKind::AllSIMTOnly)
       selectedSuperblockFactor =
           report.stageModel.allSimt.routeSuperblockFactor;
-    else
+    else if (recommended == kMixedSimdSimt)
       selectedSuperblockFactor = report.stageModel.mixed.routeSuperblockFactor;
 
     bool actionSupported = true;
@@ -264,7 +368,9 @@ struct SelectSimdSimtCostModelPass
     if (autoMode && actionSupported) {
       effective = recommended;
       selectionSource = "cpp_cost_model";
-      applicationReason = "minimum_cost_candidate";
+      applicationReason = preserveBackendIntrinsicRoute
+                              ? "backend_intrinsic_simt_required"
+                              : "minimum_cost_candidate";
     } else if (!autoMode) {
       applicationReason = "report_mode";
     } else if (applicationReason.empty()) {
@@ -297,6 +403,8 @@ struct SelectSimdSimtCostModelPass
 
     llvm::json::Object reportJSON = report.toJSON();
     reportJSON["mode"] = mode.getValue();
+    reportJSON["cost_only_decision_kind"] = costOnlyRecommended;
+    reportJSON["decision_kind"] = recommended;
     reportJSON["recommended_decision_kind"] = recommended;
     reportJSON["effective_decision_kind"] = effective;
     reportJSON["selection_source"] = selectionSource;

--- a/third_party/ascend/unittest/costmodel_ut/PassesTest.cpp
+++ b/third_party/ascend/unittest/costmodel_ut/PassesTest.cpp
@@ -307,11 +307,11 @@ module {
   const auto &anchor = plan.anchors.front();
   EXPECT_EQ(anchor.kind,
             mlir::ascend::SimtAnchorKind::PlainOneDimensionalCumsum);
-  EXPECT_FALSE(anchor.lowerability.allSimd);
+  EXPECT_TRUE(anchor.lowerability.allSimd);
   EXPECT_TRUE(anchor.lowerability.allSimtOnly);
   EXPECT_TRUE(anchor.lowerability.mixed);
-  EXPECT_TRUE(anchor.materializable);
-  EXPECT_FALSE(plan.kernelLowerability.allSimd);
+  EXPECT_FALSE(anchor.materializable);
+  EXPECT_TRUE(plan.kernelLowerability.allSimd);
   EXPECT_TRUE(plan.kernelLowerability.allSimtOnly);
   EXPECT_TRUE(plan.kernelLowerability.mixed);
 }
@@ -589,6 +589,64 @@ TEST(CostModelPassesTest, SimdSimtScoresGenericSemanticStages) {
   auto reportReason = reportObject->getString("application_reason");
   ASSERT_TRUE(reportReason);
   EXPECT_EQ(*reportReason, "report_mode");
+}
+
+TEST(CostModelPassesTest, AllSimdPreservesBackendIntrinsicSimtRouting) {
+  mlir::MLIRContext context;
+  context.allowUnregisteredDialects();
+  auto module = parseModule(context, R"mlir(
+module {
+  func.func @main(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>)
+      -> tensor<4xf32> {
+    %0 = arith.addf %arg0, %arg1 : tensor<4xf32>
+    return %0 : tensor<4xf32>
+  }
+  func.func private @intrinsic_scan(%input: tensor<1xf32>)
+      -> tensor<1xf32> {
+    %scan = "tt.scan"(%input) ({
+    ^bb0(%lhs: f32, %rhs: f32):
+      %sum = arith.addf %lhs, %rhs : f32
+      "tt.scan.return"(%sum) : (f32) -> ()
+    }) {axis = 0 : i32, reverse = false}
+      : (tensor<1xf32>) -> tensor<1xf32>
+    return %scan : tensor<1xf32>
+  }
+}
+)mlir");
+  ASSERT_TRUE(module);
+
+  SelectSimdSimtCostModelPassOptions options;
+  options.mode = "auto";
+  options.profilePath = TRITON_ASCEND_SIMD_SIMT_TEST_PROFILE_PATH;
+  options.actualTarget = "Ascend950PR_9579";
+  options.numWarps = 4;
+  options.compileOn91095 = true;
+  ASSERT_TRUE(runPasses(*module,
+                        createSelectSimdSimtCostModelPass(options)));
+
+  auto effective = (*module)->getAttrOfType<StringAttr>(
+      "ascend.simt_costmodel.effective");
+  auto reportAttr = (*module)->getAttrOfType<StringAttr>(
+      "ascend.simt_costmodel.report_json");
+  ASSERT_TRUE(effective);
+  ASSERT_TRUE(reportAttr);
+  EXPECT_EQ(effective.getValue(), "backend_default");
+  auto report = llvm::json::parse(reportAttr.getValue());
+  ASSERT_TRUE(static_cast<bool>(report));
+  auto *object = report->getAsObject();
+  ASSERT_NE(object, nullptr);
+  auto costOnly = object->getString("cost_only_decision_kind");
+  auto decision = object->getString("decision_kind");
+  auto reportedEffective = object->getString("effective_decision_kind");
+  auto reason = object->getString("application_reason");
+  ASSERT_TRUE(costOnly);
+  ASSERT_TRUE(decision);
+  ASSERT_TRUE(reportedEffective);
+  ASSERT_TRUE(reason);
+  EXPECT_EQ(*costOnly, "all_simd");
+  EXPECT_EQ(*decision, "backend_default");
+  EXPECT_EQ(*reportedEffective, "backend_default");
+  EXPECT_EQ(*reason, "backend_intrinsic_simt_required");
 }
 
 TEST(CostModelPassesTest, SimdSimtSelectionUsesExternalAnalysisIR) {

--- a/third_party/ascend/unittest/costmodel_ut/SimdSimtCostModelTest.cpp
+++ b/third_party/ascend/unittest/costmodel_ut/SimdSimtCostModelTest.cpp
@@ -1,4 +1,5 @@
 #include "AscendModel/RouteModel/SimdSimtCostModel.h"
+#include "AscendModel/Analysis/SimtAnchorAnalysis.h"
 #include "AscendModel/Analysis/StagePartitioner.h"
 #include "AscendModel/RouteModel/StageCostModels.h"
 
@@ -31,6 +32,22 @@ using mlir::ascend::StageWorkloadAnalysis;
 using mlir::ascend::TriangularSolveFacts;
 
 namespace {
+
+TEST(SimdSimtCostModelTest, CumsumCapabilitiesDistinguishMixedLocalScope) {
+  auto capabilities = mlir::ascend::querySimtLoweringCapabilities(
+      "Ascend950PR_9579", /*compileOn91095=*/true);
+  EXPECT_TRUE(capabilities.supportsLocalSimtScopes);
+  EXPECT_TRUE(capabilities.supportsPlainCumsumSIMD);
+  EXPECT_TRUE(capabilities.supportsPlainCumsumSIMTOnly);
+  EXPECT_FALSE(capabilities.supportsPlainCumsumInLocalSIMTScope);
+
+  auto genericCapabilities = mlir::ascend::querySimtLoweringCapabilities(
+      "Ascend910B", /*compileOn91095=*/false);
+  EXPECT_FALSE(genericCapabilities.supportsLocalSimtScopes);
+  EXPECT_TRUE(genericCapabilities.supportsPlainCumsumSIMD);
+  EXPECT_FALSE(genericCapabilities.supportsPlainCumsumSIMTOnly);
+  EXPECT_FALSE(genericCapabilities.supportsPlainCumsumInLocalSIMTScope);
+}
 
 SimdSimtFeatureSummary triangularBt16StageFeatures() {
   SimdSimtFeatureSummary f;

--- a/third_party/ascend/unittest/costmodel_ut/SimdSimtCostModelTest.cpp
+++ b/third_party/ascend/unittest/costmodel_ut/SimdSimtCostModelTest.cpp
@@ -1386,7 +1386,7 @@ TEST(SimdSimtCostModelTest, PointerInductionLoopIsNotADataRecurrence) {
             StageCostModelKind::IndependentPipelinedLoop);
 }
 
-TEST(SimdSimtCostModelTest, IncompatibleDominantStructuresRequireStageSplit) {
+TEST(SimdSimtCostModelTest, HybridDominantStructuresClassifyAsDominantKind) {
   StagePartition partition;
   partition.operationOwnershipComplete = true;
   LogicalStage stage =
@@ -1396,9 +1396,15 @@ TEST(SimdSimtCostModelTest, IncompatibleDominantStructuresRequireStageSplit) {
   stage.features.hasIndirectMemory = true;
   partition.stages.push_back(std::move(stage));
 
+  // A Stage mixing tt.dot with another dominant structure cannot always be
+  // split (the dot may sit inside the other structure's serial chain), so
+  // the classifier models it with the dominant structure's kind instead of
+  // failing: derive() ranks dot above indirect memory for straight-line
+  // Stages, and the workload keeps charging both structures.
   llvm::Error error =
       mlir::ascend::StageKindClassifier().analyze(partition, 16384);
-  ASSERT_TRUE(static_cast<bool>(error));
-  EXPECT_NE(llvm::toString(std::move(error)).find("requires_split"),
-            std::string::npos);
+  ASSERT_TRUE(static_cast<bool>(error) == false)
+      << llvm::toString(std::move(error));
+  EXPECT_EQ(partition.stages.front().costModelKind,
+            StageCostModelKind::TinyCubeRoofline);
 }

--- a/third_party/ascend/unittest/pytest_ut/test_costmodel_scan_routes.py
+++ b/third_party/ascend/unittest/pytest_ut/test_costmodel_scan_routes.py
@@ -63,11 +63,13 @@ def test_cumsum_keeps_supported_routes_legal(tmp_path):
     ]
     assert len(scan_stages) == 1
     assert scan_stages[0]["model"] == "prefix_scan"
-    assert scan_stages[0]["local_simt_materializable"]
+    assert not scan_stages[0]["local_simt_materializable"]
 
-    # Route choice is profile-dependent. The invariant under test is that a
-    # supported cumsum does not make any backend route illegal.
+    # Route choice is profile-dependent. Plain cumsum remains legal for both
+    # whole-kernel backend routes. A local mixed route requires the separate
+    # anchor-free materialization feature and is intentionally unavailable in
+    # this standalone scan change.
     routes = report["stage_model"]["routes"]
     assert routes["all_simd"]["legal"]
     assert routes["all_simt_only"]["legal"]
-    assert routes["mixed_simd_simt"]["legal"]
+    assert not routes["mixed_simd_simt"]["legal"]

--- a/third_party/ascend/unittest/pytest_ut/test_costmodel_scan_routes.py
+++ b/third_party/ascend/unittest/pytest_ut/test_costmodel_scan_routes.py
@@ -1,0 +1,73 @@
+import json
+import os
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+from triton.backends.ascend.utils import is_compile_on_910_95
+
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("TRITON_RUN_SIMD_SIMT_COSTMODEL_GUARDS") != "1",
+    reason="SIMD/SIMT costmodel guards are opt-in",
+)
+
+simd_simt_910_95_only = pytest.mark.xfail(
+    not is_compile_on_910_95(),
+    reason="SIMD/SIMT cost model only supports 910_95",
+    run=False,
+)
+
+
+@triton.jit
+def cumsum_backend_route_kernel(
+    input_ptr,
+    output_ptr,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK)
+    values = tl.load(input_ptr + offsets)
+    result = tl.cumsum(values, axis=0)
+    tl.store(output_ptr + offsets, result)
+
+
+@simd_simt_910_95_only
+def test_cumsum_keeps_supported_routes_legal(tmp_path):
+    block = 256
+    torch.manual_seed(7)
+    values = torch.randn((block,), dtype=torch.float32, device="npu")
+    output = torch.empty_like(values)
+    report_path = tmp_path / "cumsum_route.json"
+
+    cumsum_backend_route_kernel[(1,)](
+        values,
+        output,
+        BLOCK=block,
+        num_warps=4,
+        compile_mode="simd_simt",
+        auto_simt_scope_mode="auto",
+        auto_simt_scope_dump=str(report_path),
+        logical_program_count_hint=1,
+        physical_vector_core_count_hint=1,
+    )
+
+    torch.testing.assert_close(output, torch.cumsum(values, dim=0),
+                               rtol=1e-4, atol=1e-4)
+    report = json.loads(report_path.read_text())
+    assert report["stage_model"]["applied"]
+
+    stages = report["stage_model"]["logical_stages"]
+    scan_stages = [
+        stage for stage in stages if stage["features"]["has_prefix_scan"]
+    ]
+    assert len(scan_stages) == 1
+    assert scan_stages[0]["model"] == "prefix_scan"
+    assert scan_stages[0]["local_simt_materializable"]
+
+    # Route choice is profile-dependent. The invariant under test is that a
+    # supported cumsum does not make any backend route illegal.
+    routes = report["stage_model"]["routes"]
+    assert routes["all_simd"]["legal"]
+    assert routes["all_simt_only"]["legal"]
+    assert routes["mixed_simd_simt"]["legal"]


### PR DESCRIPTION
### Background

Cumsum is supported by the normal SIMD and whole-kernel SIMT pipelines, but not by the current mixed local-SIMT-scope lowering. Treating these paths as one capability could produce non-legalizable `vcumsum` scopes and inaccurate hybrid-stage costs.

### Solution and Changes

1. Model cumsum capabilities per execution route and charge only the workload actually materialized in a local SIMT scope.
2. Preserve backend intrinsic routing when an all-SIMD cost result would override a proven path, and use a typed error to fall back only for unsupported valid TTIR.
3. Classify unsplittable hybrid stages by their dominant structure, include dot work on the serial critical path, and multiply nested-loop trip counts safely.

### Tests

Add C++ coverage for cumsum capabilities, intrinsic-route preservation, fallback, and hybrid classification, plus a dedicated cumsum pytest for numerical correctness, stage classification, and route legality.

### Impact

Scan is no longer placed in unsupported local scopes, mixed costs match the materialized scope, unsupported inputs fall back safely, and nested/hybrid workloads are modeled more accurately.