### PR TITLE
[compiler](feat) add hivm batch matmul compile option

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -745,6 +745,9 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
             if (_needs_lib_call_no_inline(metadata)
                     and _npu_compiler_supports_option(npu_compiler_path, "--enable-lib-call-no-inline")):
                 _compile_option_list += ["--enable-lib-call-no-inline=false"]
+            # Temporary until the NPU compiler enables batch matmul by default in Q4.
+            if metadata.get("enable_hivm_batch_matmul"):
+                _compile_option_list += ["--enable-hivm-batch-matmul"]
         bisheng_options = metadata["bisheng_options"]
         if bisheng_options is not None:
             _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
@@ -1091,6 +1094,8 @@ class NPUOptions:
     enable_auto_bind_sub_block: bool = None
     disable_tightly_coupled_buffer_reuse: bool = False
     enable_hivm_auto_cv_balance: bool = None
+    # Temporary 910_95 switch; the NPU compiler plans to make this default in Q4.
+    enable_hivm_batch_matmul: bool = False
     sync_solver: bool = None
     unit_flag: bool = None
     enable_flatten: bool = None


### PR DESCRIPTION
Forward enable_hivm_batch_matmul on the 910_95 bishengir path so kernels can opt into --enable-hivm-batch-matmul until the NPU compiler turns it on by default.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
