### PR TITLE
[ssbuffer](feat) move sync after small block

### DIFF
--- a/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
+++ b/third_party/ascend/include/DynamicCVPipeline/Common/Utils.h
@@ -138,6 +138,8 @@ bool isOnlyDirectlyUse(Operation *preOp, Operation *nextOp,
 bool isSyncOp(Operation *op);
 bool isExternalSyncOp(Operation *op);
 
+void setSubBlockId(Operation *op, int subBlockId);
+
 // Wrapper around a "main loop" — either scf.for or scf.while carrying the
 // ssbuffer.main_loop attribute. Lets downstream code treat both uniformly.
 class MainLoop {

--- a/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
+++ b/third_party/ascend/include/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.h
@@ -127,7 +127,8 @@ private:
 
   std::pair<mlir::Operation *, mlir::Operation *>
   getBlockStartEnd(int blockId, mlir::ModuleOp module);
-  mlir::Operation *getSubBlockEnd(mlir::Operation *defOp);
+  std::pair<mlir::Operation *, mlir::Operation *>
+  getSubBlockStartEnd(mlir::Operation *defOp);
   bool
   isOuterLayerDependency(size_t depIndex, mlir::Operation *currProdEnd,
                          mlir::Operation *currConsStart,

--- a/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/Common/Utils.cpp
@@ -143,6 +143,11 @@ bool isExternalSyncOp(Operation *op) {
          op->getAttrOfType<IntegerAttr>(CVPipeline::kExternalSync);
 }
 
+void setSubBlockId(Operation *op, int subBlockId) {
+  OpBuilder builder(op->getContext());
+  op->setAttr(CVPipeline::kSubBlock, builder.getI32IntegerAttr(subBlockId));
+}
+
 bool isScfOp(Operation *op) {
   return llvm::isa<scf::SCFDialect>(op->getDialect());
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeComputeBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeComputeBlockPass.cpp
@@ -307,9 +307,7 @@ static void markSubBlock(const DenseMap<int, ComputeBlock> &computeBlocks,
       continue;
     for (Operation *op : it->second.ops) {
       int curId = CVPipeline::getOpBlockId(op).value_or(id);
-      op->setAttr(
-          CVPipeline::kSubBlock,
-          IntegerAttr::get(IntegerType::get(op->getContext(), 32), curId));
+      CVPipeline::setSubBlockId(op, curId);
     }
   }
 }

--- a/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSmallBlockPass.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/ComputeBlockOpt/MergeSmallBlockPass.cpp
@@ -720,6 +720,50 @@ static void getBlockIdsInProgramOrder(Block *block,
   }
 }
 
+/// Match the pattern inside a small VECTOR block:
+///   %m = arith.sitofp %mask
+///   %b = arith.subf %_, %m
+///   %r = arith.mulf %b, %_
+/// When matched, tag every op in the source block and the target block with
+/// its original block id via kSubBlock, before updateBlockId rewrites the
+/// block_id attribute.
+static void
+markSubBlockIfMaskApplyPattern(llvm::ArrayRef<Operation *> ops, int nowBlockId,
+                               int targetBlockId,
+                               CVPipeline::ComputeBlockIdManager &bm) {
+  arith::SIToFPOp sitofpOp;
+  arith::SubFOp subfOp;
+  arith::MulFOp mulfOp;
+  for (Operation *op : ops) {
+    if (auto sitofp = dyn_cast<arith::SIToFPOp>(op)) {
+      sitofpOp = sitofp;
+    } else if (auto subf = dyn_cast<arith::SubFOp>(op)) {
+      subfOp = subf;
+    } else if (auto mulf = dyn_cast<arith::MulFOp>(op)) {
+      mulfOp = mulf;
+    }
+  }
+  if (!sitofpOp || !subfOp || !mulfOp) {
+    return;
+  }
+  Value sitofpResult = sitofpOp.getResult();
+  if (subfOp.getLhs() != sitofpResult && subfOp.getRhs() != sitofpResult) {
+    return;
+  }
+  Value subfResult = subfOp.getResult();
+  if (mulfOp.getLhs() != subfResult && mulfOp.getRhs() != subfResult) {
+    return;
+  }
+
+  auto markBlockOps = [&](int blockId) {
+    for (Operation *op : bm.getOpsByBlockId(blockId)) {
+      CVPipeline::setSubBlockId(op, blockId);
+    }
+  };
+  markBlockOps(nowBlockId);
+  markBlockOps(targetBlockId);
+}
+
 void MergeSmallBlockPass::runOnOperation() {
   ModuleOp module = getOperation();
 
@@ -777,6 +821,8 @@ void MergeSmallBlockPass::runOnOperation() {
                                              memGraph, id2order, nowBlockId);
 
       if (targetBlockId.has_value()) {
+        markSubBlockIfMaskApplyPattern(ops, nowBlockId, targetBlockId.value(),
+                                       bm);
         LOG_DEBUG("Merging block " << nowBlockId << " into block "
                                    << targetBlockId.value());
         for (Operation *op : ops) {

--- a/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable/PreCheckDisablePreload.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/PreCheckAvailable/PreCheckDisablePreload.cpp
@@ -39,7 +39,6 @@ using namespace triton;
 static const llvm::SmallVector<llvm::StringRef> kBlacklistFuncNames = {
     "_attn_fwd",
     "kernel_sdpa_fwd",
-    "kernel_sdpa_bwd_q",
     "_swa_paged_decode_kernel",
     "_mqa_logits_kernel",
     "chunk_fwd_kernel_h",

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -145,13 +145,6 @@ static std::optional<int> getSubBlockId(Operation *op) {
   return attr.getInt();
 }
 
-/// Set the sub-block tag of \p op to \p subBlockId.
-static void setSubBlockId(Operation *op, int subBlockId) {
-  MLIRContext *ctx = op->getContext();
-  op->setAttr(CVPipeline::kSubBlock,
-              IntegerAttr::get(IntegerType::get(ctx, 32), subBlockId));
-}
-
 static bool isChannelSplitNeeded(RankedTensorType tensorType) {
   static constexpr int32_t alignM = 16;
   return mlir::utils::getNumPerBlock(tensorType) == alignM / 2;
@@ -759,7 +752,7 @@ Operation *InterCoreTransferAndSyncPass::insertVectorToCubeTransfer(
     // Propagate the sub-block tag from the src defining op to the copy op.
     if (Operation *srcDefOp = srcValue.getDefiningOp()) {
       if (auto subBlockId = getSubBlockId(srcDefOp)) {
-        setSubBlockId(copyOp, *subBlockId);
+        CVPipeline::setSubBlockId(copyOp, *subBlockId);
       }
     }
     LOG_DEBUG("[copyOp]: " << *copyOp << "\n");
@@ -1028,7 +1021,7 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
                      transferIndex);
   // Propagate the sub-block tag from transferOp to the sync ops.
   if (auto subBlockId = getSubBlockId(transferOp)) {
-    setSubBlockId(setOpForRead, *subBlockId);
+    CVPipeline::setSubBlockId(setOpForRead, *subBlockId);
   }
 
   builder.setInsertionPoint(consumerStartOp);
@@ -1068,7 +1061,7 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
                        transferIndex);
 
     if (auto subBlockId = getSubBlockId(transferOp)) {
-      setSubBlockId(waitOpForWrite, *subBlockId);
+      CVPipeline::setSubBlockId(waitOpForWrite, *subBlockId);
     }
 
     attachAnalyzeFlagIdTag(setOpForRead);

--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -242,31 +242,39 @@ InterCoreTransferAndSyncPass::getBlockStartEnd(int targetId,
   return {start, end};
 }
 
-mlir::Operation *
-InterCoreTransferAndSyncPass::getSubBlockEnd(mlir::Operation *defOp) {
+std::pair<mlir::Operation *, mlir::Operation *>
+InterCoreTransferAndSyncPass::getSubBlockStartEnd(mlir::Operation *defOp) {
   if (!defOp) {
-    return nullptr;
+    return {nullptr, nullptr};
   }
-  auto subBlockId = getSubBlockId(defOp);
-  if (!subBlockId) {
-    return nullptr;
+  auto targetSubBlockId = getSubBlockId(defOp);
+  if (!targetSubBlockId) {
+    return {nullptr, nullptr};
   }
   if (!defOp->getBlock()) {
-    return nullptr;
+    return {nullptr, nullptr};
   }
+  mlir::Operation *subBlockStart = nullptr;
   mlir::Operation *subBlockEnd = nullptr;
   for (Operation &op : *defOp->getBlock()) {
     auto opSubBlockId = getSubBlockId(&op);
     if (!opSubBlockId) {
       continue;
     }
-    if (*opSubBlockId == *subBlockId) {
-      subBlockEnd = &op;
-    } else if (subBlockEnd) {
-      break;
+    if (!subBlockStart) {
+      if (*opSubBlockId == *targetSubBlockId) {
+        subBlockStart = &op;
+        subBlockEnd = &op;
+      }
+    } else {
+      if (*opSubBlockId == *targetSubBlockId) {
+        subBlockEnd = &op;
+      } else {
+        break;
+      }
     }
   }
-  return subBlockEnd;
+  return {subBlockStart, subBlockEnd};
 }
 
 bool InterCoreTransferAndSyncPass::isOuterLayerDependency(
@@ -872,6 +880,11 @@ Operation *InterCoreTransferAndSyncPass::insertCubeToVectorTransfer(
                       CVPipeline::crossCoreConsumerId, builder);
   attachTransferTags(toTensorOp, vecBlockId, CVPipeline::kCoreTypeVector,
                      transferIndex);
+  // Propagate the sub-block tag from vectorStartOp to the vector-side ops.
+  if (auto subBlockId = getSubBlockId(vectorStartOp)) {
+    CVPipeline::setSubBlockId(memspaceCastOp, *subBlockId);
+    CVPipeline::setSubBlockId(toTensorOp, *subBlockId);
+  }
   LOG_DEBUG("[toTensorOp]: " << *toTensorOp << "\n");
 
   if (dep.isAllTranspoesd) {
@@ -1029,6 +1042,9 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
       loc, config.dstCoreAttr, config.forReadTPipe, config.forReadPipe, flagId);
   attachTransferTags(waitOpForRead, consumerBlockId, config.dstCoreType,
                      transferIndex);
+  if (auto subBlockId = getSubBlockId(consumerStartOp)) {
+    CVPipeline::setSubBlockId(waitOpForRead, *subBlockId);
+  }
 
   if (mainLoopOp) {
     builder.setInsertionPoint(transferOp);
@@ -1062,6 +1078,9 @@ void InterCoreTransferAndSyncPass::insertInterCoreSync(
 
     if (auto subBlockId = getSubBlockId(transferOp)) {
       CVPipeline::setSubBlockId(waitOpForWrite, *subBlockId);
+    }
+    if (auto subBlockId = getSubBlockId(consumerEndOp)) {
+      CVPipeline::setSubBlockId(setOpForWrite, *subBlockId);
     }
 
     attachAnalyzeFlagIdTag(setOpForRead);
@@ -1585,7 +1604,7 @@ LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(
     consumerPoint =
         analyzeConsumerReadInsertPoint(srcValue, dep.iniConsumerBlockId);
     if (consumerPoint && getSubBlockId(consumerPoint)) {
-      consStart = consumerPoint;
+      consStart = getSubBlockStartEnd(consumerPoint).first;
     }
   }
 
@@ -1598,7 +1617,7 @@ LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(
       getBlockStartEnd(dep.producerBlockId, module); // C Block
   auto [newConsStart, newConsEnd] =
       getBlockStartEnd(dep.consumerBlockId, module); // V Block
-  if (Operation *subBlockEnd = getSubBlockEnd(consumerPoint)) {
+  if (Operation *subBlockEnd = getSubBlockStartEnd(consumerPoint).second) {
     newConsEnd = subBlockEnd;
   }
   int flagId = flagManager.acquireId();
@@ -1609,7 +1628,8 @@ LogicalResult InterCoreTransferAndSyncPass::handleCubeToVector(
   if (dep.consumerBlockId == dep.iniConsumerBlockId) {
     auto newconsumerPoint = getConsumerWaitPoint(transferIndex);
     if (newconsumerPoint && getSubBlockId(consumerPoint)) {
-      newConsStart = newconsumerPoint;
+      // insert the wait for read at the sub-block start
+      newConsStart = getSubBlockStartEnd(consumerPoint).first;
     }
   }
 


### PR DESCRIPTION
在 MergeSmallBlockPass 中新增 markSubBlockIfMaskApplyPattern ：当被合并的小 VECTOR 块匹配 mask-apply 模式（ sitofp → subf → mulf ）时，在 updateBlockId 改写 block_id 之前，为源块与目标块内的所有 op 打上原始 block_id 的 kSubBlock 标记，以保留子块归属信息。后续在插入核间同步时，会插在subBlock的开始和结束。
将 getSubBlockEnd 扩展为 getSubBlockStartEnd ，同时返回子块的起止位置。
调整 cube→vector 跨核同步的插入点： waitOpForRead 由实际使用点移动到子块起始处，使读等待同步更早就位。
从黑名单中移除 kernel_sdpa_bwd_q。

- Add markSubBlockIfMaskApplyPattern in MergeSmallBlockPass : when a merged small VECTOR block matches the mask-apply pattern ( sitofp → subf → mulf ), tag every op in both the source and target blocks with the original block_id as kSubBlock before updateBlockId rewrites the block_id, preserving sub-block ownership.
- Extend getSubBlockEnd into getSubBlockStartEnd , returning both the start and end of a sub-block.
- Adjust cube→vector inter-core sync insertion: move waitOpForRead from consumerPoint to the sub-block start, so the read-wait sync is placed earlier.
- Remove kernel_sdpa_bwd_q from the preload-disable blacklist.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
