### PR TITLE
[ssbuffer](fix) fixpipe nz2nz not set intraDepsGroupId out of mainLoop

### DIFF
--- a/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
+++ b/third_party/ascend/lib/DynamicCVPipeline/SplitDataflow/InterCoreTransferAndSync.cpp
@@ -1703,6 +1703,7 @@ InterCoreTransferAndSyncPass::handleCubeToCube(OpBuilder &builder,
   // Allocate a single shared L1 buffer for producer and consumer.
   auto *allocOp = createC2CSharedL1Buffer(builder, loc, shape, elemType,
                                           prodBlockId, prodEnd, consStart);
+  auto *mainLoopOp = findMainLoopforTransfer(prodEnd, consStart);
 
   // Producer side: insert fixpipe to write matmul L0C output to L1 buffer
   auto dmaModeAttr =
@@ -1722,10 +1723,13 @@ InterCoreTransferAndSyncPass::handleCubeToCube(OpBuilder &builder,
       builder.getBoolAttr(channelSplit), nullptr, nullptr, mlir::ArrayAttr{},
       nullptr);
   attachCommonTags(fixpipeOp, prodBlockId, CVPipeline::kCoreTypeCube);
-  // Tag C2C fixpipe as kIntraDeps producer.
-  fixpipeOp->setAttr(CVPipeline::kIntraDeps,
-                     builder.getI32ArrayAttr(
-                         {intraDepsGroupId, CVPipeline::crossCoreProducerId}));
+  // Tag C2C fixpipe as kIntraDeps producer (only within a main loop).
+  if (mainLoopOp) {
+    fixpipeOp->setAttr(
+        CVPipeline::kIntraDeps,
+        builder.getI32ArrayAttr(
+            {intraDepsGroupId, CVPipeline::crossCoreProducerId}));
+  }
   LOG_DEBUG("[fixpipeOp C->C]: " << *fixpipeOp << "\n");
 
   // Consumer side: read L1 buffer via MemorySpaceCast + ToTensor
@@ -1737,11 +1741,13 @@ InterCoreTransferAndSyncPass::handleCubeToCube(OpBuilder &builder,
   auto toTensorOp = builder.create<bufferization::ToTensorOp>(
       loc, targetTensorType, memspaceCastOp.getResult(), true, true);
   attachCommonTags(memspaceCastOp, consBlockId, CVPipeline::kCoreTypeCube);
-  // Tag C2C memspaceCastOp as kIntraDeps consumer.
-  memspaceCastOp->setAttr(
-      CVPipeline::kIntraDeps,
-      builder.getI32ArrayAttr(
-          {intraDepsGroupId, CVPipeline::crossCoreConsumerId}));
+  // Tag C2C memspaceCastOp as kIntraDeps consumer (only within a main loop).
+  if (mainLoopOp) {
+    memspaceCastOp->setAttr(
+        CVPipeline::kIntraDeps,
+        builder.getI32ArrayAttr(
+            {intraDepsGroupId, CVPipeline::crossCoreConsumerId}));
+  }
   attachCommonTags(toTensorOp, consBlockId, CVPipeline::kCoreTypeCube);
 
   // Replace uses of transferValue within the consumer block.


### PR DESCRIPTION
Fixpipe L0C to L1 should not get attr of intraDeps when the producer and consumer are out of mainLoop.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
