### PR TITLE
[backend](revert) restore AutoBlockify policy at original sites

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -190,12 +190,11 @@ def _export_program_grid_metadata(mod, metadata, *, require_row_contract=False):
     )
 
 
-def _finalize_program_launch_policy(metadata, opt):
+def _finalize_program_launch_policy(metadata):
     required_fields = (
         "program_grid_transforms",
         "program_grid_mapping_applied",
         "row_coalescing_applied",
-        "has_auto_blockify_blacklist_op",
         "mix_mode",
     )
     missing = [name for name in required_fields if name not in metadata]
@@ -205,13 +204,10 @@ def _finalize_program_launch_policy(metadata, opt):
     raw_transforms = metadata["program_grid_transforms"]
     mapping_applied = metadata["program_grid_mapping_applied"]
     row_coalescing_applied = metadata["row_coalescing_applied"]
-    has_auto_blockify_blacklist_op = metadata["has_auto_blockify_blacklist_op"]
     if not isinstance(mapping_applied, bool):
         raise RuntimeError("program_grid_mapping_applied must be a boolean")
     if not isinstance(row_coalescing_applied, bool):
         raise RuntimeError("row_coalescing_applied must be a boolean")
-    if not isinstance(has_auto_blockify_blacklist_op, bool):
-        raise RuntimeError("has_auto_blockify_blacklist_op must be a boolean")
 
     transforms = None
     if raw_transforms is not None:
@@ -224,10 +220,6 @@ def _finalize_program_launch_policy(metadata, opt):
     if mapping_applied and row_coalescing_applied:
         raise RuntimeError("program-grid mapping conflicts with legacy RowCoalescing")
 
-    blacklist_policy_allows = bool(opt.is_pure_simt) or not has_auto_blockify_blacklist_op
-    auto_blockify_enabled = (_is_auto_map_parallel_blocks_enabled() and blacklist_policy_allows
-                             and not row_coalescing_applied and not mapping_applied)
-
     persistent_transform = get_persistent_transform(transforms) if transforms is not None else None
     ptsm_cap_authorized = False
     if persistent_transform is not None:
@@ -237,9 +229,6 @@ def _finalize_program_launch_policy(metadata, opt):
             raise RuntimeError("persistent program-grid transform lacks coverage/ABI verification")
         ptsm_cap_authorized = True
 
-    if auto_blockify_enabled and ptsm_cap_authorized:
-        raise RuntimeError("AutoBlockify and persistent-grid cap cannot both be enabled")
-    metadata["auto_blockify_enabled"] = auto_blockify_enabled
     metadata["ptsm_cap_authorized"] = ptsm_cap_authorized
 
 
@@ -703,7 +692,7 @@ def try_compile_with_config(linalg: str, ub_config: Dict[str, Any], metadata: di
 
 def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
     linalg, metadata = _parse_linalg_metadata(linalg, metadata)
-    _finalize_program_launch_policy(metadata, opt)
+    _finalize_program_launch_policy(metadata)
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_file_name = "kernel.mlir"
         ttadapter_path = os.path.join(tmpdir, tmp_file_name)
@@ -857,7 +846,7 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
                 _compile_option_list += \
                     [f"--link-aicore-bitcode={bitcode}"]
 
-        if metadata["auto_blockify_enabled"]:
+        if _is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False):
             _compile_option_list += ["--enable-auto-blockify-loop"]
         npu_compiler_path, env = _get_npucompiler_path()
         if npu_compiler_path.endswith("bishengir-compile"):
@@ -935,7 +924,7 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
 
 def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
     linalg, metadata = _parse_linalg_metadata(linalg, metadata)
-    _finalize_program_launch_policy(metadata, opt)
+    _finalize_program_launch_policy(metadata)
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_file_name = "kernel.mlir"
         ttadapter_path = os.path.join(tmpdir, tmp_file_name)
@@ -1073,7 +1062,7 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
         if enable_libdevice:
             _compile_option_list += [f"--link-aicore-bitcode={get_libdevice()}"]
 
-        if metadata["auto_blockify_enabled"]:
+        if _is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False):
             _compile_option_list += ["--enable-auto-blockify-loop"]
         npu_compiler_path, env = _get_npucompiler_path()
         if npu_compiler_path.endswith("bishengir-compile"):
@@ -1373,7 +1362,7 @@ def ttir_to_npubin(mod, metadata, opt):
     _export_program_grid_metadata(mod, metadata, require_row_contract=True)
     ttir_code = str(mod)
     metadata = _parse_ttir_metadata(ttir_code, metadata)
-    _finalize_program_launch_policy(metadata, opt)
+    _finalize_program_launch_policy(metadata)
     with tempfile.TemporaryDirectory() as tmpdir:
         # prepare input
         src_path = os.path.join(tmpdir, "kernel.ttir.mlir")
@@ -1405,7 +1394,11 @@ def ttir_to_npubin(mod, metadata, opt):
             if bisheng_options is not None:
                 _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
 
-            if metadata["auto_blockify_enabled"]:
+            # Enable SIMT auto-blockify under the fixed automatic block-mapping
+            # policy, mirroring the SIMD compile paths. driver.py's runtime
+            # block-count cap keys off the same policy, so the two stay in sync.
+            if (_is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False)
+                    and not metadata.get("row_coalescing_applied", False)):
                 _compile_option_list += ["--enable-auto-blockify-loop"]
                 if opt.superblock_factor > 1:
                     _compile_option_list += [f"--super-block-factor={opt.superblock_factor}"]

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -1033,7 +1033,7 @@ static void release_npu_tensor_handle(void* handle) {{
 
     mapping_applied = getattr(metadata, "program_grid_mapping_applied", None)
     row_coalescing_applied = getattr(metadata, "row_coalescing_applied", None)
-    ptsm_cap_authorized = getattr(metadata, "ptsm_cap_authorized", None)
+    ptsm_cap_authorized = getattr(metadata, "ptsm_cap_authorized", False)
     if not isinstance(mapping_applied, bool):
         raise RuntimeError("compiler metadata missing program_grid_mapping_applied")
     if not isinstance(row_coalescing_applied, bool):

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -32,8 +32,9 @@ import hashlib
 from triton.runtime.cache import get_cache_manager, get_dump_manager
 from triton.backends.driver import DriverBase
 from triton.backends.compiler import GPUTarget
-from triton.backends.ascend.utils import (_build_npu_ext, _check_cxx11_abi, convert_sigtype_to_int, is_ffts_supported,
-                                          force_disable_ffts, get_backend_func, get_cann_version)
+from triton.backends.ascend.utils import (_build_npu_ext, _check_cxx11_abi, convert_sigtype_to_int,
+                                          _is_auto_map_parallel_blocks_enabled, is_ffts_supported, force_disable_ffts,
+                                          get_backend_func, get_cann_version)
 from triton.backends.ascend.program_grid import (
     PROGRAM_GRID_TRANSFORMS_VERSION,
     ProgramGridContractError,
@@ -953,6 +954,12 @@ def make_launcher(constants, signature, metadata):
     enable_device_print = os.getenv("TRITON_DEVICE_PRINT", 'false').lower() in ('true', '1')
     enable_taskqueue = os.getenv("TRITON_ENABLE_TASKQUEUE", 'true').lower() in ('true', '1')
     enable_grid_warn_print = os.getenv("TRITON_GRID_WARN_PRINT", 'false').lower() in ('true', '1')
+    has_auto_blockify_blacklist_op = getattr(
+        metadata,
+        "has_auto_blockify_blacklist_op",
+        False,
+    )
+    enable_auto_map_parallel_blocks = (_is_auto_map_parallel_blocks_enabled() and not has_auto_blockify_blacklist_op)
     npu_utils = NPUUtils()
     num_physical_blocks = npu_utils.get_aivector_core_num() if mix_mode == "aiv" else npu_utils.get_aicore_num()
     task_type, mix_block_dim_ratio = _format_of_msprof_task_type_ratio(bs_task_type, mix_mode)
@@ -1026,14 +1033,11 @@ static void release_npu_tensor_handle(void* handle) {{
 
     mapping_applied = getattr(metadata, "program_grid_mapping_applied", None)
     row_coalescing_applied = getattr(metadata, "row_coalescing_applied", None)
-    auto_blockify_enabled = getattr(metadata, "auto_blockify_enabled", None)
     ptsm_cap_authorized = getattr(metadata, "ptsm_cap_authorized", None)
     if not isinstance(mapping_applied, bool):
         raise RuntimeError("compiler metadata missing program_grid_mapping_applied")
     if not isinstance(row_coalescing_applied, bool):
         raise RuntimeError("compiler metadata missing row_coalescing_applied")
-    if not isinstance(auto_blockify_enabled, bool):
-        raise RuntimeError("compiler metadata missing auto_blockify_enabled")
     if not isinstance(ptsm_cap_authorized, bool):
         raise RuntimeError("compiler metadata missing ptsm_cap_authorized")
     raw_program_grid_transforms = getattr(metadata, "program_grid_transforms", None)
@@ -1053,10 +1057,6 @@ static void release_npu_tensor_handle(void* handle) {{
                             if program_grid_transforms is not None else None)
     if program_grid_transforms is not None and row_coalescing_applied:
         raise RuntimeError("program-grid transforms conflict with legacy RowCoalescing")
-    if auto_blockify_enabled and (mapping_applied or row_coalescing_applied):
-        raise RuntimeError("auto_blockify_enabled conflicts with a rewritten program mapping")
-    if auto_blockify_enabled and ptsm_cap_authorized:
-        raise RuntimeError("auto_blockify_enabled and ptsm_cap_authorized cannot both be true")
     if persistent_transform is None:
         if ptsm_cap_authorized:
             raise RuntimeError("ptsm_cap_authorized requires a persistent transform")
@@ -1316,7 +1316,7 @@ static void release_npu_tensor_handle(void* handle) {{
         warned = true;
     }}
     #endif
-    {'blockNum = std::min(blockNum, (uint32_t)' + str(num_physical_blocks) + ');' if auto_blockify_enabled else ''}
+    {'blockNum = std::min(blockNum, (uint32_t)' + str(num_physical_blocks) + ');' if enable_auto_map_parallel_blocks else ''}
     // set mixBlockNumRation for nodeBasicBlockDim for msprof report
     uint32_t mixBlockNumRation = {mix_block_dim_ratio};
     uint32_t nodeBasicBlockDim = (mixBlockNumRation << 16) + blockNum;

--- a/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
@@ -634,7 +634,7 @@ def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
                 disable_fma=True,
             )
 
-        second_injection = env_enabled and not row_applied
+        second_injection = env_enabled and not blacklisted and not row_applied
         case = f"E={env_enabled}, B={blacklisted}, R={row_applied}, superblock={superblock}"
 
         expected_options = [*common_options, *pure_simt_prefix]

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -83,6 +83,52 @@ def test_make_launcher_exposes_triton_launch_kernel(
     _mock_ffts.assert_called_once_with("Ascend910B3")
 
 
+@pytest.mark.parametrize("persistent", [False, True])
+@patch.object(driver, "NPUUtils")
+@patch.object(driver, "force_disable_ffts", return_value=False)
+@patch.object(driver, "is_ffts_supported", return_value=True)
+@patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+def test_make_launcher_missing_ptsm_authorization(
+    _mock_backend_func_patch,
+    _mock_ffts,
+    _mock_disable_ffts,
+    mock_npu_utils,
+    persistent,
+):
+    mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
+    mock_npu_utils.return_value.get_aicore_num.return_value = 20
+    metadata = _make_metadata()
+    del metadata.ptsm_cap_authorized
+    if persistent:
+        metadata.program_grid_mapping_applied = True
+        metadata.program_grid_transforms = {
+            "version":
+            2,
+            "extent_source":
+            "runtime_original_grid",
+            "hidden_extent_axes": [0, 1],
+            "hidden_argument_order": ["originalGridX", "originalGridY"],
+            "hidden_argument_types": ["i32", "i32"],
+            "transforms": [{
+                "order": 0,
+                "kind": "ceil_div",
+                "axis": 0,
+                "factor": 64,
+                "persistent_coverage": True,
+                "grid_stride_abi_verified": True,
+            }],
+        }
+        with pytest.raises(RuntimeError, match="persistent program-grid transform lacks PTSM cap authorization"):
+            driver.make_launcher(constants={}, signature={0: "*fp32"}, metadata=metadata)
+    else:
+        src = driver.make_launcher(constants={}, signature={0: "*fp32"}, metadata=metadata)
+        c_abi_launch, cpp_launch = _split_launch_functions(src)
+        assert "void triton_launch_kernel(" in c_abi_launch
+        assert "static void _launch(" in cpp_launch
+        assert "axisCap" not in src
+        assert "originalGridX" not in src
+
+
 @patch.object(driver, "NPUUtils")
 @patch.object(driver, "force_disable_ffts", return_value=False)
 @patch.object(driver, "is_ffts_supported", return_value=True)

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -1,5 +1,6 @@
 import importlib.util
 import sys
+from itertools import product
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -45,7 +46,6 @@ def _make_metadata():
         row_coalescing_applied=False,
         program_grid_transforms=None,
         program_grid_mapping_applied=False,
-        auto_blockify_enabled=False,
         ptsm_cap_authorized=False,
     )
 
@@ -157,6 +157,7 @@ def test_make_launcher_rejects_unmatched_coalescing_metadata(
 
 
 @patch.object(driver, "NPUUtils")
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=False)
 @patch.object(driver, "force_disable_ffts", return_value=False)
 @patch.object(driver, "is_ffts_supported", return_value=True)
 @patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
@@ -164,6 +165,7 @@ def test_make_launcher_uses_ceil_div_for_row_coalescing(
     _mock_backend_func_patch,
     _mock_ffts,
     _mock_disable_ffts,
+    _mock_auto_map,
     mock_npu_utils,
 ):
     mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
@@ -223,7 +225,7 @@ def test_make_launcher_enables_91095_simt_for_sls_mixed_parallel_mode(
 @patch.object(driver, "force_disable_ffts", return_value=False)
 @patch.object(driver, "is_ffts_supported", return_value=True)
 @patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
-def test_make_launcher_block_cap_consumes_compiler_auto_blockify_policy(
+def test_make_launcher_block_cap_uses_only_env_and_blacklist(
     _mock_backend_func_patch,
     _mock_ffts,
     _mock_disable_ffts,
@@ -233,18 +235,29 @@ def test_make_launcher_block_cap_consumes_compiler_auto_blockify_policy(
     mock_npu_utils.return_value.get_aicore_num.return_value = 20
     cap = "blockNum = std::min(blockNum, (uint32_t)40);"
 
-    for auto_blockify_enabled in (False, True):
+    for env_enabled, blacklisted, row_applied in product((False, True), (False, True), (False, True)):
         metadata = _make_metadata()
-        metadata.auto_blockify_enabled = auto_blockify_enabled
-        src = driver.make_launcher(
-            constants={},
-            signature={0: "*fp32", 1: "*fp32"},
-            metadata=metadata,
-        )
-        expected_per_launch_path = 1 if auto_blockify_enabled else 0
+        metadata.row_coalescing_applied = row_applied
+        metadata.has_auto_blockify_blacklist_op = blacklisted
+        if row_applied:
+            metadata.coalesce_factor = 4
+            metadata.coalesce_axis = 1
+            metadata.coalesce_grid_ceil_div = True
+        with patch.object(
+                driver,
+                "_is_auto_map_parallel_blocks_enabled",
+                return_value=env_enabled,
+        ):
+            src = driver.make_launcher(
+                constants={},
+                signature={0: "*fp32", 1: "*fp32"},
+                metadata=metadata,
+            )
+        case = f"E={env_enabled}, B={blacklisted}, R={row_applied}"
+        expected_per_launch_path = 1 if env_enabled and not blacklisted else 0
         c_abi_launch, cpp_launch = _split_launch_functions(src)
-        assert c_abi_launch.count(cap) == expected_per_launch_path
-        assert cpp_launch.count(cap) == expected_per_launch_path
+        assert c_abi_launch.count(cap) == expected_per_launch_path, case
+        assert cpp_launch.count(cap) == expected_per_launch_path, case
 
 
 @patch.object(driver, "NPUUtils")


### PR DESCRIPTION
Resource-gated program mapping moved AutoBlockify decisions into shared metadata and changed when compilation and the launcher enable automatic block mapping. Port #2127 to `main-dev` to restore the original decisions at their original compiler-option and launcher sites.

- Both Linalg compile paths use the backend policy and blacklist; pure SIMT also checks `row_coalescing_applied` while assembling options.
- The launcher computes its block-count cap from the backend policy and blacklist, matching the original launcher behavior, including its lack of a RowCoalescing gate.
- Remove the centralized `auto_blockify_enabled` producer/consumer and its mapping/PTSM exclusion checks. Keep program-grid metadata checks, PTSM coverage/ABI validation, and the `ptsm_cap_authorized` assignment in all three compiler paths.
- Default an absent `ptsm_cap_authorized` to false when constructing the launcher, allowing ordinary kernels without that field to proceed. Persistent transforms still require explicit authorization, and non-boolean values remain invalid.

This contains the same two patches as #2127, cherry-picked onto `main-dev` at `36f6ae3734965d08c9912ac52f7684533aa1d4f6`. The combined stable patch ID matches #2127; branch-specific compiler options are preserved.

Validation: source-loaded compiler and launcher suites passed with **19 passed, 28 pre-existing skips**. The three compiler AutoBlockify blocks and their positions, plus the launcher decision block and cap emission, match the original pre-67bdc021 source. Pre-commit and `git diff --check` passed.

Tests mock external compilation and use the installed native extension. No wheel build or NPU runtime validation was performed; interactions between the restored AutoBlockify policy and program-grid mapping are not runtime-validated.
