### PR TITLE
[backend](revert) restore AutoBlockify compiler and launcher gates

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -842,7 +842,7 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
                 _compile_option_list += \
                     [f"--link-aicore-bitcode={bitcode}"]
 
-        if metadata["auto_blockify_enabled"]:
+        if _is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False):
             _compile_option_list += ["--enable-auto-blockify-loop"]
         npu_compiler_path, env = _get_npucompiler_path()
         if npu_compiler_path.endswith("bishengir-compile"):
@@ -1055,7 +1055,7 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
         if enable_libdevice:
             _compile_option_list += [f"--link-aicore-bitcode={get_libdevice()}"]
 
-        if metadata["auto_blockify_enabled"]:
+        if _is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False):
             _compile_option_list += ["--enable-auto-blockify-loop"]
         npu_compiler_path, env = _get_npucompiler_path()
         if npu_compiler_path.endswith("bishengir-compile"):
@@ -1384,7 +1384,8 @@ def ttir_to_npubin(mod, metadata, opt):
             if bisheng_options is not None:
                 _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
 
-            if metadata["auto_blockify_enabled"]:
+            if (_is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False)
+                    and not metadata.get("row_coalescing_applied", False)):
                 _compile_option_list += ["--enable-auto-blockify-loop"]
                 if opt.superblock_factor > 1:
                     _compile_option_list += [f"--super-block-factor={opt.superblock_factor}"]

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -32,8 +32,9 @@ import hashlib
 from triton.runtime.cache import get_cache_manager, get_dump_manager
 from triton.backends.driver import DriverBase
 from triton.backends.compiler import GPUTarget
-from triton.backends.ascend.utils import (_build_npu_ext, _check_cxx11_abi, convert_sigtype_to_int, is_ffts_supported,
-                                          force_disable_ffts, get_backend_func, get_cann_version)
+from triton.backends.ascend.utils import (_build_npu_ext, _check_cxx11_abi, convert_sigtype_to_int,
+                                          _is_auto_map_parallel_blocks_enabled, is_ffts_supported, force_disable_ffts,
+                                          get_backend_func, get_cann_version)
 from triton.backends.ascend.program_grid import (
     PROGRAM_GRID_TRANSFORMS_VERSION,
     ProgramGridContractError,
@@ -953,6 +954,12 @@ def make_launcher(constants, signature, metadata):
     enable_device_print = os.getenv("TRITON_DEVICE_PRINT", 'false').lower() in ('true', '1')
     enable_taskqueue = os.getenv("TRITON_ENABLE_TASKQUEUE", 'true').lower() in ('true', '1')
     enable_grid_warn_print = os.getenv("TRITON_GRID_WARN_PRINT", 'false').lower() in ('true', '1')
+    has_auto_blockify_blacklist_op = getattr(
+        metadata,
+        "has_auto_blockify_blacklist_op",
+        False,
+    )
+    enable_auto_map_parallel_blocks = (_is_auto_map_parallel_blocks_enabled() and not has_auto_blockify_blacklist_op)
     npu_utils = NPUUtils()
     num_physical_blocks = npu_utils.get_aivector_core_num() if mix_mode == "aiv" else npu_utils.get_aicore_num()
     task_type, mix_block_dim_ratio = _format_of_msprof_task_type_ratio(bs_task_type, mix_mode)
@@ -1316,7 +1323,7 @@ static void release_npu_tensor_handle(void* handle) {{
         warned = true;
     }}
     #endif
-    {'blockNum = std::min(blockNum, (uint32_t)' + str(num_physical_blocks) + ');' if auto_blockify_enabled else ''}
+    {'blockNum = std::min(blockNum, (uint32_t)' + str(num_physical_blocks) + ');' if enable_auto_map_parallel_blocks else ''}
     // set mixBlockNumRation for nodeBasicBlockDim for msprof report
     uint32_t mixBlockNumRation = {mix_block_dim_ratio};
     uint32_t nodeBasicBlockDim = (mixBlockNumRation << 16) + blockNum;

--- a/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
@@ -596,7 +596,7 @@ def test_make_ttir_forwards_normalized_graph_ub_budget(compiler_module, monkeypa
 
 
 def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
-    """Keep the internal-policy-and-safety pure-SIMT auto-blockify argv contract."""
+    """Check the pure-SIMT policy, blacklist, and RowCoalescing argv gates."""
     common_options = ["--common-before-pure-simt", "--common-after-pure-simt"]
     pure_simt_prefix = [
         "--enable-hivm-compile=false",
@@ -634,7 +634,7 @@ def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
                 disable_fma=True,
             )
 
-        second_injection = env_enabled and not row_applied
+        second_injection = env_enabled and not blacklisted and not row_applied
         case = f"E={env_enabled}, B={blacklisted}, R={row_applied}, superblock={superblock}"
 
         expected_options = [*common_options, *pure_simt_prefix]
@@ -643,7 +643,7 @@ def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
             if superblock > 0:
                 expected_options.append(f"--super-block-factor={superblock}")
 
-        # The compiler and launcher now agree on the single policy/safety gate.
+        # Pure-SIMT option emission retains the blacklist and RowCoalescing gates.
         assert command[0] == "/fake/bisheng", case
         assert Path(command[1]).name == "kernel.ttir.mlir", case
         assert command[2:-2] == expected_options, case

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -160,7 +160,9 @@ def test_make_launcher_rejects_unmatched_coalescing_metadata(
 @patch.object(driver, "force_disable_ffts", return_value=False)
 @patch.object(driver, "is_ffts_supported", return_value=True)
 @patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=True)
 def test_make_launcher_uses_ceil_div_for_row_coalescing(
+    _mock_auto_map,
     _mock_backend_func_patch,
     _mock_ffts,
     _mock_disable_ffts,
@@ -182,7 +184,7 @@ def test_make_launcher_uses_ceil_div_for_row_coalescing(
 
     assert src.count("gridZ = (gridZ + 4 - 1) / 4;") == 2
     assert "ChunkCoalescing: grid[2] not divisible" not in src
-    assert "blockNum = std::min(blockNum" not in src
+    assert src.count("blockNum = std::min(blockNum, (uint32_t)40);") == 2
 
 
 @patch.object(driver, "NPUUtils")
@@ -219,29 +221,45 @@ def test_make_launcher_enables_91095_simt_for_sls_mixed_parallel_mode(
     assert "sizeof(args)" in cpp_launch
 
 
+@pytest.mark.parametrize(
+    ("auto_map_enabled", "blacklisted", "expect_cap"),
+    (
+        (False, False, False),
+        (False, True, False),
+        (True, False, True),
+        (True, True, False),
+    ),
+)
 @patch.object(driver, "NPUUtils")
 @patch.object(driver, "force_disable_ffts", return_value=False)
 @patch.object(driver, "is_ffts_supported", return_value=True)
 @patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
-def test_make_launcher_block_cap_consumes_compiler_auto_blockify_policy(
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled")
+def test_make_launcher_block_cap_uses_backend_policy_and_blacklist(
+    mock_auto_map,
     _mock_backend_func_patch,
     _mock_ffts,
     _mock_disable_ffts,
     mock_npu_utils,
+    auto_map_enabled,
+    blacklisted,
+    expect_cap,
 ):
+    mock_auto_map.return_value = auto_map_enabled
     mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
     mock_npu_utils.return_value.get_aicore_num.return_value = 20
     cap = "blockNum = std::min(blockNum, (uint32_t)40);"
 
     for auto_blockify_enabled in (False, True):
         metadata = _make_metadata()
+        metadata.has_auto_blockify_blacklist_op = blacklisted
         metadata.auto_blockify_enabled = auto_blockify_enabled
         src = driver.make_launcher(
             constants={},
             signature={0: "*fp32", 1: "*fp32"},
             metadata=metadata,
         )
-        expected_per_launch_path = 1 if auto_blockify_enabled else 0
+        expected_per_launch_path = 1 if expect_cap else 0
         c_abi_launch, cpp_launch = _split_launch_functions(src)
         assert c_abi_launch.count(cap) == expected_per_launch_path
         assert cpp_launch.count(cap) == expected_per_launch_path


### PR DESCRIPTION
Restore the original AutoBlockify compiler-option conditions and launcher block-count cap. In the supplied cumsum regression, the good and bad kernels have byte-identical TTIR, TTAdapter, BCMLIR, and npubin, but the bad launcher omits the original `min(blockNum, 56)` cap. RowCoalescing makes centralized `auto_blockify_enabled=False`, so restoring the compiler flags alone does not restore the launch behavior.

- Restore the three `--enable-auto-blockify-loop` conditions at their original option-assembly sites: backend policy plus blacklist for Linalg, with the existing RowCoalescing gate for pure SIMT.
- Restore the launcher policy/blacklist decision at its original site and use it for block-count capping, including after RowCoalescing as in the original revision.
- Preserve `_finalize_program_launch_policy(metadata, opt)` and existing metadata production, checks, and defaults, including `ptsm_cap_authorized`.
- Update the three regression-test expectations to match the restored policy. Keep all 32 compiler argv combinations, check RowCoalescing ceil-div and capping, and cover all four backend-policy/blacklist combinations with either centralized metadata value in both launch APIs.

Validation: the two source-loaded Python suites pass on this branch (**20 passed, 28 existing skips**), and pre-commit and `git diff --check` pass. The latest commit changes only the two test files. Prior artifact validation showed that restoring the launcher adds exactly the block-count cap in both launch APIs for the supplied bad metadata; the historical compiler argv and launcher policy matrices also passed.

Local validation uses source-loaded modules and mocked compiler/backend interactions. No local wheel build or NPU correctness/performance rerun was performed; the supplied artifacts do not quantify recovered performance.

Base: `main` at `3841a37338b7e342f2a88d95818c81274c947040`. Supersedes #2127.
