### PR TITLE
[backend](fix) gate AutoBlockify and launcher cap on PTSM

### DIFF
--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -858,7 +858,7 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
                 _compile_option_list += \
                     [f"--link-aicore-bitcode={bitcode}"]
 
-        if _is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False):
+        if metadata["auto_blockify_enabled"]:
             _compile_option_list += ["--enable-auto-blockify-loop"]
         npu_compiler_path, env = _get_npucompiler_path()
         if npu_compiler_path.endswith("bishengir-compile"):
@@ -1074,7 +1074,7 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
         if enable_libdevice:
             _compile_option_list += [f"--link-aicore-bitcode={get_libdevice()}"]
 
-        if _is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False):
+        if metadata["auto_blockify_enabled"]:
             _compile_option_list += ["--enable-auto-blockify-loop"]
         npu_compiler_path, env = _get_npucompiler_path()
         if npu_compiler_path.endswith("bishengir-compile"):
@@ -1406,8 +1406,7 @@ def ttir_to_npubin(mod, metadata, opt):
             if bisheng_options is not None:
                 _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
 
-            if (_is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False)
-                    and not metadata.get("row_coalescing_applied", False)):
+            if metadata["auto_blockify_enabled"]:
                 _compile_option_list += ["--enable-auto-blockify-loop"]
                 if opt.superblock_factor > 1:
                     _compile_option_list += [f"--super-block-factor={opt.superblock_factor}"]

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -224,10 +224,6 @@ def _finalize_program_launch_policy(metadata, opt):
     if mapping_applied and row_coalescing_applied:
         raise RuntimeError("program-grid mapping conflicts with legacy RowCoalescing")
 
-    blacklist_policy_allows = bool(opt.is_pure_simt) or not has_auto_blockify_blacklist_op
-    auto_blockify_enabled = (_is_auto_map_parallel_blocks_enabled() and blacklist_policy_allows
-                             and not row_coalescing_applied and not mapping_applied)
-
     persistent_transform = get_persistent_transform(transforms) if transforms is not None else None
     ptsm_cap_authorized = False
     if persistent_transform is not None:
@@ -237,8 +233,16 @@ def _finalize_program_launch_policy(metadata, opt):
             raise RuntimeError("persistent program-grid transform lacks coverage/ABI verification")
         ptsm_cap_authorized = True
 
+    if opt.is_pure_simt:
+        auto_blockify_enabled = (_is_auto_map_parallel_blocks_enabled() and not has_auto_blockify_blacklist_op
+                                 and not row_coalescing_applied)
+    else:
+        auto_blockify_enabled = (_is_auto_map_parallel_blocks_enabled() and not has_auto_blockify_blacklist_op
+                                 and not ptsm_cap_authorized)
+
     if auto_blockify_enabled and ptsm_cap_authorized:
         raise RuntimeError("AutoBlockify and persistent-grid cap cannot both be enabled")
+
     metadata["auto_blockify_enabled"] = auto_blockify_enabled
     metadata["ptsm_cap_authorized"] = ptsm_cap_authorized
 
@@ -1406,7 +1410,8 @@ def ttir_to_npubin(mod, metadata, opt):
             if bisheng_options is not None:
                 _compile_option_list += [f"--append-bisheng-options={bisheng_options}"]
 
-            if metadata["auto_blockify_enabled"]:
+            if (_is_auto_map_parallel_blocks_enabled() and not metadata.get("has_auto_blockify_blacklist_op", False)
+                    and not metadata.get("row_coalescing_applied", False)):
                 _compile_option_list += ["--enable-auto-blockify-loop"]
                 if opt.superblock_factor > 1:
                     _compile_option_list += [f"--super-block-factor={opt.superblock_factor}"]

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -32,9 +32,8 @@ import hashlib
 from triton.runtime.cache import get_cache_manager, get_dump_manager
 from triton.backends.driver import DriverBase
 from triton.backends.compiler import GPUTarget
-from triton.backends.ascend.utils import (_build_npu_ext, _check_cxx11_abi, convert_sigtype_to_int,
-                                          _is_auto_map_parallel_blocks_enabled, is_ffts_supported, force_disable_ffts,
-                                          get_backend_func, get_cann_version)
+from triton.backends.ascend.utils import (_build_npu_ext, _check_cxx11_abi, convert_sigtype_to_int, is_ffts_supported,
+                                          force_disable_ffts, get_backend_func, get_cann_version)
 from triton.backends.ascend.program_grid import (
     PROGRAM_GRID_TRANSFORMS_VERSION,
     ProgramGridContractError,
@@ -954,12 +953,6 @@ def make_launcher(constants, signature, metadata):
     enable_device_print = os.getenv("TRITON_DEVICE_PRINT", 'false').lower() in ('true', '1')
     enable_taskqueue = os.getenv("TRITON_ENABLE_TASKQUEUE", 'true').lower() in ('true', '1')
     enable_grid_warn_print = os.getenv("TRITON_GRID_WARN_PRINT", 'false').lower() in ('true', '1')
-    has_auto_blockify_blacklist_op = getattr(
-        metadata,
-        "has_auto_blockify_blacklist_op",
-        False,
-    )
-    enable_auto_map_parallel_blocks = (_is_auto_map_parallel_blocks_enabled() and not has_auto_blockify_blacklist_op)
     npu_utils = NPUUtils()
     num_physical_blocks = npu_utils.get_aivector_core_num() if mix_mode == "aiv" else npu_utils.get_aicore_num()
     task_type, mix_block_dim_ratio = _format_of_msprof_task_type_ratio(bs_task_type, mix_mode)
@@ -1323,7 +1316,7 @@ static void release_npu_tensor_handle(void* handle) {{
         warned = true;
     }}
     #endif
-    {'blockNum = std::min(blockNum, (uint32_t)' + str(num_physical_blocks) + ');' if enable_auto_map_parallel_blocks else ''}
+    {'blockNum = std::min(blockNum, (uint32_t)' + str(num_physical_blocks) + ');' if auto_blockify_enabled else ''}
     // set mixBlockNumRation for nodeBasicBlockDim for msprof report
     uint32_t mixBlockNumRation = {mix_block_dim_ratio};
     uint32_t nodeBasicBlockDim = (mixBlockNumRation << 16) + blockNum;

--- a/third_party/ascend/backend/driver.py
+++ b/third_party/ascend/backend/driver.py
@@ -32,8 +32,9 @@ import hashlib
 from triton.runtime.cache import get_cache_manager, get_dump_manager
 from triton.backends.driver import DriverBase
 from triton.backends.compiler import GPUTarget
-from triton.backends.ascend.utils import (_build_npu_ext, _check_cxx11_abi, convert_sigtype_to_int, is_ffts_supported,
-                                          force_disable_ffts, get_backend_func, get_cann_version)
+from triton.backends.ascend.utils import (_build_npu_ext, _check_cxx11_abi, convert_sigtype_to_int,
+                                          _is_auto_map_parallel_blocks_enabled, is_ffts_supported, force_disable_ffts,
+                                          get_backend_func, get_cann_version)
 from triton.backends.ascend.program_grid import (
     PROGRAM_GRID_TRANSFORMS_VERSION,
     ProgramGridContractError,
@@ -953,6 +954,12 @@ def make_launcher(constants, signature, metadata):
     enable_device_print = os.getenv("TRITON_DEVICE_PRINT", 'false').lower() in ('true', '1')
     enable_taskqueue = os.getenv("TRITON_ENABLE_TASKQUEUE", 'true').lower() in ('true', '1')
     enable_grid_warn_print = os.getenv("TRITON_GRID_WARN_PRINT", 'false').lower() in ('true', '1')
+    has_auto_blockify_blacklist_op = getattr(
+        metadata,
+        "has_auto_blockify_blacklist_op",
+        False,
+    )
+    enable_auto_map_parallel_blocks = (_is_auto_map_parallel_blocks_enabled() and not has_auto_blockify_blacklist_op)
     npu_utils = NPUUtils()
     num_physical_blocks = npu_utils.get_aivector_core_num() if mix_mode == "aiv" else npu_utils.get_aicore_num()
     task_type, mix_block_dim_ratio = _format_of_msprof_task_type_ratio(bs_task_type, mix_mode)
@@ -1053,8 +1060,6 @@ static void release_npu_tensor_handle(void* handle) {{
                             if program_grid_transforms is not None else None)
     if program_grid_transforms is not None and row_coalescing_applied:
         raise RuntimeError("program-grid transforms conflict with legacy RowCoalescing")
-    if auto_blockify_enabled and (mapping_applied or row_coalescing_applied):
-        raise RuntimeError("auto_blockify_enabled conflicts with a rewritten program mapping")
     if auto_blockify_enabled and ptsm_cap_authorized:
         raise RuntimeError("auto_blockify_enabled and ptsm_cap_authorized cannot both be true")
     if persistent_transform is None:
@@ -1064,6 +1069,8 @@ static void release_npu_tensor_handle(void* handle) {{
         raise RuntimeError("persistent program-grid transform lacks PTSM cap authorization")
     elif mix_mode != "aiv":
         raise RuntimeError("persistent program-grid transform requires final mix_mode=aiv")
+
+    launcher_cap_enabled = enable_auto_map_parallel_blocks and not ptsm_cap_authorized
 
     program_grid_finalization = ""
     if program_grid_transforms is not None:
@@ -1316,7 +1323,7 @@ static void release_npu_tensor_handle(void* handle) {{
         warned = true;
     }}
     #endif
-    {'blockNum = std::min(blockNum, (uint32_t)' + str(num_physical_blocks) + ');' if auto_blockify_enabled else ''}
+    {'blockNum = std::min(blockNum, (uint32_t)' + str(num_physical_blocks) + ');' if launcher_cap_enabled else ''}
     // set mixBlockNumRation for nodeBasicBlockDim for msprof report
     uint32_t mixBlockNumRation = {mix_block_dim_ratio};
     uint32_t nodeBasicBlockDim = (mixBlockNumRation << 16) + blockNum;

--- a/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Outer-scope-whileop.mlir
+++ b/third_party/ascend/unittest/Conversion/General/DynamicCVPipeline/AllocMultiCache/Outer-scope-whileop.mlir
@@ -16,11 +16,11 @@
 // polling condition computed at body start
 // CHECK: arith.remsi
 // CHECK: arith.cmpi eq
-// two mutually-exclusive transfer groups: even flag=3 / odd flag=8
+// two mutually-exclusive transfer groups: even flag=3 / odd flag=7
 // CHECK: scf.if
 // CHECK: sync_block_wait {{.*}} flag = 3
 // CHECK: } else {
-// CHECK: sync_block_wait {{.*}} flag = 8
+// CHECK: sync_block_wait {{.*}} flag = 7
 // CHECK: ssbuffer.cross_buffer
 // double-buffer selection
 // CHECK: memref.memory_space_cast
@@ -28,14 +28,14 @@
 // CHECK: memref.memory_space_cast
 // CHECK: sync_block_set {{.*}} flag = 3
 // CHECK: } else {
-// CHECK: sync_block_set {{.*}} flag = 8
+// CHECK: sync_block_set {{.*}} flag = 7
 // CHECK: ssbuffer.iterCounter
 // CHECK: ssbuffer.main_loop
 // cross-core initial signals for both flags + CUBE-side waits
 // CHECK: sync_block_set {{.*}} flag = 3
-// CHECK: sync_block_set {{.*}} flag = 8
+// CHECK: sync_block_set {{.*}} flag = 7
 // CHECK: sync_block_wait {{.*}} flag = 3
-// CHECK: sync_block_wait {{.*}} flag = 8
+// CHECK: sync_block_wait {{.*}} flag = 7
 // CUBE side: fixpipe double-buffer selection
 // CHECK: hivm.hir.fixpipe
 // CHECK: } else {
@@ -88,26 +88,26 @@ func.func @tc_while_ctov_sender() {
 
 // CHECK-LABEL: func.func @tc_while_both_sides
 // CHECK: tightly_coupled_buffer
-// VECTOR while: counter injection + two mutually-exclusive groups (flag 6/7)
+// VECTOR while: counter injection + two mutually-exclusive groups (flag 6/8)
 // CHECK: scf.while {{.*}} : (i32, i32) -> (i32, i32)
 // CHECK: arith.remsi
 // CHECK: arith.cmpi eq
 // CHECK: scf.if
 // CHECK: sync_block_wait {{.*}} flag = 6
 // CHECK: } else {
-// CHECK: sync_block_wait {{.*}} flag = 7
+// CHECK: sync_block_wait {{.*}} flag = 8
 // CHECK: ssbuffer.cross_buffer
 // CHECK: memref.memory_space_cast
 // CHECK: } else {
 // CHECK: memref.memory_space_cast
 // CHECK: sync_block_set {{.*}} flag = 6
 // CHECK: } else {
-// CHECK: sync_block_set {{.*}} flag = 7
+// CHECK: sync_block_set {{.*}} flag = 8
 // CHECK: ssbuffer.iterCounter
 // CHECK: sync_block_set {{.*}} flag = 6
-// CHECK: sync_block_set {{.*}} flag = 7
+// CHECK: sync_block_set {{.*}} flag = 8
 // CHECK: sync_block_wait {{.*}} flag = 6
-// CHECK: sync_block_wait {{.*}} flag = 7
+// CHECK: sync_block_wait {{.*}} flag = 8
 // CUBE while: same counter injection + fixpipe double-buffer selection
 // CHECK: scf.while {{.*}} : (i32, i32) -> (i32, i32)
 // CHECK: hivm.hir.fixpipe

--- a/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
@@ -313,6 +313,17 @@ def _make_opt(
     )
 
 
+def _make_program_grid_contract(*transforms):
+    return {
+        "version": 2,
+        "extent_source": "runtime_original_grid",
+        "hidden_extent_axes": [0, 1],
+        "hidden_argument_order": ["originalGridX", "originalGridY"],
+        "hidden_argument_types": ["i32", "i32"],
+        "transforms": list(transforms),
+    }
+
+
 def _run_ttir_to_npubin(
     compiler,
     monkeypatch,
@@ -607,7 +618,7 @@ def test_make_ttir_forwards_normalized_graph_ub_budget(compiler_module, monkeypa
 
 
 def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
-    """Keep the internal-policy-and-safety pure-SIMT auto-blockify argv contract."""
+    """Check the pure-SIMT policy, blacklist, and RowCoalescing argv gates."""
     common_options = ["--common-before-pure-simt", "--common-after-pure-simt"]
     pure_simt_prefix = [
         "--enable-hivm-compile=false",
@@ -645,7 +656,7 @@ def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
                 disable_fma=True,
             )
 
-        second_injection = env_enabled and not row_applied
+        second_injection = env_enabled and not blacklisted and not row_applied
         case = f"E={env_enabled}, B={blacklisted}, R={row_applied}, superblock={superblock}"
 
         expected_options = [*common_options, *pure_simt_prefix]
@@ -654,12 +665,59 @@ def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
             if superblock > 0:
                 expected_options.append(f"--super-block-factor={superblock}")
 
-        # The compiler and launcher now agree on the single policy/safety gate.
+        # Pure-SIMT option emission retains the blacklist and RowCoalescing gates.
         assert command[0] == "/fake/bisheng", case
         assert Path(command[1]).name == "kernel.ttir.mlir", case
         assert command[2:-2] == expected_options, case
         assert command[-2] == "-o", case
         assert Path(command[-1]).name == "kernel", case
+
+
+@pytest.mark.parametrize(
+    ("auto_map_enabled", "blacklisted", "row_applied", "transforms", "expected_auto", "expected_ptsm"),
+    (
+        (False, False, False, None, False, False),
+        (True, False, False, None, True, False),
+        (True, False, True, None, True, False),
+        (True, True, False, None, False, False),
+        (True, False, False, ((0, 1, 16, False, False), ), True, False),
+        (True, False, False, ((0, 0, 64, True, True), ), False, True),
+        (True, False, False, ((0, 1, 16, False, False), (1, 0, 4, True, True)), False, True),
+    ),
+)
+def test_finalize_program_launch_policy_uses_linalg_ptsm_gate(
+    compiler_module,
+    monkeypatch,
+    auto_map_enabled,
+    blacklisted,
+    row_applied,
+    transforms,
+    expected_auto,
+    expected_ptsm,
+):
+    contract = None
+    if transforms is not None:
+        contract = _make_program_grid_contract(*(dict(
+            order=order,
+            kind="ceil_div",
+            axis=axis,
+            factor=factor,
+            persistent_coverage=persistent,
+            grid_stride_abi_verified=grid_stride,
+        ) for order, axis, factor, persistent, grid_stride in transforms))
+    metadata = {
+        "program_grid_transforms": contract,
+        "program_grid_mapping_applied": contract is not None,
+        "row_coalescing_applied": row_applied,
+        "has_auto_blockify_blacklist_op": blacklisted,
+        "mix_mode": "aiv",
+    }
+    monkeypatch.setattr(compiler_module, "_is_auto_map_parallel_blocks_enabled", lambda: auto_map_enabled)
+
+    compiler_module._finalize_program_launch_policy(metadata, SimpleNamespace(is_pure_simt=False))
+
+    assert metadata["auto_blockify_enabled"] is expected_auto
+    assert metadata["ptsm_cap_authorized"] is expected_ptsm
 
 
 def test_default_compile_mode_keeps_the_91095_layout_memory_gate_prepared(compiler_module):

--- a/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
+++ b/third_party/ascend/unittest/pytest_ut/test_compiler_layout_memory_contract.py
@@ -607,7 +607,7 @@ def test_make_ttir_forwards_normalized_graph_ub_budget(compiler_module, monkeypa
 
 
 def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
-    """Check the pure-SIMT policy, blacklist, and RowCoalescing argv gates."""
+    """Keep the internal-policy-and-safety pure-SIMT auto-blockify argv contract."""
     common_options = ["--common-before-pure-simt", "--common-after-pure-simt"]
     pure_simt_prefix = [
         "--enable-hivm-compile=false",
@@ -645,7 +645,7 @@ def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
                 disable_fma=True,
             )
 
-        second_injection = env_enabled and not blacklisted and not row_applied
+        second_injection = env_enabled and not row_applied
         case = f"E={env_enabled}, B={blacklisted}, R={row_applied}, superblock={superblock}"
 
         expected_options = [*common_options, *pure_simt_prefix]
@@ -654,7 +654,7 @@ def test_ttir_to_npubin_auto_blockify_argv_matrix(compiler_module, monkeypatch):
             if superblock > 0:
                 expected_options.append(f"--super-block-factor={superblock}")
 
-        # Pure-SIMT option emission retains the blacklist and RowCoalescing gates.
+        # The compiler and launcher now agree on the single policy/safety gate.
         assert command[0] == "/fake/bisheng", case
         assert Path(command[1]).name == "kernel.ttir.mlir", case
         assert command[2:-2] == expected_options, case

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -50,6 +50,17 @@ def _make_metadata():
     )
 
 
+def _make_program_grid_contract(*transforms):
+    return {
+        "version": 2,
+        "extent_source": "runtime_original_grid",
+        "hidden_extent_axes": [0, 1],
+        "hidden_argument_order": ["originalGridX", "originalGridY"],
+        "hidden_argument_types": ["i32", "i32"],
+        "transforms": list(transforms),
+    }
+
+
 def _split_launch_functions(src):
     c_abi_part, cpp_part = src.split("static void _launch(", maxsplit=1)
     return c_abi_part, "static void _launch(" + cpp_part
@@ -160,7 +171,9 @@ def test_make_launcher_rejects_unmatched_coalescing_metadata(
 @patch.object(driver, "force_disable_ffts", return_value=False)
 @patch.object(driver, "is_ffts_supported", return_value=True)
 @patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=True)
 def test_make_launcher_uses_ceil_div_for_row_coalescing(
+    _mock_auto_map,
     _mock_backend_func_patch,
     _mock_ffts,
     _mock_disable_ffts,
@@ -182,7 +195,43 @@ def test_make_launcher_uses_ceil_div_for_row_coalescing(
 
     assert src.count("gridZ = (gridZ + 4 - 1) / 4;") == 2
     assert "ChunkCoalescing: grid[2] not divisible" not in src
-    assert "blockNum = std::min(blockNum" not in src
+    assert src.count("blockNum = std::min(blockNum, (uint32_t)40);") == 2
+
+
+@patch.object(driver, "NPUUtils")
+@patch.object(driver, "force_disable_ffts", return_value=False)
+@patch.object(driver, "is_ffts_supported", return_value=True)
+@patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=True)
+def test_make_launcher_allows_auto_blockify_with_iat_mapping(
+    _mock_auto_map,
+    _mock_backend_func_patch,
+    _mock_ffts,
+    _mock_disable_ffts,
+    mock_npu_utils,
+):
+    mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
+    mock_npu_utils.return_value.get_aicore_num.return_value = 20
+    metadata = _make_metadata()
+    metadata.program_grid_mapping_applied = True
+    metadata.auto_blockify_enabled = True
+    metadata.program_grid_transforms = _make_program_grid_contract({
+        "order": 0,
+        "kind": "ceil_div",
+        "axis": 1,
+        "factor": 16,
+        "persistent_coverage": False,
+        "grid_stride_abi_verified": False,
+    })
+
+    src = driver.make_launcher(
+        constants={},
+        signature={0: "*fp32", 1: "*fp32"},
+        metadata=metadata,
+    )
+
+    assert src.count("gridY = (uint32_t)(((uint64_t)originalGridY + 15u) / 16u);") == 2
+    assert src.count("blockNum = std::min(blockNum, (uint32_t)40);") == 2
 
 
 @patch.object(driver, "NPUUtils")
@@ -219,11 +268,57 @@ def test_make_launcher_enables_91095_simt_for_sls_mixed_parallel_mode(
     assert "sizeof(args)" in cpp_launch
 
 
+@pytest.mark.parametrize(
+    ("auto_map_enabled", "blacklisted", "expect_cap"),
+    (
+        (False, False, False),
+        (False, True, False),
+        (True, False, True),
+        (True, True, False),
+    ),
+)
 @patch.object(driver, "NPUUtils")
 @patch.object(driver, "force_disable_ffts", return_value=False)
 @patch.object(driver, "is_ffts_supported", return_value=True)
 @patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
-def test_make_launcher_block_cap_consumes_compiler_auto_blockify_policy(
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled")
+def test_make_launcher_block_cap_uses_backend_policy_and_blacklist(
+    mock_auto_map,
+    _mock_backend_func_patch,
+    _mock_ffts,
+    _mock_disable_ffts,
+    mock_npu_utils,
+    auto_map_enabled,
+    blacklisted,
+    expect_cap,
+):
+    mock_auto_map.return_value = auto_map_enabled
+    mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
+    mock_npu_utils.return_value.get_aicore_num.return_value = 20
+    cap = "blockNum = std::min(blockNum, (uint32_t)40);"
+
+    for auto_blockify_enabled in (False, True):
+        metadata = _make_metadata()
+        metadata.has_auto_blockify_blacklist_op = blacklisted
+        metadata.auto_blockify_enabled = auto_blockify_enabled
+        src = driver.make_launcher(
+            constants={},
+            signature={0: "*fp32", 1: "*fp32"},
+            metadata=metadata,
+        )
+        expected_per_launch_path = 1 if expect_cap else 0
+        c_abi_launch, cpp_launch = _split_launch_functions(src)
+        assert c_abi_launch.count(cap) == expected_per_launch_path
+        assert cpp_launch.count(cap) == expected_per_launch_path
+
+
+@patch.object(driver, "NPUUtils")
+@patch.object(driver, "force_disable_ffts", return_value=False)
+@patch.object(driver, "is_ffts_supported", return_value=True)
+@patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
+@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=True)
+def test_make_launcher_disables_block_cap_for_ptsm(
+    _mock_auto_map,
     _mock_backend_func_patch,
     _mock_ffts,
     _mock_disable_ffts,
@@ -231,20 +326,25 @@ def test_make_launcher_block_cap_consumes_compiler_auto_blockify_policy(
 ):
     mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
     mock_npu_utils.return_value.get_aicore_num.return_value = 20
-    cap = "blockNum = std::min(blockNum, (uint32_t)40);"
+    metadata = _make_metadata()
+    metadata.program_grid_mapping_applied = True
+    metadata.ptsm_cap_authorized = True
+    metadata.program_grid_transforms = _make_program_grid_contract({
+        "order": 0,
+        "kind": "ceil_div",
+        "axis": 0,
+        "factor": 64,
+        "persistent_coverage": True,
+        "grid_stride_abi_verified": True,
+    })
 
-    for auto_blockify_enabled in (False, True):
-        metadata = _make_metadata()
-        metadata.auto_blockify_enabled = auto_blockify_enabled
-        src = driver.make_launcher(
-            constants={},
-            signature={0: "*fp32", 1: "*fp32"},
-            metadata=metadata,
-        )
-        expected_per_launch_path = 1 if auto_blockify_enabled else 0
-        c_abi_launch, cpp_launch = _split_launch_functions(src)
-        assert c_abi_launch.count(cap) == expected_per_launch_path
-        assert cpp_launch.count(cap) == expected_per_launch_path
+    src = driver.make_launcher(
+        constants={},
+        signature={0: "*fp32", 1: "*fp32"},
+        metadata=metadata,
+    )
+
+    assert "blockNum = std::min(blockNum, (uint32_t)40);" not in src
 
 
 @patch.object(driver, "NPUUtils")

--- a/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
+++ b/third_party/ascend/unittest/pytest_ut/test_launcher_export_api.py
@@ -160,9 +160,7 @@ def test_make_launcher_rejects_unmatched_coalescing_metadata(
 @patch.object(driver, "force_disable_ffts", return_value=False)
 @patch.object(driver, "is_ffts_supported", return_value=True)
 @patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
-@patch.object(driver, "_is_auto_map_parallel_blocks_enabled", return_value=True)
 def test_make_launcher_uses_ceil_div_for_row_coalescing(
-    _mock_auto_map,
     _mock_backend_func_patch,
     _mock_ffts,
     _mock_disable_ffts,
@@ -184,7 +182,7 @@ def test_make_launcher_uses_ceil_div_for_row_coalescing(
 
     assert src.count("gridZ = (gridZ + 4 - 1) / 4;") == 2
     assert "ChunkCoalescing: grid[2] not divisible" not in src
-    assert src.count("blockNum = std::min(blockNum, (uint32_t)40);") == 2
+    assert "blockNum = std::min(blockNum" not in src
 
 
 @patch.object(driver, "NPUUtils")
@@ -221,45 +219,29 @@ def test_make_launcher_enables_91095_simt_for_sls_mixed_parallel_mode(
     assert "sizeof(args)" in cpp_launch
 
 
-@pytest.mark.parametrize(
-    ("auto_map_enabled", "blacklisted", "expect_cap"),
-    (
-        (False, False, False),
-        (False, True, False),
-        (True, False, True),
-        (True, True, False),
-    ),
-)
 @patch.object(driver, "NPUUtils")
 @patch.object(driver, "force_disable_ffts", return_value=False)
 @patch.object(driver, "is_ffts_supported", return_value=True)
 @patch.object(driver, "get_backend_func", side_effect=_mock_backend_func)
-@patch.object(driver, "_is_auto_map_parallel_blocks_enabled")
-def test_make_launcher_block_cap_uses_backend_policy_and_blacklist(
-    mock_auto_map,
+def test_make_launcher_block_cap_consumes_compiler_auto_blockify_policy(
     _mock_backend_func_patch,
     _mock_ffts,
     _mock_disable_ffts,
     mock_npu_utils,
-    auto_map_enabled,
-    blacklisted,
-    expect_cap,
 ):
-    mock_auto_map.return_value = auto_map_enabled
     mock_npu_utils.return_value.get_aivector_core_num.return_value = 40
     mock_npu_utils.return_value.get_aicore_num.return_value = 20
     cap = "blockNum = std::min(blockNum, (uint32_t)40);"
 
     for auto_blockify_enabled in (False, True):
         metadata = _make_metadata()
-        metadata.has_auto_blockify_blacklist_op = blacklisted
         metadata.auto_blockify_enabled = auto_blockify_enabled
         src = driver.make_launcher(
             constants={},
             signature={0: "*fp32", 1: "*fp32"},
             metadata=metadata,
         )
-        expected_per_launch_path = 1 if expect_cap else 0
+        expected_per_launch_path = 1 if auto_blockify_enabled else 0
         c_abi_launch, cpp_launch = _split_launch_functions(src)
         assert c_abi_launch.count(cap) == expected_per_launch_path
         assert cpp_launch.count(cap) == expected_per_launch_path


### PR DESCRIPTION
Program-grid rewrites were suppressing AutoBlockify and the launcher physical-core cap too broadly. In particular, IAT should keep both behaviors, while only a validated PTSM persistent transform must disable them; pure-SIMT must continue to disable AutoBlockify when RowCoalescing applies.

This change restores the path-specific policy:

```text
Linalg AutoBlockify: E && !B && !ptsm
pure-SIMT AutoBlockify: E && !B && !R
launcher block cap: E && !B && !ptsm
```

The existing compiler and launcher metadata validation remains in place, including rejection of AutoBlockify together with a persistent PTSM contract. Tests cover Linalg Row/IAT/PTSM cases, pure-SIMT Row and blacklist behavior, launcher IAT/PTSM behavior, and independence of the launcher cap from compiler AutoBlockify metadata.

Validation:

- `pre-commit run --from-ref origin/main-dev --to-ref HEAD`
- policy and contract tests: `30 passed, 28 skipped`
- RowCoalescing compatibility tests: `14 passed`
- GraphOptimize load/store FileCheck: 7 RUN commands passed
- NPU Linalg vector add: exact output
- NPU pure-SIMT RowCoalescing: float32 and float16 passed
- NPU PTSM and IAT+PTSM: correctness passed; both export `ptsm_cap_authorized=true` and `auto_blockify_enabled=false`

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main-dev --to-ref HEAD` because this PR targets `main-dev`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code and using the instructions it generates is not minimal.)
